### PR TITLE
fix(ci): correct wiki sidebar link order to [[label|Page]]

### DIFF
--- a/.github/scripts/wiki-sync.ts
+++ b/.github/scripts/wiki-sync.ts
@@ -166,7 +166,9 @@ const main = () => {
       const stem = sub.slice(0, -3);
       const segments = stem.split('-');
       const indent = '  '.repeat(segments.length - 1);
-      sidebar.push(`${indent}- [[${stem}|${segments[segments.length - 1]}]]`);
+      // GitHub wiki links are [[Link Text|Page Name]] (text first, page second),
+      // reversed from MediaWiki. Short last segment = label, full stem = page.
+      sidebar.push(`${indent}- [[${segments[segments.length - 1]}|${stem}]]`);
     }
   }
   Deno.writeTextFileSync(path.join(out, '_Sidebar.md'), sidebar.join('\n') + '\n');


### PR DESCRIPTION
GitHub wiki links are `[[Link Text|Page Name]]` (text first) — reversed from MediaWiki. The sidebar generator emitted `[[Page|Label]]`, so sub-page links targeted nonexistent pages and rendered red/broken. Swaps to `[[Label|Page]]`. Live wiki sidebar already corrected via direct push; this stops the next auto-sync from regenerating the broken version.