### PR TITLE
Guardian/date parse

### DIFF
--- a/guardian/Guardians/NumberGuardian.ts
+++ b/guardian/Guardians/NumberGuardian.ts
@@ -1,4 +1,5 @@
 import { BaseGuardian } from "../BaseGuardian.ts";
+import { DateGuardian } from "./DateGuardian.ts";
 import { type } from "../utils.ts";
 import type {
   FunctionParameters,
@@ -16,6 +17,14 @@ import type {
 export class NumberGuardian<
   P extends FunctionParameters = [number],
 > extends BaseGuardian<FunctionType<number, P>> {
+  //#region Manipulators
+  toDate(): GuardianProxy<DateGuardian<P>> {
+    return this.transform(
+      (num: number) => new Date(String(num).length === 10 ? num * 1000 : num),
+      DateGuardian,
+    );
+  }
+  //#endregion Manipulators
   //#region Validators
   /**
    * float

--- a/guardian/Guardians/StructGuardian.ts
+++ b/guardian/Guardians/StructGuardian.ts
@@ -14,7 +14,7 @@ import type { GuardianProxy, StructValidatorFunction } from "../types.ts";
 export const Struct = function <S>(
   struct: S,
   message?: string,
-  mode: "STRICT" | "DEFINED" | "ALL" = "STRICT",
+  mode: "STRICT" | "DEFINED" | "PARTIAL" | "ALL" = "STRICT",
 ): GuardianProxy<BaseGuardian<StructValidatorFunction<S>>> {
   return new BaseGuardian(
     compile(struct, {

--- a/guardian/Guardians/StructGuardian.ts
+++ b/guardian/Guardians/StructGuardian.ts
@@ -14,7 +14,7 @@ import type { GuardianProxy, StructValidatorFunction } from "../types.ts";
 export const Struct = function <S>(
   struct: S,
   message?: string,
-  mode: "STRICT" | "PARTIAL" | "ANY" = "STRICT",
+  mode: "STRICT" | "DEFINED" | "ALL" = "STRICT",
 ): GuardianProxy<BaseGuardian<StructValidatorFunction<S>>> {
   return new BaseGuardian(
     compile(struct, {

--- a/guardian/tests/NumberGuard.test.ts
+++ b/guardian/tests/NumberGuard.test.ts
@@ -27,3 +27,12 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "Number - Transform to Date",
+  fn(): void {
+    const ts = 1661066144083,
+      dt = new Date(ts);
+    assertEquals(numberGuard.toDate()(ts), dt);
+  },
+});

--- a/guardian/types.ts
+++ b/guardian/types.ts
@@ -67,7 +67,7 @@ export type MaybeAsync<T, V> = unknown extends IsAsync<T> ? PromiseLike<V> | V
 
 export type StructOptions = {
   message?: string;
-  mode: "STRICT" | "PARTIAL" | "ANY";
+  mode: "STRICT" | "DEFINED" | "ALL";
   path: string[];
 };
 

--- a/guardian/types.ts
+++ b/guardian/types.ts
@@ -67,7 +67,7 @@ export type MaybeAsync<T, V> = unknown extends IsAsync<T> ? PromiseLike<V> | V
 
 export type StructOptions = {
   message?: string;
-  mode: "STRICT" | "DEFINED" | "ALL";
+  mode: "STRICT" | "DEFINED" | "PARTIAL" | "ALL";
   path: string[];
 };
 

--- a/guardian/utils.ts
+++ b/guardian/utils.ts
@@ -218,6 +218,7 @@ export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
  * Modes - (valid for struct)
  * STRICT - Definition must match the provided, i.e Only defined keys allowed. Any "extra" keys will throw an error.
  * DEFINED - Only defined keys will be processed, any "extra" keys will be ignored.
+ * PARTIAL - This will only validate values which are present (irrespective of they are defined as mandatory or optional). Will only return defined keys
  * ALL - Most loosely typed of the lot, will validate for properties for which definition is there, if defined but no value then it will ignore. Any junk will be passed as is
  *
  * @param struct
@@ -274,12 +275,14 @@ export function compile<S>(struct: S, options?: Partial<StructOptions>) {
         obj = objs[0];
       // We inject defined keys which are not passed. This helps validate optional keys.
       // Properties defined but not passed needs to be handled for strict
-      const tempKeys = new Set(Object.keys(obj));
-      structKeys.forEach((key) => {
-        if (!tempKeys.has(key)) {
-          obj[key] = undefined;
-        }
-      });
+      if (mode !== "PARTIAL") {
+        const tempKeys = new Set(Object.keys(obj));
+        structKeys.forEach((key) => {
+          if (!tempKeys.has(key)) {
+            obj[key] = undefined;
+          }
+        });
+      }
       // if (mode === "STRICT" || mode === 'DEFINED') {
       //   structKeys.forEach((key) => {
       //     if (!objKeys.has(key)) {

--- a/guardian/utils.ts
+++ b/guardian/utils.ts
@@ -216,9 +216,9 @@ export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
 /**
  * Composes a guardian for the provided value.
  * Modes - (valid for struct)
- * STRICT - Return object will match definition provided (all). Undefined will be ignored
- * PARTIAL - Same as strict, but allows all properties to be optional
- * ANY - Most loosely typed of the lot, will validate for properties for which definition is there, if defined but no value then it will ignore. Any junk will be passed as is
+ * STRICT - Definition must match the provided, i.e Only defined keys allowed. Any "extra" keys will throw an error.
+ * DEFINED - Only defined keys will be processed, any "extra" keys will be ignored.
+ * ALL - Most loosely typed of the lot, will validate for properties for which definition is there, if defined but no value then it will ignore. Any junk will be passed as is
  *
  * @param struct
  * @param options
@@ -270,34 +270,53 @@ export function compile<S>(struct: S, options?: Partial<StructOptions>) {
     return ((
       ...objs: StructParameters<S>
     ): StructResolveType<S> | Promise<StructResolveType<S>> => {
-      // If strict mode, we have to
       const retObj: Record<string, unknown> = {},
-        obj = objs[0],
-        objKeys: Set<string> = new Set(Object.keys(obj)),
+        obj = objs[0];
+      // We inject defined keys which are not passed. This helps validate optional keys.
+      // Properties defined but not passed needs to be handled for strict
+      const tempKeys = new Set(Object.keys(obj));
+      structKeys.forEach((key) => {
+        if (!tempKeys.has(key)) {
+          obj[key] = undefined;
+        }
+      });
+      // if (mode === "STRICT" || mode === 'DEFINED') {
+      //   structKeys.forEach((key) => {
+      //     if (!objKeys.has(key)) {
+      //       errors.push({
+      //         error: makeError(`Missing property "${key}"`),
+      //         path: [...path, key],
+      //       });
+      //     }
+      //   });
+      // }
+      const objKeys: Set<string> = new Set(Object.keys(obj)),
         errors: PathError[] = [],
         // errors: {error: string, path: ObjectPath}[] = [],
         promises: Promise<unknown>[] = [];
       objKeys.forEach((key) => {
         try {
           // If it is Strict or Partial, only defined properties are allowed
-          if (mode !== "ANY" && !structKeys.has(key)) {
+          if (mode === "STRICT" && !structKeys.has(key)) {
             // pathErrors(`${key} is not a valid property`, [...opts.path, key]);
             throw makeError(`Unknown property passed "${key}"`);
           }
-          const retVal = (validators[key] !== undefined)
-            ? validators[key](obj[key])
-            : obj[key];
-          if (isPromiseLike(retVal)) {
-            promises.push(retVal as Promise<unknown>);
-            retVal.then((v) => retObj[key] = v, (e) => {
-              // const err = makeError(e)
-              errors.push({
-                error: e,
-                path: [...path, key],
+          if (structKeys.has(key) || mode === "ALL") {
+            const retVal = (validators[key] !== undefined)
+              ? validators[key](obj[key])
+              : obj[key];
+            if (isPromiseLike(retVal)) {
+              promises.push(retVal as Promise<unknown>);
+              retVal.then((v) => retObj[key] = v, (e) => {
+                // const err = makeError(e)
+                errors.push({
+                  error: e,
+                  path: [...path, key],
+                });
               });
-            });
-          } else {
-            retObj[key] = retVal;
+            } else {
+              retObj[key] = retVal;
+            }
           }
         } catch (e) {
           // errors.push(...toPathErrors(error as Error, path));
@@ -309,17 +328,6 @@ export function compile<S>(struct: S, options?: Partial<StructOptions>) {
           });
         }
       });
-      // Properties defined but not passed needs to be handled for strict
-      if (mode === "STRICT") {
-        structKeys.forEach((key) => {
-          if (!objKeys.has(key)) {
-            errors.push({
-              error: makeError(`Missing property "${key}"`),
-              path: [...path, key],
-            });
-          }
-        });
-      }
       // Done Now we return
       if (promises.length === 0) {
         // No promises found, so return

--- a/norm/Model.ts
+++ b/norm/Model.ts
@@ -198,7 +198,7 @@ export class Model<
     this._validator = Struct(
       validator,
       `Validation failed for model ${model.name}`,
-      "DEFINED",
+      "PARTIAL",
     );
   }
 
@@ -595,7 +595,7 @@ export class Model<
       } catch (e) {
         // Set error
         // TODO: Handle not null errors and validation errors gracefully
-        console.log(data[index])
+        console.log(data[index]);
         errors[index] = e;
         console.log(e.toJSON());
       }

--- a/norm/Model.ts
+++ b/norm/Model.ts
@@ -126,6 +126,9 @@ export class Model<
       } else {
         validator[column] = DefaultValidator[definition.dataType];
       }
+
+      // validator[column].optional();
+
       // Define validations
       // const validator: GuardianProxy<any> = hasValidation ? definition.validator : Guardian;
       columnAlias[column as keyof T] = definition.name || column;
@@ -592,8 +595,9 @@ export class Model<
       } catch (e) {
         // Set error
         // TODO: Handle not null errors and validation errors gracefully
+        console.log(data[index])
         errors[index] = e;
-        // console.log(e.toJSON());
+        console.log(e.toJSON());
       }
     });
     // Check if there is error

--- a/norm/Model.ts
+++ b/norm/Model.ts
@@ -195,7 +195,7 @@ export class Model<
     this._validator = Struct(
       validator,
       `Validation failed for model ${model.name}`,
-      "PARTIAL",
+      "DEFINED",
     );
   }
 


### PR DESCRIPTION
# Description

Modify NumberGuard to provide parsing to timestamp to date
Improve Validation of Structs (additional modes):
- Added Defined Mode which will only validate defined entries.
- STRICT, DEFINED and ALL modes will ensure all keys which are defined is present
- PARTIAL mode validates only keys which are defined

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] Code follows the style guidelines of this project
- [x] Executed deno --fmt and deno --test locally before pushing
- [x] Code is well commented
- [x] Documentation has been updated
- [x] No new warnings are generated
- [ ] Test cases have been updated to reflect the changes/fixes
- [ ] New and existing unit tests pass locally with changes
- [ ] Any dependent changes have been merged and published in downstream modules
