### PR TITLE
Oak can not handle concurrent http requests 

### DIFF
--- a/dependencies.ts
+++ b/dependencies.ts
@@ -88,7 +88,7 @@ export type {
   Middleware,
   RouterContext,
   RouterMiddleware,
-} from 'https://deno.land/x/oak@v11.1.0/mod.ts';
+} from 'https://deno.land/x/oak@v12.6.1/mod.ts';
 
 export {
   Context,

--- a/dependencies.ts
+++ b/dependencies.ts
@@ -95,7 +95,7 @@ export {
   helpers as oakHelpers,
   Request,
   Response,
-} from 'https://deno.land/x/oak@v11.1.0/mod.ts';
+} from 'https://deno.land/x/oak@v12.6.1/mod.ts';
 
 //#endregion Endpoint
 


### PR DESCRIPTION
# Description
We have updated the deno oak's version to 12.6.1 which can handle concurrent requests on the same connection

Fixes #67

### Known downstream dependencies

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] Code follows the style guidelines of this project
- [ ] Executed deno --fmt and deno --test locally before pushing
- [ ] Code is well commented
- [ ] Documentation has been updated
- [x] No new warnings are generated
- [ ] Test cases have been updated to reflect the changes/fixes
- [ ] New and existing unit tests pass locally with changes
- [ ] Any dependent changes have been merged and published in downstream modules
