### PR TITLE
Fix - Deno Panic

### DIFF
--- a/guardian/BaseGuardian.ts
+++ b/guardian/BaseGuardian.ts
@@ -5,7 +5,7 @@ import type {
   MergeParameters,
   ResolvedValue,
 } from "./types.ts";
-import { equals, isPromiseLike, optional, test } from "./utils.ts";
+import { equals, isPromiseLike, oneOf, optional, test } from "./utils.ts";
 
 export interface GuardianConstructor<
   V extends BaseGuardian<F>,
@@ -61,6 +61,12 @@ export class BaseGuardian<F extends FunctionType> {
     return this.transform(equals(value, error));
   }
 
+  public oneOf<T extends ResolvedValue<ReturnType<F>>>(
+    values: T[],
+    error?: string,
+  ): GuardianProxy<this, FunctionType<T, Parameters<F>>> {
+    return this.transform(oneOf(values, error));
+  }
   /**
    * test
    *

--- a/guardian/Error.ts
+++ b/guardian/Error.ts
@@ -17,11 +17,11 @@ export type ErrorList = {
 
 export class ValidationError extends Error {
   public path?: ObjectPath;
-  public errors?: PathError[];
+  public validations?: PathError[];
 
   constructor(message: string, errors?: PathError[]) {
     super(message);
-    this.errors = errors;
+    this.validations = errors;
 
     Object.setPrototypeOf(this, ValidationError.prototype);
   }
@@ -30,7 +30,7 @@ export class ValidationError extends Error {
     // console.log(JSON.stringify(this.errors));
     return {
       message: this.message,
-      errors: this.errors?.map(({ path, error }) => ({
+      errors: this.validations?.map(({ path, error }) => ({
         path,
         // error: ValidationError.prototype.toJSON?.apply(error) || error,
         error: ValidationError.prototype.toJSON?.apply(error),

--- a/guardian/Guardians/ArrayGuardian.ts
+++ b/guardian/Guardians/ArrayGuardian.ts
@@ -40,7 +40,7 @@ export class ArrayGuardian<
       let isAsync;
       const items = arr.map(
         (value): StructResolveType<S> | PromiseLike<StructResolveType<S>> => {
-          console.log(validator);
+          // console.log(validator);
           const ret = validator(value);
           // console.log("sdgg");
           if (ret instanceof Promise) {

--- a/guardian/tests/ComplexStruct.ts
+++ b/guardian/tests/ComplexStruct.ts
@@ -1,0 +1,64 @@
+import { Guardian, Struct } from "../mod.ts";
+// import type { Type } from "../mod.ts";
+
+const PhoneNumbers = Struct({
+  number: Guardian.string().mobile(),
+  type: Guardian.array().of(Guardian.string().max(1).oneOf(["M", "P", "H"])),
+});
+
+const IdDetails = Struct({
+  type: Guardian.string().oneOf(["DL", "PASSPORT", "AADHAAR"]),
+  number: Guardian.string().max(10),
+});
+
+const address = Struct({
+  street: Guardian.string().max(100),
+  city: Guardian.string().max(100),
+  state: Guardian.string().max(100),
+});
+const profile = Struct({
+  address: address,
+  phoneNumbers: Guardian.array().of(PhoneNumbers),
+});
+// const CustomerInfo = Struct({
+//   name: Guardian.string().max(10),
+//   phone: PhoneNumbers,
+//   id: IdDetails
+// });
+
+const CustomerInfo = Struct({
+  name: Guardian.string().max(10),
+  profile: profile,
+  id: Guardian.array().of(IdDetails),
+});
+// try {
+CustomerInfo({
+  name: "John Doe",
+  profile: {
+    address: {
+      street: "123 Main St",
+      city: "New York",
+      state: "NY",
+    },
+    phoneNumbers: [
+      { number: "9886704501", type: ["M"] },
+      { number: "9886819090", type: ["P"] },
+      { number: "1234567890", type: ["H"] },
+    ],
+  },
+  id: [
+    { type: "DL", number: "1234567890" },
+    { type: "PASSPORT", number: "1234567890" },
+    { type: "AADHAAR", number: "1234567890" },
+  ],
+});
+// } catch (e) {
+//   console.log(e.toJSON());
+//   console.log(e.errors, '--');
+// }
+
+// CustomerInfo({
+//   name: 'John Doe',
+//   phone: { number: '1234567890', type: ['M'] },
+//   id: { type: 'DL', number: '1234567890' }
+// })


### PR DESCRIPTION
Deno paniced!!!
Happend because the nested error info was stored with variable name errors. Renamed to validations :|

# Description

Deno panicked when running complex struct with multiple nested objects.
In ValidationError, the nested errors were stored in a public var called errors. Upon changing the name to validations, the panic stopped. Probably a core Deno issue, may need to raise with Deno team.

Fixes # (issue)

### Known downstream dependencies

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] Code follows the style guidelines of this project
- [x] Executed deno --fmt and deno --test locally before pushing
- [x] Code is well commented
- [x] Documentation has been updated
- [x] No new warnings are generated
- [x] Test cases have been updated to reflect the changes/fixes
- [x] New and existing unit tests pass locally with changes
- [x] Any dependent changes have been merged and published in downstream modules
