### PR TITLE
feat(slogger): add contextProvider hook for request-context correlation

### DIFF
--- a/packages/slogger/README.md
+++ b/packages/slogger/README.md
@@ -261,6 +261,40 @@ logger.info('hello ${user.name}', { user: { name: 'alice' } });
 > interpolation off and pass already-formatted strings (e.g. template
 > literals) instead.
 
+### Automatic context (`contextProvider`)
+
+A logger-level `contextProvider` is invoked on every emitted record and merged
+**under** the call/scope context (explicit fields always win). It's the seam for
+folding request-scoped context in automatically — pair it with
+`@tundralibs/ambient` so every line carries the request's correlation id with no
+per-call argument:
+
+```typescript
+import { ambient } from '@tundralibs/ambient';
+
+const log = LogManager.createSlogger({
+  appName: 'orders',
+  level: SyslogSeverities.INFO,
+  contextProvider: () => ambient.get() ?? {}, // the seam
+});
+
+ambient.run({ correlationId: crypto.randomUUID() }, () => {
+  log.info('charging'); // context includes { correlationId }
+});
+```
+
+Precedence is **provider < scope < per-call**:
+
+```typescript
+log.scope({ svc: 'auth' }).info('done', { attempt: 2 });
+// context: { ...provider(), svc: 'auth', attempt: 2 }
+```
+
+The provider is called **lazily** — only for records that pass the level/handler
+filters, so muted lines never invoke it. Like formatters, it is compared by
+**reference identity** for `LogManager` caching: hoist it to a stable `const`
+rather than passing a fresh arrow to each `createSlogger` call.
+
 ## Core API
 
 ### Slogger Class

--- a/packages/slogger/Slogger.test.ts
+++ b/packages/slogger/Slogger.test.ts
@@ -1058,3 +1058,102 @@ describe('slogger.core', () => {
     });
   });
 });
+
+describe('slogger.contextProvider', () => {
+  it('merges the provider UNDER the call context on every line', () => {
+    const logger = new Slogger({
+      appName: 'CtxProviderApp',
+      level: SyslogSeverities.DEBUG,
+      contextProvider: () => ({ correlationId: 'c1', source: 'provider' }),
+      handlers: [
+        { name: 'h', type: 'TestHandler', level: SyslogSeverities.DEBUG },
+      ],
+    });
+    // @ts-expect-error inspecting protected handlers for the test
+    const handler = logger._handlers[0] as TestHandler;
+
+    logger.info('no call context');
+    asserts.assertEquals(handler.messages[0]!.context, {
+      correlationId: 'c1',
+      source: 'provider',
+    });
+
+    logger.info('with call context', { orderId: 'o1', source: 'call' });
+    asserts.assertEquals(handler.messages[1]!.context, {
+      correlationId: 'c1',
+      orderId: 'o1',
+      source: 'call', // per-call wins the collision
+    });
+  });
+
+  it('applies precedence provider < scope < per-call', () => {
+    const logger = new Slogger({
+      appName: 'CtxPrecApp',
+      level: SyslogSeverities.DEBUG,
+      contextProvider: () => ({ layer: 'provider', a: 1 }),
+      handlers: [
+        { name: 'h', type: 'TestHandler', level: SyslogSeverities.DEBUG },
+      ],
+    });
+    // @ts-expect-error inspecting protected handlers for the test
+    const handler = logger._handlers[0] as TestHandler;
+
+    logger.scope({ layer: 'scope', b: 2 }).info('msg', { layer: 'call', c: 3 });
+
+    asserts.assertEquals(handler.messages[0]!.context, {
+      a: 1, // from provider
+      b: 2, // from scope
+      c: 3, // from per-call
+      layer: 'call', // per-call wins over scope wins over provider
+    });
+  });
+
+  it('invokes the provider lazily — never for filtered-out records', () => {
+    let calls = 0;
+    const logger = new Slogger({
+      appName: 'CtxLazyApp',
+      level: SyslogSeverities.WARNING,
+      contextProvider: () => {
+        calls++;
+        return { x: 1 };
+      },
+      handlers: [
+        { name: 'h', type: 'TestHandler', level: SyslogSeverities.WARNING },
+      ],
+    });
+
+    logger.info('below level — muted');
+    asserts.assertEquals(calls, 0);
+
+    logger.warning('emitted');
+    asserts.assertEquals(calls, 1);
+  });
+
+  it('is compared by reference identity for LogManager caching', () => {
+    const provider = () => ({ r: 1 });
+    const first = LogManager.createSlogger({
+      appName: 'CtxCacheApp',
+      level: SyslogSeverities.INFO,
+      handlers: [],
+      contextProvider: provider,
+    });
+    const second = LogManager.createSlogger({
+      appName: 'CtxCacheApp',
+      level: SyslogSeverities.INFO,
+      handlers: [],
+      contextProvider: provider, // same hoisted reference → cache hit
+    });
+    asserts.assertStrictEquals(first, second);
+
+    asserts.assertThrows(
+      () =>
+        LogManager.createSlogger({
+          appName: 'CtxCacheApp',
+          level: SyslogSeverities.INFO,
+          handlers: [],
+          contextProvider: () => ({ r: 2 }), // fresh arrow → different config
+        }),
+      SloggerConfigError,
+    );
+  });
+});

--- a/packages/slogger/Slogger.ts
+++ b/packages/slogger/Slogger.ts
@@ -79,6 +79,27 @@ export type SloggerOptions = {
    * of this flag.
    */
   interpolateMessage?: boolean;
+
+  /**
+   * A logger-level context provider, invoked on every emitted record and
+   * merged **under** the call/scope context (explicit fields always win). Use
+   * it to fold request-scoped context in automatically — e.g. from
+   * `@tundralibs/ambient`:
+   *
+   * ```ts
+   * const log = LogManager.createSlogger({
+   *   appName: 'orders',
+   *   contextProvider: () => ambient.get() ?? {},
+   * });
+   * log.info('charging'); // every line carries the ambient context, no thunk
+   * ```
+   *
+   * Called lazily — only for records that pass the level/handler filters, so
+   * muted lines never invoke it. Like formatters, the provider is compared by
+   * **reference identity** for {@link LogManager} caching: hoist it to a
+   * stable `const`, don't pass a fresh arrow on each `createSlogger` call.
+   */
+  contextProvider?: () => LogContext;
 };
 
 /** */
@@ -95,6 +116,11 @@ export class Slogger {
    * for the security rationale.
    */
   private readonly __interpolateMessage: boolean;
+  /**
+   * Optional logger-level context provider merged under every record's
+   * call/scope context. See {@link SloggerOptions.contextProvider}.
+   */
+  private readonly __contextProvider?: () => LogContext;
 
   /**
    * @param options - Logger configuration. See {@link SloggerOptions}.
@@ -134,6 +160,7 @@ export class Slogger {
     // an attacker-controlled message against the context is a
     // log-injection / data-exfiltration vector. See SloggerOptions.
     this.__interpolateMessage = options.interpolateMessage === true;
+    this.__contextProvider = options.contextProvider;
 
     // Initialize handlers if provided
     if (options.handlers) {
@@ -383,7 +410,16 @@ export class Slogger {
     if (!hasActiveHandlers) return;
 
     // Lazy context resolution — only call the thunk if we'll actually use it.
-    const resolvedContext = typeof context === 'function' ? context() : context;
+    const callContext = typeof context === 'function' ? context() : context;
+
+    // Fold in the logger-level context provider (e.g. an ambient request
+    // context) UNDER the call/scope context — explicit fields always win.
+    // Also lazy: the provider only runs for records that reach here (past the
+    // level/handler early-exits above).
+    const providerContext = this.__contextProvider?.();
+    const resolvedContext = providerContext === undefined
+      ? callContext
+      : { ...providerContext, ...callContext };
 
     // Message interpolation is opt-in (see SloggerOptions.interpolateMessage).
     // When disabled (the default), the message is emitted verbatim — a


### PR DESCRIPTION
## What

Adds a logger-level **`contextProvider?: () => LogContext`** to `SloggerOptions`, invoked on every emitted record and merged **under** the call/scope context (explicit fields always win). It's the seam that lets request-scoped context land on every log line **without a per-call thunk**:

```typescript
import { ambient } from '@tundralibs/ambient';

const log = LogManager.createSlogger({
  appName: 'orders',
  contextProvider: () => ambient.get() ?? {}, // ← the seam
});

ambient.run({ correlationId: crypto.randomUUID() }, () => {
  log.info('charging'); // context auto-includes { correlationId }
});
```

This is **PR2 of 2** — the slogger side of the ambient integration ([#107](https://github.com/TundraSoft/TundraLibs/pull/107) is PR1, the ambient package itself).

## Why this shape (decoupled)

`slogger` gains **no dependency on ambient** — the provider is a generic `() => LogContext`, and the app wires ambient in at the composition root. So tracer/rpc that use ambient never drag a logging package into their graph, and this PR is independent of PR1's merge order.

## Design

- **One-place merge** in `Slogger.log()`: `{ ...provider(), ...callContext }`. `scope()` delegates to `log()`, so scoped loggers inherit it. Precedence: **provider < scope < per-call**.
- **Lazy** — the provider runs only for records past the level/handler early-exits; muted lines never invoke it.
- **No LogManager change** — the whole config flows through `createSlogger`, and `__sameConfig` already compares function members by reference identity (same *hoist-your-function* rule as formatters, documented on the option).

## Tests & verification

New `slogger.contextProvider` suite covers: merge-under-call-context, `provider < scope < per-call` precedence, laziness, and reference-identity caching.

| Gate | Result |
|---|---|
| `deno test packages/slogger` | ✅ 22 suites, 347 steps, 0 failed |
| type-check · lint · fmt --check | ✅ |
| JSR publish dry-run | ✅ |

Touches one package (`packages/slogger/`) → `Single-package guard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)