### PR TITLE
feat: add @tundralibs/tracer distributed tracing kernel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,7 @@ body:
         - restler
         - rpc
         - slogger
+        - tracer
         - utils
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -25,6 +25,7 @@ body:
         - restler
         - rpc
         - slogger
+        - tracer
         - utils
         - new package
     validations:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -143,6 +143,13 @@ component_management:
       statuses:
         - type: project
           target: auto
+    - component_id: tracer
+      name: tracer
+      paths:
+        - packages/tracer/**
+      statuses:
+        - type: project
+          target: auto
     - component_id: utils
       name: utils
       paths:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,6 +49,9 @@
 'pkg: slogger':
   - changed-files:
       - any-glob-to-any-file: packages/slogger/**
+'pkg: tracer':
+  - changed-files:
+      - any-glob-to-any-file: packages/tracer/**
 'pkg: utils':
   - changed-files:
       - any-glob-to-any-file: packages/utils/**

--- a/.github/workspace-meta.json
+++ b/.github/workspace-meta.json
@@ -17,6 +17,7 @@
     "restler": "RESTler",
     "rpc": "RPC",
     "slogger": "Slogger",
+    "tracer": "Tracer",
     "utils": "utils"
   }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,5 +15,6 @@
   "packages/restler": "1.0.0",
   "packages/rpc": "1.0.0",
   "packages/slogger": "1.0.0",
+  "packages/tracer": "0.1.0",
   "packages/utils": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ published to [JSR](https://jsr.io) under the `@tundralibs` scope.
 - **[RESTler](packages/restler/README.md)** — Cross-runtime REST API client base class for building typed per-vendor SDKs on Deno, Bun, and Node.js
 - **[RPC](packages/rpc/README.md)** — Remote Procedure Call + pub/sub framework over WebSocket — typed request/response, channels, middleware, and pluggable adapters
 - **[Slogger](packages/slogger/README.md)** — Cross-runtime structured logging that fans one record out to many formats in-process — console, JSON, syslog, file, HTTP, TCP
+- **[Tracer](packages/tracer/README.md)** — Cross-runtime distributed tracing — W3C Trace Context propagation, automatic span nesting via ambient async context, pluggable samplers and exporters
 - **[utils](packages/utils/README.md)** — Core TypeScript building blocks — the typed Options + Events base class, BaseError, and shared helpers (config/env, memoize, IP/subnet, free-port)
 
 <!-- workspace:packages:end -->

--- a/packages/tracer/README.md
+++ b/packages/tracer/README.md
@@ -1,0 +1,184 @@
+# Tracer
+
+Distributed tracing that shows where a request actually spent its time —
+across functions, and across services. Completes the observability triad with
+[Slogger](../slogger/README.md) (logs) and [MetroMan](../metro-man/README.md)
+(metrics).
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## What it gives you
+
+A log line says _one event happened_. A trace says _where the time went_:
+
+```text
+checkout ──────────────────────────────── 210ms
+  auth.verify      ──── 40ms
+  db.query           ──────── 120ms
+  POST /charge              ───── 45ms   ← a different service, same trace
+```
+
+Each box is a **span**. Spans nest **automatically** — a span opened inside
+another becomes its child at any call depth and across every `await` — because
+the active span lives in an [ambient](../ambient/README.md) async context
+instead of being threaded through function signatures. W3C `traceparent`
+propagation carries the trace across process boundaries.
+
+## Installation
+
+**Deno:**
+
+```bash
+deno add @tundralibs/tracer
+```
+
+**Bun:**
+
+```bash
+bunx jsr add @tundralibs/tracer
+```
+
+**Node.js:**
+
+```bash
+npx jsr add @tundralibs/tracer
+```
+
+## Real-world examples
+
+### 1. Trace a request, end to end
+
+`startActiveSpan` makes the span active for the callback's whole lifetime, so
+nothing below needs a `span` parameter:
+
+```typescript
+import { ConsoleExporter, SpanKind, Tracer } from '@tundralibs/tracer';
+
+const tracer = new Tracer({
+  serviceName: 'orders',
+  exporter: new ConsoleExporter(),
+});
+
+await tracer.startActiveSpan('checkout', async (span) => {
+  span.setAttribute('order.id', 'ord_42');
+
+  await tracer.startActiveSpan('db.query', async () => {
+    await db.query('SELECT …'); // auto-parents to `checkout`
+  });
+
+  await chargeCard(); // spans started in here parent too — no threading
+});
+```
+
+### 2. Continue a trace across a service boundary
+
+`extract` joins the caller's trace on the way in; `inject` hands it onward:
+
+```typescript
+import { extract, inject, SpanKind } from '@tundralibs/tracer';
+
+// Inbound — join the caller's trace (or start one if there's no header).
+const parent = extract(request.headers);
+
+await tracer.startActiveSpan(
+  `${request.method} ${route}`,
+  { kind: SpanKind.SERVER, parent },
+  async (span) => {
+    // Outbound — pass the trace on, so the callee's spans join this trace.
+    await fetch('https://payments.internal/charge', {
+      method: 'POST',
+      headers: { traceparent: inject(span.context) },
+    });
+  },
+);
+```
+
+### 3. Correlate logs with traces
+
+Slogger's `contextProvider` is called for every record, so trace ids land on
+every log line — click a log, jump to its trace:
+
+```typescript
+import { LogManager } from '@tundralibs/slogger';
+
+const log = LogManager.createSlogger({
+  appName: 'orders',
+  contextProvider: () => {
+    const span = tracer.active();
+    return span
+      ? { trace_id: span.context.traceId, span_id: span.context.spanId }
+      : {};
+  },
+});
+
+log.info('charging'); // → { trace_id: '4bf92f…', span_id: '00f067…' }
+```
+
+### 4. Sample a fraction of traces
+
+`ratioSampler` derives its decision from the trace id, so every service that
+uses the same ratio agrees — traces stay complete end-to-end rather than
+fragmenting:
+
+```typescript
+import { ratioSampler, Tracer } from '@tundralibs/tracer';
+
+const tracer = new Tracer({
+  serviceName: 'orders',
+  sampler: ratioSampler(0.1), // 10% of traces, whole
+});
+```
+
+Child spans **inherit** the parent's decision — a trace is always sampled whole
+or not at all. Unsampled spans still carry and propagate their context, so
+correlation keeps working even when nothing is exported.
+
+### 5. A framework-agnostic tracing middleware
+
+Tracer never sees your framework's context, so you write the ~10-line adapter
+and keep full type knowledge — including writing back to `ctx`:
+
+```typescript
+async function tracing(ctx, next) {
+  const parent = extract(ctx.request.headers);
+  return tracer.startActiveSpan(
+    `${ctx.request.method} ${ctx.route}`,
+    { kind: SpanKind.SERVER, parent },
+    async (span) => {
+      ctx.span = span; // your ctx, your types
+      await next();
+      span.setAttribute('http.status_code', ctx.response.status);
+    },
+  );
+}
+```
+
+See [RECIPES.md](RECIPES.md) for ready-made adapters (Express, Koa, Oak,
+Fetch-standard servers).
+
+## Custom id generation
+
+Ids are random by default. Override when a backend needs a specific format —
+AWS X-Ray requires a timestamp-prefixed trace id and rejects pure-random ones —
+or to make ids deterministic in tests. A custom generator is smoke-tested once
+at construction, because malformed ids are _silently dropped_ by collectors:
+
+```typescript
+new Tracer({ serviceName: 'orders', idGenerator: myGenerator });
+```
+
+## Design notes
+
+- **Nothing on a span throws.** Tracing is observability; it must never break
+  the code it observes. Export failures are swallowed, writes after `end()` are
+  ignored, and a malformed inbound `traceparent` just means "start a new trace".
+- **Config errors throw loudly** at construction — that is the one place a
+  mistake is cheap to surface.
+- **Core is dependency-light**: `ambient` + `utils`. The OTLP exporter lives
+  behind its own subpath so an HTTP client is never pulled into the core graph.
+
+## License
+
+MIT

--- a/packages/tracer/RECIPES.md
+++ b/packages/tracer/RECIPES.md
@@ -1,0 +1,158 @@
+# Tracer Recipes
+
+Copy-paste integrations. These are **not shipped in-tree**: every framework has
+its own context shape and release cadence, and shipping adapters for each means
+tracking version drift across frameworks we don't control. They are ~10 lines
+each, and writing your own keeps full type knowledge of _your_ context — you can
+write back to it (`ctx.span = span`), which a generic adapter cannot.
+
+Everything below works with the core package as-is — `startActiveSpan`,
+`extract`, and `inject` are all an adapter needs.
+
+## Inbound: server middleware
+
+The shape is always the same — extract the inbound `traceparent`, open a
+`SERVER` span, run the handler inside it, record the status on the way out.
+
+### Fetch-standard (Deno.serve, Bun.serve, Hono, compat/webserver)
+
+```typescript
+import { extract, inject, SpanKind, SpanStatusCode } from '@tundralibs/tracer';
+
+const traced =
+  (handler: (req: Request) => Promise<Response>) =>
+  async (req: Request): Promise<Response> => {
+    const { pathname } = new URL(req.url);
+    return tracer.startActiveSpan(
+      `${req.method} ${pathname}`,
+      { kind: SpanKind.SERVER, parent: extract(req.headers) },
+      async (span) => {
+        span.setAttributes({ 'http.method': req.method, 'url.path': pathname });
+        const res = await handler(req);
+        span.setAttribute('http.status_code', res.status);
+        if (res.status >= 500) span.setStatus(SpanStatusCode.ERROR);
+        return res;
+      },
+    );
+  };
+```
+
+### Express
+
+```typescript
+app.use((req, res, next) => {
+  tracer.startActiveSpan(
+    `${req.method} ${req.path}`,
+    { kind: SpanKind.SERVER, parent: extract(req.headers) },
+    (span) => {
+      // Express signals completion via the response, not a promise.
+      res.on('finish', () => {
+        span.setAttribute('http.status_code', res.statusCode);
+        if (res.statusCode >= 500) span.setStatus(SpanStatusCode.ERROR);
+        span.end();
+      });
+      next();
+    },
+  );
+});
+```
+
+> Note the `res.on('finish')`: because `next()` returns immediately, the span
+> must be ended by the response lifecycle rather than by `startActiveSpan`.
+> Ending twice is harmless — `end()` is idempotent.
+
+### Koa
+
+```typescript
+app.use((ctx, next) =>
+  tracer.startActiveSpan(
+    `${ctx.method} ${ctx.path}`,
+    { kind: SpanKind.SERVER, parent: extract(ctx.headers) },
+    async (span) => {
+      ctx.span = span; // your context, your types
+      await next();
+      span.setAttribute('http.status_code', ctx.status);
+      if (ctx.status >= 500) span.setStatus(SpanStatusCode.ERROR);
+    },
+  )
+);
+```
+
+### Oak
+
+```typescript
+app.use((ctx, next) =>
+  tracer.startActiveSpan(
+    `${ctx.request.method} ${ctx.request.url.pathname}`,
+    { kind: SpanKind.SERVER, parent: extract(ctx.request.headers) },
+    async (span) => {
+      await next();
+      span.setAttribute('http.status_code', ctx.response.status);
+    },
+  )
+);
+```
+
+### RadRouter / RPC
+
+Both are generic over their middleware type, so the same body works — supply
+your own context type and read headers from wherever your context keeps them:
+
+```typescript
+type AppMw = (ctx: AppCtx, next: () => Promise<void>) => Promise<void>;
+
+const tracing: AppMw = (ctx, next) =>
+  tracer.startActiveSpan(
+    ctx.route,
+    { kind: SpanKind.SERVER, parent: extract(ctx.headers) },
+    () => next(),
+  );
+
+const router = new RadRouter<AppMw>();
+```
+
+## Outbound: propagating the trace
+
+Open a `CLIENT` span and inject `traceparent` so the callee joins this trace.
+
+```typescript
+const tracedFetch = (input: string, init: RequestInit = {}) =>
+  tracer.startActiveSpan(
+    `${init.method ?? 'GET'} ${new URL(input).pathname}`,
+    { kind: SpanKind.CLIENT },
+    async (span) => {
+      const headers = new Headers(init.headers);
+      headers.set('traceparent', inject(span.context));
+      const res = await fetch(input, { ...init, headers });
+      span.setAttribute('http.status_code', res.status);
+      return res;
+    },
+  );
+```
+
+## Testing traces
+
+`MemoryExporter` buffers spans so you can assert on them directly:
+
+```typescript
+import { MemoryExporter, Tracer } from '@tundralibs/tracer';
+
+const exporter = new MemoryExporter();
+const tracer = new Tracer({ serviceName: 'test', exporter });
+
+tracer.startActiveSpan('work', (span) => span.setAttribute('ok', true));
+
+exporter.find('work')?.attributes.ok; // true
+exporter.reset(); // between cases
+```
+
+For deterministic ids, inject a fixed byte source:
+
+```typescript
+import { createRandomIdGenerator } from '@tundralibs/tracer';
+
+const idGenerator = createRandomIdGenerator(
+  (n) => new Uint8Array(n).fill(0x0a),
+);
+new Tracer({ serviceName: 'test', idGenerator, exporter });
+```

--- a/packages/tracer/ROADMAP.md
+++ b/packages/tracer/ROADMAP.md
@@ -1,0 +1,96 @@
+# Tracer — Roadmap
+
+What is deliberately not built yet, and the reasoning behind the choices that
+shaped the package. The kernel ships first; export and framework glue follow.
+
+## OTLP exporter (next)
+
+The only exporters in-tree are `ConsoleExporter` and `MemoryExporter` — enough
+for development and tests, but not for a real backend. Next is
+`@tundralibs/tracer/otlp`: **OTLP over HTTP with a JSON payload**, POSTed to
+`<endpoint>/v1/traces`, built as a `RESTler` subclass so it inherits URL
+validation, timeouts and retries.
+
+Decided: **write the encoder in-house rather than depend on
+`@opentelemetry/otlp-*`** — that keeps the suite dependency-light and
+cross-runtime, and conformance here is verifiable rather than a matter of
+judgement. It is pinned to a named `opentelemetry-proto` version, and verified
+two ways: fixture tests, plus a real `otel/opentelemetry-collector` service
+container in CI asserting our payload is actually accepted (the repo already
+runs live service containers, so this is house style).
+
+The encoder will be built as a **Guardian schema with `.transform()`** rather
+than a hand-written mapper, so shape, conversion, defaults and validation live
+in one declaration and `GuardianInfer` derives the output type — no separately
+maintained `types/otlp.ts` to drift. **Open question to settle with a benchmark,
+not a guess:** guardian's per-value cost on a batch flush (~512 spans × ~10
+attributes) versus a hand-rolled encoder. If it is badly slower, fall back to
+guardian-as-test-schema with a hand-rolled fast path. The repo has `.bench.ts`
+conventions and a `bench` task for exactly this.
+
+Spec gotchas to encode carefully (each silently breaks ingest): trace/span ids
+are **lowercase hex, not base64** (an OTLP-specific override of protobuf-JSON);
+`startTimeUnixNano`/`endTimeUnixNano` are **decimal strings**, not numbers;
+attributes use the typed `{ key, value: { stringValue | intValue | … } }`
+wrapper; `kind` and `status.code` are numeric enums.
+
+**Out of scope:** OTLP over gRPC, and protobuf-over-HTTP. Anyone needing those
+runs the OTel Collector, which accepts JSON on the front door and re-exports in
+any format.
+
+## Batch span processor
+
+Spans are currently exported one at a time, as each ends. That is fine for
+console/memory, and wrong for a network exporter — the OTLP work will add a
+batching processor (queue, size/time flush thresholds, drop policy on overflow)
+and route exports through it.
+
+## Framework middleware
+
+Deliberately **not** shipped in-tree beyond what
+[RECIPES.md](RECIPES.md) documents. RadRouter and RPC are both generic over
+their middleware type and never read `ctx` themselves, so there is no canonical
+context to write an adapter against; and a generic adapter cannot _write_ to a
+context it does not know (`ctx.span = span`), which is exactly what an
+application wants. A ~10-line adapter in the app keeps full type knowledge.
+
+Planned once `rAPId` exists: a first-class `rAPId/tracing` middleware, since
+rAPId is the package that will own a typed request context. A convenience
+`handleTrace(info, fn)` wrapper in this package is also on the table if the
+recipes prove repetitive in practice.
+
+## Semantic conventions
+
+Attribute names follow OpenTelemetry semantic conventions by hand
+(`http.method`, `db.system`, `exception.type`). Typed helpers/constants for the
+common groups may follow; shipping the whole spec is not planned — it is large,
+churns, and most of it is irrelevant to any one service.
+
+## Not planned
+
+- **W3C `baggage`** — separate spec from `traceparent`; add only on demand.
+- **Tail-based sampling** — requires buffering whole traces and a collector-side
+  decision. Head-based sampling is what an in-process SDK can do correctly; tail
+  sampling belongs in the OTel Collector.
+- **Auto-instrumentation** (monkey-patching `fetch`, DB drivers) — implicit
+  global patching is at odds with the suite's explicit-composition style. Manual
+  wrappers are documented in RECIPES instead.
+- **Metrics/logs over OTLP** — `metro-man` and `slogger` own those. Tracer
+  exports spans only.
+
+## Decisions worth not relitigating
+
+- **No `compat/async`.** The `AsyncLocalStorage` primitive stays in `ambient`,
+  and tracer depends on `ambient` for `createContext`. Moving it to `compat`
+  would make a leaf primitive depend on a 47-file package that pulls `ws`, and
+  buys nothing: `ambient/createContext.ts` is already the one-file seam a future
+  TC39 `AsyncContext` migration would touch. Revisit only if a runtime appears
+  that needs an ALS shim (making it a genuine _compat_ concern), or if a package
+  that cannot depend on `ambient` needs raw ALS.
+- **Ids via `crypto.getRandomValues`, not `@tundralibs/id`.** W3C needs raw
+  uniform hex of a fixed byte width; `id` ships no such generator, and using it
+  would mean adding one there to replace ten lines here. There is no id
+  _semantics_ to reuse — it is just random bytes.
+- **Sampling is head-based and parent-inherited.** Child spans never re-sample;
+  a partially-sampled trace renders as a waterfall with holes. `ratioSampler`
+  derives its verdict from the trace id so independent services agree.

--- a/packages/tracer/Span.test.ts
+++ b/packages/tracer/Span.test.ts
@@ -1,0 +1,164 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { Span, SpanKind, SpanStatusCode } from './mod.ts';
+import type { SpanData, SpanInit } from './mod.ts';
+
+const makeSpan = (
+  overrides: Partial<SpanInit> = {},
+): { span: Span; ended: SpanData[] } => {
+  const ended: SpanData[] = [];
+  const span = new Span({
+    name: 'op',
+    context: {
+      traceId: 'a'.repeat(32),
+      spanId: 'b'.repeat(16),
+      traceFlags: 1,
+    },
+    kind: SpanKind.INTERNAL,
+    startTime: new Date(1000),
+    resource: { 'service.name': 'test' },
+    recording: true,
+    onEnd: (data) => ended.push(data),
+    ...overrides,
+  });
+  return { span, ended };
+};
+
+describe('tracer.Span', () => {
+  it('records attributes, chaining', () => {
+    const { span } = makeSpan();
+    span.setAttribute('a', 1).setAttribute('b', 'two').setAttribute('c', true);
+    span.setAttributes({ d: [1, 2], e: false });
+    span.end();
+    asserts.assertEquals(span.toData().attributes, {
+      a: 1,
+      b: 'two',
+      c: true,
+      d: [1, 2],
+      e: false,
+    });
+  });
+
+  it('seeds attributes supplied at construction', () => {
+    const { span } = makeSpan({ attributes: { seeded: 'yes' } });
+    asserts.assertEquals(span.toData().attributes.seeded, 'yes');
+  });
+
+  it('drops null and undefined attribute values', () => {
+    const { span } = makeSpan();
+    // deno-lint-ignore no-explicit-any
+    span.setAttribute('nope', null as any).setAttribute(
+      'nada',
+      undefined as any,
+    );
+    asserts.assertEquals(span.toData().attributes, {});
+  });
+
+  it('records events in insertion order', () => {
+    const { span } = makeSpan();
+    span.addEvent('first', { i: 1 }, new Date(2000));
+    span.addEvent('second');
+    const events = span.toData().events;
+    asserts.assertEquals(events.length, 2);
+    asserts.assertEquals(events[0]!.name, 'first');
+    asserts.assertEquals(events[0]!.attributes, { i: 1 });
+    asserts.assertEquals(events[0]!.time, new Date(2000));
+    asserts.assertEquals(events[1]!.name, 'second');
+    asserts.assertEquals(events[1]!.attributes, {});
+  });
+
+  it('defaults status to UNSET and records an explicit status', () => {
+    const { span } = makeSpan();
+    asserts.assertEquals(span.toData().status.code, SpanStatusCode.UNSET);
+    span.setStatus(SpanStatusCode.ERROR, 'boom');
+    asserts.assertEquals(span.toData().status, {
+      code: SpanStatusCode.ERROR,
+      message: 'boom',
+    });
+    span.setStatus(SpanStatusCode.OK);
+    asserts.assertEquals(span.toData().status, { code: SpanStatusCode.OK });
+  });
+
+  it('records an Error as an exception event with semantic attributes', () => {
+    const { span } = makeSpan();
+    span.recordException(new TypeError('bad input'));
+    const event = span.toData().events[0]!;
+    asserts.assertEquals(event.name, 'exception');
+    asserts.assertEquals(event.attributes['exception.type'], 'TypeError');
+    asserts.assertEquals(event.attributes['exception.message'], 'bad input');
+    asserts.assert(
+      typeof event.attributes['exception.stacktrace'] === 'string',
+    );
+  });
+
+  it('records an Error without a stack', () => {
+    const { span } = makeSpan();
+    const error = new Error('no stack');
+    error.stack = undefined;
+    span.recordException(error);
+    const attributes = span.toData().events[0]!.attributes;
+    asserts.assertEquals(attributes['exception.stacktrace'], undefined);
+    asserts.assertEquals(attributes['exception.message'], 'no stack');
+  });
+
+  it('stringifies a non-Error thrown value', () => {
+    const { span } = makeSpan();
+    span.recordException('just a string');
+    asserts.assertEquals(
+      span.toData().events[0]!.attributes['exception.message'],
+      'just a string',
+    );
+  });
+
+  it('hands a snapshot to onEnd exactly once', () => {
+    const { span, ended } = makeSpan();
+    span.end(new Date(5000));
+    span.end(new Date(9999)); // idempotent
+    asserts.assertEquals(ended.length, 1);
+    asserts.assertEquals(ended[0]!.endTime, new Date(5000));
+    asserts.assertEquals(ended[0]!.name, 'op');
+    asserts.assertEquals(ended[0]!.resource['service.name'], 'test');
+  });
+
+  it('stops recording after end()', () => {
+    const { span } = makeSpan();
+    asserts.assertEquals(span.isRecording(), true);
+    span.end();
+    asserts.assertEquals(span.isRecording(), false);
+    span.setAttribute('late', 1).addEvent('late').setStatus(SpanStatusCode.OK);
+    const data = span.toData();
+    asserts.assertEquals(data.attributes, {});
+    asserts.assertEquals(data.events, []);
+    asserts.assertEquals(data.status.code, SpanStatusCode.UNSET);
+  });
+
+  it('is inert when sampling dropped it, but still carries its context', () => {
+    const { span, ended } = makeSpan({ recording: false });
+    asserts.assertEquals(span.isRecording(), false);
+    span.setAttribute('a', 1).addEvent('e').setStatus(SpanStatusCode.ERROR);
+    span.recordException(new Error('x'));
+    span.end();
+    asserts.assertEquals(ended.length, 0); // never exported
+    asserts.assertEquals(span.toData().attributes, {});
+    asserts.assertEquals(span.context.traceId, 'a'.repeat(32)); // still propagates
+  });
+
+  it('snapshots defensively — mutating the result cannot alter the span', () => {
+    const { span } = makeSpan();
+    span.setAttribute('a', 1);
+    const data = span.toData();
+    data.attributes.a = 999;
+    data.events.push({ name: 'injected', time: new Date(), attributes: {} });
+    asserts.assertEquals(span.toData().attributes.a, 1);
+    asserts.assertEquals(span.toData().events.length, 0);
+  });
+
+  it('exposes parent id and kind', () => {
+    const { span } = makeSpan({
+      parentSpanId: 'c'.repeat(16),
+      kind: SpanKind.SERVER,
+    });
+    asserts.assertEquals(span.parentSpanId, 'c'.repeat(16));
+    asserts.assertEquals(span.kind, SpanKind.SERVER);
+  });
+});

--- a/packages/tracer/Span.ts
+++ b/packages/tracer/Span.ts
@@ -1,0 +1,209 @@
+/**
+ * @fileoverview The {@link Span} — one unit of work in a trace.
+ *
+ * A span is mutable while open (attributes, events, status) and becomes an
+ * immutable {@link SpanData} snapshot when {@link Span.end} is called.
+ *
+ * Spans are created by {@link Tracer}, never constructed directly by callers.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type {
+  Attributes,
+  AttributeValue,
+  SpanContext,
+  SpanData,
+  SpanEvent,
+  SpanKind,
+  SpanStatus,
+} from './types/mod.ts';
+import { SpanStatusCode } from './types/mod.ts';
+
+/** Constructor arguments for a {@link Span}. Internal to the package. */
+export type SpanInit = {
+  name: string;
+  context: SpanContext;
+  kind: SpanKind;
+  startTime: Date;
+  parentSpanId?: string;
+  attributes?: Attributes;
+  resource: Attributes;
+  /** `false` when sampling dropped this span — mutations become no-ops. */
+  recording: boolean;
+  /** Called once, on `end()`, only for recording spans. */
+  onEnd: (data: SpanData) => void;
+};
+
+/**
+ * One unit of work within a trace: a name, a start and end time, a parent, and
+ * whatever attributes and events were recorded on it.
+ *
+ * **Nothing on a span throws.** Tracing is observability; it must never be able
+ * to break the code it observes. Writes after `end()`, or on a span that
+ * sampling dropped, are silently ignored.
+ */
+export class Span {
+  /** Operation name, e.g. `GET /orders/:id`. */
+  public readonly name: string;
+  /** This span's propagated identity — pass to `inject()` for outbound calls. */
+  public readonly context: SpanContext;
+  /** The span's role in the trace. */
+  public readonly kind: SpanKind;
+  /** Parent span id within the same trace; absent when this is the root. */
+  public readonly parentSpanId?: string;
+  /** When the span started. */
+  public readonly startTime: Date;
+
+  private readonly __resource: Attributes;
+  private readonly __onEnd: (data: SpanData) => void;
+  private readonly __recording: boolean;
+  private readonly __attributes: Attributes;
+  private readonly __events: SpanEvent[] = [];
+  private __status: SpanStatus = { code: SpanStatusCode.UNSET };
+  private __endTime?: Date;
+
+  /**
+   * @param init - See {@link SpanInit}. Created by {@link Tracer}, not callers.
+   */
+  constructor(init: SpanInit) {
+    this.name = init.name;
+    this.context = init.context;
+    this.kind = init.kind;
+    this.startTime = init.startTime;
+    this.parentSpanId = init.parentSpanId;
+    this.__resource = init.resource;
+    this.__recording = init.recording;
+    this.__onEnd = init.onEnd;
+    this.__attributes = { ...init.attributes };
+  }
+
+  /**
+   * Whether this span is still collecting data — i.e. it was sampled and has
+   * not ended. Use it to skip building expensive attribute values.
+   */
+  public isRecording(): boolean {
+    return this.__recording && this.__endTime === undefined;
+  }
+
+  /**
+   * Set one attribute. `null`/`undefined` values are dropped — OTLP has no
+   * encoding for them, and emitting one invalidates the whole payload.
+   *
+   * @param key - Attribute name; prefer OpenTelemetry semantic conventions.
+   * @param value - See {@link AttributeValue}.
+   * @returns `this`, for chaining.
+   */
+  public setAttribute(key: string, value: AttributeValue): this {
+    if (!this.isRecording()) return this;
+    if (value === null || value === undefined) return this;
+    this.__attributes[key] = value;
+    return this;
+  }
+
+  /**
+   * Set several attributes at once. See {@link Span.setAttribute}.
+   *
+   * @param attributes - Attributes to merge in.
+   * @returns `this`, for chaining.
+   */
+  public setAttributes(attributes: Attributes): this {
+    for (const [key, value] of Object.entries(attributes)) {
+      this.setAttribute(key, value);
+    }
+    return this;
+  }
+
+  /**
+   * Record a timestamped event on this span.
+   *
+   * @param name - Event name, e.g. `cache.miss`.
+   * @param attributes - Structured detail for the event.
+   * @param time - When it happened. Defaults to now.
+   * @returns `this`, for chaining.
+   */
+  public addEvent(
+    name: string,
+    attributes: Attributes = {},
+    time: Date = new Date(),
+  ): this {
+    if (!this.isRecording()) return this;
+    this.__events.push({ name, time, attributes });
+    return this;
+  }
+
+  /**
+   * Set the span's outcome. `message` is only meaningful for
+   * {@link SpanStatusCode.ERROR}.
+   *
+   * @param code - The outcome.
+   * @param message - Description, for errors.
+   * @returns `this`, for chaining.
+   */
+  public setStatus(code: SpanStatusCode, message?: string): this {
+    if (!this.isRecording()) return this;
+    this.__status = message === undefined ? { code } : { code, message };
+    return this;
+  }
+
+  /**
+   * Record an exception as an `exception` event, using the OpenTelemetry
+   * semantic-convention attribute names so backends render it as an error.
+   *
+   * This records the exception but does **not** set the span status — a caught
+   * and handled exception is not necessarily a failed operation. Call
+   * {@link Span.setStatus} explicitly when it is.
+   *
+   * @param error - The thrown value. Non-`Error` values are stringified.
+   * @returns `this`, for chaining.
+   */
+  public recordException(error: unknown): this {
+    if (!this.isRecording()) return this;
+    const attributes: Attributes = error instanceof Error
+      ? {
+        'exception.type': error.name,
+        'exception.message': error.message,
+        ...(error.stack === undefined
+          ? {}
+          : { 'exception.stacktrace': error.stack }),
+      }
+      : { 'exception.message': String(error) };
+    return this.addEvent('exception', attributes);
+  }
+
+  /**
+   * End the span and hand it to the exporter. Idempotent — a second call is
+   * ignored, so a `finally { span.end() }` is always safe.
+   *
+   * @param endTime - Explicit end time. Defaults to now.
+   */
+  public end(endTime: Date = new Date()): void {
+    if (this.__endTime !== undefined) return;
+    this.__endTime = endTime;
+    if (!this.__recording) return;
+    this.__onEnd(this.toData());
+  }
+
+  /**
+   * Immutable snapshot of this span for export. Exporters receive one of these
+   * rather than the live span, so nothing downstream can mutate trace state.
+   *
+   * @returns The {@link SpanData} snapshot.
+   */
+  public toData(): SpanData {
+    return {
+      name: this.name,
+      context: { ...this.context },
+      parentSpanId: this.parentSpanId,
+      kind: this.kind,
+      startTime: this.startTime,
+      endTime: this.__endTime ?? new Date(),
+      attributes: { ...this.__attributes },
+      events: [...this.__events],
+      status: { ...this.__status },
+      resource: { ...this.__resource },
+    };
+  }
+}

--- a/packages/tracer/Tracer.test.ts
+++ b/packages/tracer/Tracer.test.ts
@@ -1,0 +1,388 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import {
+  alwaysOffSampler,
+  createRandomIdGenerator,
+  extract,
+  FLAG_SAMPLED,
+  inject,
+  MemoryExporter,
+  SpanKind,
+  SpanStatusCode,
+  Tracer,
+  TracerConfigError,
+} from './mod.ts';
+import type { IdGenerator, SpanData, SpanExporter } from './mod.ts';
+
+const tracerWith = (
+  options: Partial<ConstructorParameters<typeof Tracer>[0]> = {},
+): { tracer: Tracer; exporter: MemoryExporter } => {
+  const exporter = new MemoryExporter();
+  const tracer = new Tracer({ serviceName: 'test', exporter, ...options });
+  return { tracer, exporter };
+};
+
+describe('tracer.Tracer', () => {
+  describe('configuration', () => {
+    it('rejects a missing or empty serviceName', () => {
+      for (const serviceName of ['', '   ', undefined, 42]) {
+        asserts.assertThrows(
+          () => new Tracer({ serviceName } as never),
+          TracerConfigError,
+          'serviceName',
+        );
+      }
+    });
+
+    it('rejects a non-function sampler', () => {
+      asserts.assertThrows(
+        () => new Tracer({ serviceName: 'a', sampler: 'nope' as never }),
+        TracerConfigError,
+        'sampler',
+      );
+    });
+
+    it('rejects an exporter without an export method', () => {
+      for (const exporter of [{}, null, 'nope']) {
+        asserts.assertThrows(
+          () => new Tracer({ serviceName: 'a', exporter: exporter as never }),
+          TracerConfigError,
+          'exporter',
+        );
+      }
+    });
+
+    it('rejects an idGenerator that is not a shaped object', () => {
+      for (const idGenerator of [null, 'nope', {}, { traceId: () => 'x' }]) {
+        asserts.assertThrows(
+          () =>
+            new Tracer({ serviceName: 'a', idGenerator: idGenerator as never }),
+          TracerConfigError,
+          'idGenerator',
+        );
+      }
+    });
+
+    it('rejects an idGenerator producing non-conformant ids', () => {
+      const cases: IdGenerator[] = [
+        { traceId: () => 'too-short', spanId: () => 'b'.repeat(16) },
+        { traceId: () => 'A'.repeat(32), spanId: () => 'b'.repeat(16) }, // uppercase
+        { traceId: () => '0'.repeat(32), spanId: () => 'b'.repeat(16) }, // all-zero
+        { traceId: () => 'a'.repeat(32), spanId: () => 'short' },
+        { traceId: () => 'a'.repeat(32), spanId: () => '0'.repeat(16) },
+      ];
+      for (const idGenerator of cases) {
+        asserts.assertThrows(
+          () => new Tracer({ serviceName: 'a', idGenerator }),
+          TracerConfigError,
+          'idGenerator',
+        );
+      }
+    });
+
+    it('accepts a conformant custom idGenerator', () => {
+      const idGenerator = createRandomIdGenerator(
+        (n) => new Uint8Array(n).fill(0x0a),
+      );
+      const tracer = new Tracer({ serviceName: 'a', idGenerator });
+      asserts.assertEquals(
+        tracer.startSpan('s').context.traceId,
+        '0a'.repeat(16),
+      );
+    });
+
+    it('works with no exporter at all', () => {
+      const tracer = new Tracer({ serviceName: 'a' });
+      const span = tracer.startSpan('s');
+      span.end(); // must not throw
+      asserts.assertMatch(span.context.traceId, /^[0-9a-f]{32}$/);
+    });
+  });
+
+  describe('span creation', () => {
+    it('starts a root span with a fresh trace and no parent', () => {
+      const { tracer } = tracerWith();
+      const span = tracer.startSpan('root');
+      asserts.assertEquals(span.parentSpanId, undefined);
+      asserts.assertMatch(span.context.traceId, /^[0-9a-f]{32}$/);
+      asserts.assertEquals(span.kind, SpanKind.INTERNAL);
+    });
+
+    it('honours kind, attributes and startTime', () => {
+      const { tracer } = tracerWith();
+      const span = tracer.startSpan('s', {
+        kind: SpanKind.SERVER,
+        attributes: { 'http.method': 'GET' },
+        startTime: new Date(1234),
+      });
+      asserts.assertEquals(span.kind, SpanKind.SERVER);
+      asserts.assertEquals(span.startTime, new Date(1234));
+      asserts.assertEquals(span.toData().attributes['http.method'], 'GET');
+    });
+
+    it('attaches service.name and custom resource attributes', () => {
+      const { tracer, exporter } = tracerWith({
+        resource: { 'deployment.environment': 'ci' },
+      });
+      tracer.startSpan('s').end();
+      const resource = exporter.spans[0]!.resource;
+      asserts.assertEquals(resource['service.name'], 'test');
+      asserts.assertEquals(resource['deployment.environment'], 'ci');
+    });
+
+    it('adopts an explicit parent context', () => {
+      const { tracer } = tracerWith();
+      const parent = extract({
+        traceparent: `00-${'c'.repeat(32)}-${'d'.repeat(16)}-01`,
+      })!;
+      const span = tracer.startSpan('child', { parent });
+      asserts.assertEquals(span.context.traceId, 'c'.repeat(32));
+      asserts.assertEquals(span.parentSpanId, 'd'.repeat(16));
+    });
+  });
+
+  describe('automatic parenting', () => {
+    it('parents to the active span, across await and depth', async () => {
+      const { tracer, exporter } = tracerWith();
+      await tracer.startActiveSpan('parent', async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        await tracer.startActiveSpan('child', async () => {
+          await new Promise((r) => setTimeout(r, 1));
+          tracer.startSpan('grandchild').end();
+        });
+      });
+      const parent = exporter.find('parent')!;
+      const child = exporter.find('child')!;
+      const grandchild = exporter.find('grandchild')!;
+      asserts.assertEquals(child.parentSpanId, parent.context.spanId);
+      asserts.assertEquals(grandchild.parentSpanId, child.context.spanId);
+      // One trace throughout.
+      asserts.assertEquals(child.context.traceId, parent.context.traceId);
+      asserts.assertEquals(grandchild.context.traceId, parent.context.traceId);
+    });
+
+    it('parent: null forces a new root even inside an active span', () => {
+      const { tracer, exporter } = tracerWith();
+      tracer.startActiveSpan('outer', (outer) => {
+        tracer.startSpan('detached', { parent: null }).end();
+        const detached = exporter.find('detached')!;
+        asserts.assertEquals(detached.parentSpanId, undefined);
+        asserts.assertNotEquals(
+          detached.context.traceId,
+          outer.context.traceId,
+        );
+      });
+    });
+
+    it('isolates concurrent traces', async () => {
+      const { tracer, exporter } = tracerWith();
+      await Promise.all([
+        tracer.startActiveSpan('a', async () => {
+          await new Promise((r) => setTimeout(r, 5));
+          tracer.startSpan('a.child').end();
+        }),
+        tracer.startActiveSpan('b', async () => {
+          await new Promise((r) => setTimeout(r, 1));
+          tracer.startSpan('b.child').end();
+        }),
+      ]);
+      asserts.assertEquals(
+        exporter.find('a.child')!.parentSpanId,
+        exporter.find('a')!.context.spanId,
+      );
+      asserts.assertEquals(
+        exporter.find('b.child')!.parentSpanId,
+        exporter.find('b')!.context.spanId,
+      );
+    });
+
+    it('active() reports the current span and clears afterwards', () => {
+      const { tracer } = tracerWith();
+      asserts.assertEquals(tracer.active(), undefined);
+      tracer.startActiveSpan('s', (span) => {
+        asserts.assertStrictEquals(tracer.active(), span);
+      });
+      asserts.assertEquals(tracer.active(), undefined);
+    });
+  });
+
+  describe('sampling', () => {
+    it('drops unsampled spans but still propagates their context', () => {
+      const { tracer, exporter } = tracerWith({ sampler: alwaysOffSampler });
+      const span = tracer.startSpan('dropped');
+      span.setAttribute('a', 1);
+      span.end();
+      asserts.assertEquals(exporter.spans.length, 0);
+      asserts.assertEquals(span.isRecording(), false);
+      asserts.assertEquals(span.context.traceFlags, 0);
+      asserts.assertMatch(inject(span.context), /-00$/);
+    });
+
+    it('children inherit the parent decision rather than re-sampling', () => {
+      let sampplerCalls = 0;
+      const { tracer, exporter } = tracerWith({
+        sampler: () => {
+          sampplerCalls++;
+          return true;
+        },
+      });
+      tracer.startActiveSpan('root', () => {
+        tracer.startSpan('child').end();
+      });
+      asserts.assertEquals(sampplerCalls, 1); // root only
+      asserts.assertEquals(exporter.spans.length, 2);
+    });
+
+    it('inherits an unsampled remote parent', () => {
+      const { tracer, exporter } = tracerWith();
+      const parent = extract({
+        traceparent: `00-${'c'.repeat(32)}-${'d'.repeat(16)}-00`,
+      })!;
+      tracer.startSpan('child', { parent }).end();
+      asserts.assertEquals(exporter.spans.length, 0);
+    });
+
+    it('marks sampled spans with the W3C sampled flag', () => {
+      const { tracer } = tracerWith();
+      asserts.assertEquals(
+        tracer.startSpan('s').context.traceFlags,
+        FLAG_SAMPLED,
+      );
+    });
+  });
+
+  describe('startActiveSpan', () => {
+    it('returns the callback result and ends the span', () => {
+      const { tracer, exporter } = tracerWith();
+      const result = tracer.startActiveSpan('s', () => 42);
+      asserts.assertEquals(result, 42);
+      asserts.assertEquals(exporter.spans.length, 1);
+    });
+
+    it('accepts options as the second argument', () => {
+      const { tracer, exporter } = tracerWith();
+      tracer.startActiveSpan('s', { kind: SpanKind.CLIENT }, () => {});
+      asserts.assertEquals(exporter.spans[0]!.kind, SpanKind.CLIENT);
+    });
+
+    it('awaits an async callback before ending the span', async () => {
+      const { tracer, exporter } = tracerWith();
+      await tracer.startActiveSpan('s', async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      const span = exporter.spans[0]!;
+      asserts.assert(
+        span.endTime.getTime() - span.startTime.getTime() >= 9,
+        'span duration should cover the awaited work',
+      );
+    });
+
+    it('records and rethrows a synchronous throw', () => {
+      const { tracer, exporter } = tracerWith();
+      asserts.assertThrows(
+        () =>
+          tracer.startActiveSpan('s', () => {
+            throw new Error('sync boom');
+          }),
+        Error,
+        'sync boom',
+      );
+      const span = exporter.spans[0]!;
+      asserts.assertEquals(span.events[0]!.name, 'exception');
+      asserts.assertEquals(
+        span.events[0]!.attributes['exception.message'],
+        'sync boom',
+      );
+    });
+
+    it('records and rethrows an async rejection', async () => {
+      const { tracer, exporter } = tracerWith();
+      await asserts.assertRejects(
+        () =>
+          tracer.startActiveSpan('s', async () => {
+            await new Promise((r) => setTimeout(r, 1));
+            throw new Error('async boom');
+          }),
+        Error,
+        'async boom',
+      );
+      asserts.assertEquals(
+        exporter.spans[0]!.events[0]!.attributes['exception.message'],
+        'async boom',
+      );
+    });
+  });
+
+  describe('export resilience', () => {
+    it('swallows a rejected export', async () => {
+      const exporter: SpanExporter = {
+        export: () => Promise.reject(new Error('collector down')),
+      };
+      const tracer = new Tracer({ serviceName: 'test', exporter });
+      tracer.startSpan('s').end(); // must not throw or reject
+      await tracer.shutdown();
+    });
+
+    it('swallows a synchronous throw from a broken exporter', () => {
+      const exporter = {
+        export: () => {
+          throw new Error('broken');
+        },
+      } as unknown as SpanExporter;
+      const tracer = new Tracer({ serviceName: 'test', exporter });
+      tracer.startSpan('s').end(); // must not throw
+    });
+
+    it('shutdown awaits in-flight exports and calls exporter.shutdown', async () => {
+      let flushed = false;
+      let exported: SpanData[] = [];
+      const exporter: SpanExporter = {
+        export: async (spans) => {
+          await new Promise((r) => setTimeout(r, 5));
+          exported = spans;
+        },
+        shutdown: () => {
+          flushed = true;
+          return Promise.resolve();
+        },
+      };
+      const tracer = new Tracer({ serviceName: 'test', exporter });
+      tracer.startSpan('s').end();
+      await tracer.shutdown();
+      asserts.assertEquals(exported.length, 1);
+      asserts.assertEquals(flushed, true);
+    });
+
+    it('shutdown is safe with no exporter', async () => {
+      const tracer = new Tracer({ serviceName: 'test' });
+      await tracer.shutdown();
+    });
+  });
+
+  describe('end-to-end propagation', () => {
+    it('continues a trace across a simulated service boundary', () => {
+      const a = tracerWith();
+      const b = tracerWith();
+
+      let header = '';
+      a.tracer.startActiveSpan('client', { kind: SpanKind.CLIENT }, (span) => {
+        header = inject(span.context);
+      });
+
+      // …the header travels over the wire…
+      const parent = extract({ traceparent: header });
+      b.tracer.startActiveSpan(
+        'server',
+        { kind: SpanKind.SERVER, parent },
+        (span) => {
+          span.setStatus(SpanStatusCode.OK);
+        },
+      );
+
+      const client = a.exporter.find('client')!;
+      const server = b.exporter.find('server')!;
+      asserts.assertEquals(server.context.traceId, client.context.traceId);
+      asserts.assertEquals(server.parentSpanId, client.context.spanId);
+    });
+  });
+});

--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -302,11 +302,18 @@ export class Tracer extends Options<TracerOptions> {
     const exporter = this.getOption('exporter') as SpanExporter | undefined;
     if (exporter === undefined) return;
     let promise: Promise<void>;
-    try {
-      // The attached `.catch()` — rather than an `await` — is what stops a
-      // rejected export from surfacing as an unhandled rejection, while
-      // keeping the call synchronous. The surrounding try/catch covers only a
-      // *synchronous* throw from a misbehaving exporter.
+    // The two failure modes need two different guards, and both are load-bearing:
+    //   - `.catch()` absorbs a REJECTED export, without an `await` that would
+    //     make ending a span asynchronous.
+    //   - the try/catch absorbs a SYNCHRONOUS throw from a misbehaving
+    //     exporter, which happens before a promise exists and so can never
+    //     reach `.catch()`. `Tracer.test.ts` covers this path.
+    // S4822 reads the `.catch()` and concludes the try is redundant; removing
+    // it would let a synchronous throw escape into the caller's `span.end()`,
+    // which is exactly what this method exists to prevent. Wrapping the call in
+    // `Promise.resolve().then(...)` would satisfy the rule but defer the export
+    // to a microtask, breaking synchronous-export semantics.
+    try { //NOSONAR - see above: guards a sync throw, which .catch() cannot
       promise = exporter.export([data]).catch(() => {
         /* observability must not break the application */
       });

--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -269,7 +269,7 @@ export class Tracer extends Options<TracerOptions> {
    * are not lost.
    */
   public async shutdown(): Promise<void> {
-    await Promise.allSettled([...this.__pending]);
+    await Promise.allSettled(this.__pending);
     const exporter = this.getOption('exporter') as SpanExporter | undefined;
     await exporter?.shutdown?.();
   }
@@ -303,13 +303,17 @@ export class Tracer extends Options<TracerOptions> {
     if (exporter === undefined) return;
     let promise: Promise<void>;
     try {
-      promise = exporter.export([data]);
+      // The attached `.catch()` — rather than an `await` — is what stops a
+      // rejected export from surfacing as an unhandled rejection, while
+      // keeping the call synchronous. The surrounding try/catch covers only a
+      // *synchronous* throw from a misbehaving exporter.
+      promise = exporter.export([data]).catch(() => {
+        /* observability must not break the application */
+      });
     } catch {
-      return; // synchronous throw from a misbehaving exporter
+      return;
     }
     this.__pending.add(promise);
-    void promise
-      .catch(() => {/* observability must not break the application */})
-      .finally(() => this.__pending.delete(promise));
+    void promise.finally(() => this.__pending.delete(promise));
   }
 }

--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -1,0 +1,315 @@
+/**
+ * @fileoverview The {@link Tracer} — creates spans, resolves their parents from
+ * the ambient active-span store, applies sampling, and hands finished spans to
+ * the exporter.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ *
+ * @example
+ * ```typescript
+ * import { ConsoleExporter, Tracer } from '@tundralibs/tracer';
+ *
+ * const tracer = new Tracer({
+ *   serviceName: 'orders',
+ *   exporter: new ConsoleExporter(),
+ * });
+ *
+ * await tracer.startActiveSpan('checkout', async (span) => {
+ *   span.setAttribute('order.id', 'ord_42');
+ *   await chargeCard();          // any span started in here parents to `checkout`
+ * });
+ * ```
+ */
+
+import { Options } from '@tundralibs/utils';
+import { activeSpan } from './activeSpan.ts';
+import { Span } from './Span.ts';
+import { randomIdGenerator } from './ids.ts';
+import { alwaysOnSampler } from './samplers.ts';
+import { FLAG_SAMPLED } from './propagation.ts';
+import { TracerConfigError } from './errors/mod.ts';
+import type {
+  Attributes,
+  IdGenerator,
+  Sampler,
+  SpanContext,
+  SpanData,
+  SpanExporter,
+  SpanOptions,
+  TracerOptions,
+} from './types/mod.ts';
+import { SpanKind } from './types/mod.ts';
+
+/** Shape a custom {@link IdGenerator} must produce — 32 lowercase hex chars. */
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+/** Shape a custom {@link IdGenerator} must produce — 16 lowercase hex chars. */
+const SPAN_ID_PATTERN = /^[0-9a-f]{16}$/;
+
+/**
+ * Creates and manages spans for one service.
+ *
+ * Parenting is automatic: a span created while another is active becomes its
+ * child, at any call depth and across every `await`, because the active span
+ * lives in an `ambient` async context rather than being threaded through
+ * function signatures.
+ */
+export class Tracer extends Options<TracerOptions> {
+  /**
+   * @param options - See {@link TracerOptions}.
+   * @throws {TracerConfigError} When `serviceName` is not a non-empty string.
+   * @throws {TracerConfigError} When `sampler` is not a function.
+   * @throws {TracerConfigError} When `exporter` has no `export` method.
+   * @throws {TracerConfigError} When `idGenerator` produces ids that are not
+   *   W3C-conformant (wrong width, non-hex, uppercase, or all-zero).
+   */
+  constructor(options: TracerOptions) {
+    super();
+    this._setOptions(options, {
+      sampler: alwaysOnSampler,
+      idGenerator: randomIdGenerator,
+      resource: {},
+    });
+  }
+
+  /**
+   * Validate and normalise options at construction. Nothing here runs on the
+   * span hot path.
+   *
+   * @throws {TracerConfigError} See the constructor.
+   */
+  protected override _processOption<K extends keyof TracerOptions>(
+    key: K,
+    value: TracerOptions[K],
+  ): TracerOptions[K] {
+    switch (key) {
+      case 'serviceName':
+        if (typeof value !== 'string' || value.trim() === '') {
+          throw new TracerConfigError(
+            'serviceName must be a non-empty string',
+            { key: 'serviceName' },
+          );
+        }
+        break;
+      case 'sampler':
+        if (typeof value !== 'function') {
+          throw new TracerConfigError('sampler must be a function', {
+            key: 'sampler',
+          });
+        }
+        break;
+      case 'exporter':
+        if (
+          value === null || typeof value !== 'object' ||
+          typeof (value as SpanExporter).export !== 'function'
+        ) {
+          throw new TracerConfigError(
+            'exporter must expose an export() method',
+            { key: 'exporter' },
+          );
+        }
+        break;
+      case 'idGenerator':
+        this.__validateIdGenerator(value as IdGenerator);
+        break;
+    }
+    return value;
+  }
+
+  /**
+   * Smoke-test a custom id generator once, at construction.
+   *
+   * Malformed ids are not rejected by collectors with an error — the spans are
+   * silently dropped, so traces simply never appear. Failing loudly here turns
+   * that into an immediate, obvious error.
+   *
+   * @throws {TracerConfigError} When output is not W3C-conformant.
+   */
+  private __validateIdGenerator(generator: IdGenerator): void {
+    if (
+      generator === null || typeof generator !== 'object' ||
+      typeof generator.traceId !== 'function' ||
+      typeof generator.spanId !== 'function'
+    ) {
+      throw new TracerConfigError(
+        'idGenerator must expose traceId() and spanId() methods',
+        { key: 'idGenerator' },
+      );
+    }
+    const traceId = generator.traceId();
+    if (!TRACE_ID_PATTERN.test(traceId) || /^0+$/.test(traceId)) {
+      throw new TracerConfigError(
+        'idGenerator.traceId() must return 32 lowercase hex characters, not all-zero',
+        { key: 'idGenerator', value: traceId },
+      );
+    }
+    const spanId = generator.spanId();
+    if (!SPAN_ID_PATTERN.test(spanId) || /^0+$/.test(spanId)) {
+      throw new TracerConfigError(
+        'idGenerator.spanId() must return 16 lowercase hex characters, not all-zero',
+        { key: 'idGenerator', value: spanId },
+      );
+    }
+  }
+
+  /** The span currently in scope, or `undefined` outside any span. */
+  public active(): Span | undefined {
+    return activeSpan.get();
+  }
+
+  /**
+   * Start a span **without** making it active. The caller owns its lifetime and
+   * must call {@link Span.end}; spans started inside will *not* parent to it.
+   * Prefer {@link Tracer.startActiveSpan} unless the span's scope genuinely
+   * does not match a function call.
+   *
+   * @param name - Operation name.
+   * @param options - See {@link SpanOptions}.
+   * @returns The new {@link Span}.
+   */
+  public startSpan(name: string, options: SpanOptions = {}): Span {
+    const idGenerator = this.getOption('idGenerator') as IdGenerator;
+    const parent = this.__resolveParent(options);
+    const kind = options.kind ?? SpanKind.INTERNAL;
+    const attributes = options.attributes ?? {};
+    const traceId = parent?.traceId ?? idGenerator.traceId();
+
+    // Child spans inherit the parent's decision so a trace is sampled whole;
+    // only roots consult the sampler.
+    const sampled = parent !== undefined
+      ? (parent.traceFlags & FLAG_SAMPLED) !== 0
+      : (this.getOption('sampler') as Sampler)({
+        traceId,
+        name,
+        kind,
+        attributes,
+        parent,
+      });
+
+    return new Span({
+      name,
+      context: {
+        traceId,
+        spanId: idGenerator.spanId(),
+        traceFlags: sampled ? FLAG_SAMPLED : 0,
+      },
+      kind,
+      startTime: options.startTime ?? new Date(),
+      parentSpanId: parent?.spanId,
+      attributes,
+      resource: this.__resourceAttributes(),
+      recording: sampled,
+      onEnd: (data) => this.__export(data),
+    });
+  }
+
+  /**
+   * Start a span, make it **active** for the duration of `fn`, and end it when
+   * `fn` settles. This is the form to reach for: everything `fn` does — at any
+   * depth, across any `await` — parents to this span automatically.
+   *
+   * The span is ended and exceptions recorded even when `fn` throws; the error
+   * is re-thrown unchanged.
+   *
+   * @typeParam R - `fn`'s return type.
+   * @param name - Operation name.
+   * @param optionsOrFn - {@link SpanOptions}, or `fn` when there are none.
+   * @param maybeFn - `fn`, when options were supplied.
+   * @returns Whatever `fn` returns.
+   */
+  public startActiveSpan<R>(name: string, fn: (span: Span) => R): R;
+  public startActiveSpan<R>(
+    name: string,
+    options: SpanOptions,
+    fn: (span: Span) => R,
+  ): R;
+  public startActiveSpan<R>(
+    name: string,
+    optionsOrFn: SpanOptions | ((span: Span) => R),
+    maybeFn?: (span: Span) => R,
+  ): R {
+    const options = typeof optionsOrFn === 'function' ? {} : optionsOrFn;
+    const fn = typeof optionsOrFn === 'function'
+      ? optionsOrFn
+      : maybeFn as (span: Span) => R;
+
+    const span = this.startSpan(name, options);
+    return activeSpan.run(span, () => {
+      let result: R;
+      try {
+        result = fn(span);
+      } catch (error) {
+        span.recordException(error);
+        span.end();
+        throw error;
+      }
+      // Async `fn`: keep the span open until the promise settles, so its
+      // duration reflects the real work rather than just the synchronous head.
+      if (result instanceof Promise) {
+        return result.then(
+          (value) => {
+            span.end();
+            return value;
+          },
+          (error: unknown) => {
+            span.recordException(error);
+            span.end();
+            throw error;
+          },
+        ) as R;
+      }
+      span.end();
+      return result;
+    });
+  }
+
+  /**
+   * Flush and release the exporter. Call before process exit so buffered spans
+   * are not lost.
+   */
+  public async shutdown(): Promise<void> {
+    await Promise.allSettled([...this.__pending]);
+    const exporter = this.getOption('exporter') as SpanExporter | undefined;
+    await exporter?.shutdown?.();
+  }
+
+  /** In-flight export promises, awaited by {@link Tracer.shutdown}. */
+  private readonly __pending: Set<Promise<void>> = new Set();
+
+  /**
+   * Resolve the parent context: an explicit one, else the active span's, else
+   * none (making this a trace root). `parent: null` forces a root.
+   */
+  private __resolveParent(options: SpanOptions): SpanContext | undefined {
+    if (options.parent === null) return undefined;
+    return options.parent ?? activeSpan.get()?.context;
+  }
+
+  /** `service.name` merged with any user-supplied resource attributes. */
+  private __resourceAttributes(): Attributes {
+    return {
+      ...(this.getOption('resource') as Attributes),
+      'service.name': this.getOption('serviceName') as string,
+    };
+  }
+
+  /**
+   * Hand a finished span to the exporter. Export failures are swallowed: a
+   * broken collector must never surface as an application error.
+   */
+  private __export(data: SpanData): void {
+    const exporter = this.getOption('exporter') as SpanExporter | undefined;
+    if (exporter === undefined) return;
+    let promise: Promise<void>;
+    try {
+      promise = exporter.export([data]);
+    } catch {
+      return; // synchronous throw from a misbehaving exporter
+    }
+    this.__pending.add(promise);
+    void promise
+      .catch(() => {/* observability must not break the application */})
+      .finally(() => this.__pending.delete(promise));
+  }
+}

--- a/packages/tracer/activeSpan.ts
+++ b/packages/tracer/activeSpan.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview The active-span store — a dedicated `ambient` context holding
+ * the span currently in scope.
+ *
+ * This is why `startSpan` needs no explicit parent: the active span travels
+ * with the async flow (across every `await`, isolated between concurrent
+ * requests), so a span created five frames deep automatically parents to the
+ * one opened at the request boundary.
+ *
+ * It is deliberately a **separate** store from `ambient`'s `RequestContext`:
+ * span lifecycle is tracer's concern, not part of the shared request bag.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import { createContext } from '@tundralibs/ambient';
+import type { Span } from './Span.ts';
+
+/**
+ * The currently active {@link Span}, or `undefined` outside any span scope.
+ * Prefer `tracer.active()` — this is the underlying store.
+ */
+export const activeSpan: ReturnType<typeof createContext<Span>> = createContext<
+  Span
+>();

--- a/packages/tracer/deno.json
+++ b/packages/tracer/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tundralibs/tracer",
+  "version": "0.1.0",
+  "description": "Cross-runtime distributed tracing — W3C Trace Context propagation, automatic span nesting via ambient async context, pluggable samplers and exporters",
+  "license": "MIT",
+  "exports": {
+    ".": "./mod.ts",
+    "./errors": "./errors/mod.ts",
+    "./exporters": "./exporters/mod.ts",
+    "./types": "./types/mod.ts"
+  },
+  "imports": {}
+}

--- a/packages/tracer/errors/Base.ts
+++ b/packages/tracer/errors/Base.ts
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview {@link TracerError} — the package base error.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import { BaseError } from '@tundralibs/utils';
+
+/**
+ * Base class for every error thrown by `@tundralibs/tracer`. Extends
+ * `BaseError` so all package errors share the project-wide contract (typed
+ * `context`, `${var}` substitution, cause chains, JSON serialisation).
+ */
+export class TracerError<
+  M extends Record<string, unknown> = Record<string, unknown>,
+> extends BaseError<M> {
+  // `name` is set automatically by BaseError via this.constructor.name.
+}

--- a/packages/tracer/errors/TracerConfigError.ts
+++ b/packages/tracer/errors/TracerConfigError.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview {@link TracerConfigError} — invalid {@link Tracer}
+ * configuration.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import { TracerError } from './Base.ts';
+
+/** Metadata carried by a {@link TracerConfigError}. */
+export type TracerConfigErrorMeta = {
+  /** The offending option key. */
+  key: string;
+  /** The rejected value, when it is safe and useful to surface. */
+  value?: unknown;
+};
+
+/**
+ * Thrown at construction when an option is missing or invalid — an empty
+ * `serviceName`, a non-function `sampler`, or an `idGenerator` whose output
+ * does not match the W3C format.
+ *
+ * Config problems throw; nothing at span-recording time ever does. Tracing is
+ * observability, and observability must not be able to break the application
+ * it observes.
+ */
+export class TracerConfigError extends TracerError<TracerConfigErrorMeta> {}

--- a/packages/tracer/errors/mod.ts
+++ b/packages/tracer/errors/mod.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Re-exports the error surface of `@tundralibs/tracer`.
+ *
+ * @module
+ */
+
+export { TracerError } from './Base.ts';
+export {
+  TracerConfigError,
+  type TracerConfigErrorMeta,
+} from './TracerConfigError.ts';

--- a/packages/tracer/exporters/ConsoleExporter.ts
+++ b/packages/tracer/exporters/ConsoleExporter.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview {@link ConsoleExporter} — prints spans for local development.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { SpanData, SpanExporter } from '../types/mod.ts';
+import { SpanStatusCode } from '../types/mod.ts';
+
+/** Options for {@link ConsoleExporter}. */
+export type ConsoleExporterOptions = {
+  /**
+   * Emit each span as a single JSON line instead of the human-readable
+   * summary. Defaults to `false`.
+   */
+  json?: boolean;
+};
+
+/**
+ * Writes finished spans to the console — a readable one-line summary by
+ * default, or newline-delimited JSON with `{ json: true }`.
+ *
+ * For local development only; use the OTLP exporter for real backends.
+ *
+ * @example
+ * ```text
+ * [trace 4bf92f35…] GET /orders/:id  12.4ms  OK
+ * ```
+ */
+export class ConsoleExporter implements SpanExporter {
+  private readonly __json: boolean;
+
+  /**
+   * @param options - See {@link ConsoleExporterOptions}.
+   */
+  constructor(options: ConsoleExporterOptions = {}) {
+    this.__json = options.json === true;
+  }
+
+  /**
+   * Print `spans`.
+   *
+   * @param spans - Finished spans to print.
+   */
+  public export(spans: SpanData[]): Promise<void> {
+    for (const span of spans) {
+      console.log(this.__json ? JSON.stringify(span) : this.__format(span));
+    }
+    return Promise.resolve();
+  }
+
+  /** One-line human-readable summary of a span. */
+  private __format(span: SpanData): string {
+    const ms = span.endTime.getTime() - span.startTime.getTime();
+    const status = span.status.code === SpanStatusCode.ERROR
+      ? `ERROR${span.status.message ? ` (${span.status.message})` : ''}`
+      : 'OK';
+    const trace = span.context.traceId.slice(0, 8);
+    return `[trace ${trace}…] ${span.name}  ${ms}ms  ${status}`;
+  }
+}

--- a/packages/tracer/exporters/ConsoleExporter.ts
+++ b/packages/tracer/exporters/ConsoleExporter.ts
@@ -51,13 +51,17 @@ export class ConsoleExporter implements SpanExporter {
     return Promise.resolve();
   }
 
+  /** Render a span's outcome, appending the message when there is one. */
+  private __status(span: SpanData): string {
+    if (span.status.code !== SpanStatusCode.ERROR) return 'OK';
+    if (span.status.message === undefined) return 'ERROR';
+    return `ERROR (${span.status.message})`;
+  }
+
   /** One-line human-readable summary of a span. */
   private __format(span: SpanData): string {
     const ms = span.endTime.getTime() - span.startTime.getTime();
-    const status = span.status.code === SpanStatusCode.ERROR
-      ? `ERROR${span.status.message ? ` (${span.status.message})` : ''}`
-      : 'OK';
     const trace = span.context.traceId.slice(0, 8);
-    return `[trace ${trace}…] ${span.name}  ${ms}ms  ${status}`;
+    return `[trace ${trace}…] ${span.name}  ${ms}ms  ${this.__status(span)}`;
   }
 }

--- a/packages/tracer/exporters/MemoryExporter.ts
+++ b/packages/tracer/exporters/MemoryExporter.ts
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview {@link MemoryExporter} — buffers spans in memory. The exporter
+ * to use in tests.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { SpanData, SpanExporter } from '../types/mod.ts';
+
+/**
+ * Collects finished spans in an array instead of sending them anywhere.
+ * Intended for tests and local assertions.
+ *
+ * @example
+ * ```typescript
+ * const exporter = new MemoryExporter();
+ * const tracer = new Tracer({ serviceName: 'test', exporter });
+ *
+ * tracer.startActiveSpan('work', () => {});
+ *
+ * exporter.spans[0]?.name; // 'work'
+ * ```
+ */
+export class MemoryExporter implements SpanExporter {
+  private readonly __spans: SpanData[] = [];
+
+  /** Every span exported so far, in completion order. */
+  public get spans(): SpanData[] {
+    return this.__spans;
+  }
+
+  /**
+   * Buffer `spans`.
+   *
+   * @param spans - Finished spans to record.
+   */
+  public export(spans: SpanData[]): Promise<void> {
+    this.__spans.push(...spans);
+    return Promise.resolve();
+  }
+
+  /** Discard everything buffered — call between test cases. */
+  public reset(): void {
+    this.__spans.length = 0;
+  }
+
+  /** Finds the first buffered span named `name`, for concise assertions. */
+  public find(name: string): SpanData | undefined {
+    return this.__spans.find((span) => span.name === name);
+  }
+}

--- a/packages/tracer/exporters/exporters.test.ts
+++ b/packages/tracer/exporters/exporters.test.ts
@@ -1,0 +1,92 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { ConsoleExporter, MemoryExporter } from './mod.ts';
+import { SpanKind, SpanStatusCode } from '../types/mod.ts';
+import type { SpanData } from '../types/mod.ts';
+
+const spanData = (overrides: Partial<SpanData> = {}): SpanData => ({
+  name: 'op',
+  context: { traceId: 'a'.repeat(32), spanId: 'b'.repeat(16), traceFlags: 1 },
+  kind: SpanKind.INTERNAL,
+  startTime: new Date(1000),
+  endTime: new Date(1250),
+  attributes: {},
+  events: [],
+  status: { code: SpanStatusCode.UNSET },
+  resource: { 'service.name': 'test' },
+  ...overrides,
+});
+
+/** Capture console.log for the duration of `fn`. */
+const captureLog = async (fn: () => void | Promise<void>) => {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+};
+
+describe('tracer.exporters', () => {
+  describe('MemoryExporter', () => {
+    it('buffers spans in completion order', async () => {
+      const exporter = new MemoryExporter();
+      await exporter.export([spanData({ name: 'one' })]);
+      await exporter.export([spanData({ name: 'two' })]);
+      asserts.assertEquals(exporter.spans.map((s) => s.name), ['one', 'two']);
+    });
+
+    it('finds a span by name', async () => {
+      const exporter = new MemoryExporter();
+      await exporter.export([spanData({ name: 'findme' })]);
+      asserts.assertEquals(exporter.find('findme')?.name, 'findme');
+      asserts.assertEquals(exporter.find('absent'), undefined);
+    });
+
+    it('reset empties the buffer', async () => {
+      const exporter = new MemoryExporter();
+      await exporter.export([spanData()]);
+      exporter.reset();
+      asserts.assertEquals(exporter.spans.length, 0);
+    });
+  });
+
+  describe('ConsoleExporter', () => {
+    it('prints a human-readable summary', async () => {
+      const exporter = new ConsoleExporter();
+      const lines = await captureLog(() => exporter.export([spanData()]));
+      asserts.assertEquals(lines.length, 1);
+      asserts.assertStringIncludes(lines[0]!, 'op');
+      asserts.assertStringIncludes(lines[0]!, '250ms');
+      asserts.assertStringIncludes(lines[0]!, 'OK');
+      asserts.assertStringIncludes(lines[0]!, 'aaaaaaaa');
+    });
+
+    it('surfaces an error status and message', async () => {
+      const exporter = new ConsoleExporter();
+      const lines = await captureLog(() =>
+        exporter.export([
+          spanData({ status: { code: SpanStatusCode.ERROR, message: 'boom' } }),
+        ])
+      );
+      asserts.assertStringIncludes(lines[0]!, 'ERROR (boom)');
+    });
+
+    it('surfaces an error status without a message', async () => {
+      const exporter = new ConsoleExporter();
+      const lines = await captureLog(() =>
+        exporter.export([spanData({ status: { code: SpanStatusCode.ERROR } })])
+      );
+      asserts.assertStringIncludes(lines[0]!, 'ERROR');
+    });
+
+    it('emits JSON lines when configured', async () => {
+      const exporter = new ConsoleExporter({ json: true });
+      const lines = await captureLog(() => exporter.export([spanData()]));
+      asserts.assertEquals(JSON.parse(lines[0]!).name, 'op');
+    });
+  });
+});

--- a/packages/tracer/exporters/mod.ts
+++ b/packages/tracer/exporters/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview Built-in span exporters.
+ *
+ * The OTLP exporter lives behind its own subpath (`@tundralibs/tracer/otlp`)
+ * so the core stays dependency-free — importing a tracer does not pull an HTTP
+ * client into the graph.
+ *
+ * @module
+ */
+
+export {
+  ConsoleExporter,
+  type ConsoleExporterOptions,
+} from './ConsoleExporter.ts';
+export { MemoryExporter } from './MemoryExporter.ts';

--- a/packages/tracer/ids.test.ts
+++ b/packages/tracer/ids.test.ts
@@ -1,0 +1,50 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { createRandomIdGenerator, randomIdGenerator } from './mod.ts';
+import type { RandomBytes } from './mod.ts';
+import { isZeroId, toHex } from './ids.ts';
+
+describe('tracer.ids', () => {
+  it('toHex encodes bytes as lowercase hex, two chars per byte', () => {
+    asserts.assertEquals(toHex(new Uint8Array([0, 15, 16, 255])), '000f10ff');
+    asserts.assertEquals(toHex(new Uint8Array(0)), '');
+  });
+
+  it('isZeroId detects the all-zero id', () => {
+    asserts.assertEquals(isZeroId('0'.repeat(32)), true);
+    asserts.assertEquals(isZeroId('0'.repeat(15) + '1'), false);
+  });
+
+  it('generates W3C-conformant trace and span ids', () => {
+    asserts.assertMatch(randomIdGenerator.traceId(), /^[0-9a-f]{32}$/);
+    asserts.assertMatch(randomIdGenerator.spanId(), /^[0-9a-f]{16}$/);
+  });
+
+  it('generates distinct ids across calls', () => {
+    const ids = new Set(
+      Array.from({ length: 100 }, () => randomIdGenerator.traceId()),
+    );
+    asserts.assertEquals(ids.size, 100);
+  });
+
+  it('redraws when the random source yields an all-zero id', () => {
+    let call = 0;
+    const source: RandomBytes = (length) => {
+      call++;
+      // First draw is all-zero (invalid per W3C) and must be rejected.
+      return call === 1
+        ? new Uint8Array(length)
+        : new Uint8Array(length).fill(0x07);
+    };
+    const generator = createRandomIdGenerator(source);
+    asserts.assertEquals(generator.traceId(), '07'.repeat(16));
+    asserts.assertEquals(call, 2);
+  });
+
+  it('accepts an injected deterministic source', () => {
+    const source: RandomBytes = (length) => new Uint8Array(length).fill(0xab);
+    const generator = createRandomIdGenerator(source);
+    asserts.assertEquals(generator.traceId(), 'ab'.repeat(16));
+    asserts.assertEquals(generator.spanId(), 'ab'.repeat(8));
+  });
+});

--- a/packages/tracer/ids.ts
+++ b/packages/tracer/ids.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Trace and span id generation. The default generator produces
+ * W3C-conformant random ids from `crypto.getRandomValues`, which is a global on
+ * every supported runtime — so this file carries no dependency at all.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ *
+ * @example
+ * ```typescript
+ * import { randomIdGenerator } from '@tundralibs/tracer';
+ *
+ * randomIdGenerator.traceId(); // '4bf92f3577b34da6a3ce929d0e0e4736'
+ * randomIdGenerator.spanId();  // '00f067aa0ba902b7'
+ * ```
+ */
+
+import type { IdGenerator } from './types/mod.ts';
+
+/** Byte width of a W3C trace id (32 hex characters). */
+const TRACE_ID_BYTES = 16;
+/** Byte width of a W3C span id (16 hex characters). */
+const SPAN_ID_BYTES = 8;
+
+/** A source of cryptographically random bytes. */
+export type RandomBytes = (length: number) => Uint8Array;
+
+/** The runtime's random source — Web Crypto, a global on Deno/Bun/Node. */
+const cryptoRandomBytes: RandomBytes = (length) =>
+  crypto.getRandomValues(new Uint8Array(length));
+
+/**
+ * Lowercase hex encoding of `bytes`. Exported for testing; not part of the
+ * package's public surface.
+ *
+ * @internal
+ * @param bytes - The bytes to encode.
+ * @returns Two lowercase hex characters per byte.
+ */
+export function toHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) {
+    out += byte.toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+/**
+ * Whether `id` is the all-zero id, which W3C defines as invalid. Exported for
+ * testing; not part of the package's public surface.
+ *
+ * @internal
+ * @param id - A lowercase hex id.
+ */
+export function isZeroId(id: string): boolean {
+  return /^0+$/.test(id);
+}
+
+/**
+ * Build an {@link IdGenerator} over a supplied random source.
+ *
+ * The random source is injectable so the all-zero rejection path — which is
+ * otherwise unreachable at a probability of 1 in 2^128 — stays testable, and
+ * so tests can pin ids deterministically.
+ *
+ * @param randomBytes - Byte source. Defaults to `crypto.getRandomValues`.
+ * @returns An {@link IdGenerator} producing W3C-conformant ids.
+ */
+export function createRandomIdGenerator(
+  randomBytes: RandomBytes = cryptoRandomBytes,
+): IdGenerator {
+  // W3C forbids the all-zero id; draw again rather than emit an invalid one.
+  const nonZeroHex = (bytes: number): string => {
+    let id = toHex(randomBytes(bytes));
+    while (isZeroId(id)) {
+      id = toHex(randomBytes(bytes));
+    }
+    return id;
+  };
+  return {
+    traceId: (): string => nonZeroHex(TRACE_ID_BYTES),
+    spanId: (): string => nonZeroHex(SPAN_ID_BYTES),
+  };
+}
+
+/** The default id generator — random ids from `crypto.getRandomValues`. */
+export const randomIdGenerator: IdGenerator = createRandomIdGenerator();

--- a/packages/tracer/mod.ts
+++ b/packages/tracer/mod.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview `@tundralibs/tracer` — distributed tracing that completes the
+ * observability triad with `slogger` (logs) and `metro-man` (metrics).
+ *
+ * Spans nest automatically: a span opened inside another becomes its child at
+ * any call depth and across every `await`, because the active span lives in an
+ * `ambient` async context rather than being threaded through signatures. W3C
+ * `traceparent` propagation carries the trace across process boundaries.
+ *
+ * - {@link Tracer} — creates spans, samples, exports.
+ * - {@link Span} — one unit of work.
+ * - {@link extract} / {@link inject} — W3C Trace Context propagation.
+ * - `ConsoleExporter` / `MemoryExporter` — built-in destinations.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+export { Tracer } from './Tracer.ts';
+export { Span, type SpanInit } from './Span.ts';
+export { activeSpan } from './activeSpan.ts';
+export {
+  createRandomIdGenerator,
+  type RandomBytes,
+  randomIdGenerator,
+} from './ids.ts';
+export {
+  extract,
+  FLAG_SAMPLED,
+  inject,
+  TRACEPARENT_HEADER,
+} from './propagation.ts';
+export { alwaysOffSampler, alwaysOnSampler, ratioSampler } from './samplers.ts';
+export {
+  ConsoleExporter,
+  type ConsoleExporterOptions,
+  MemoryExporter,
+} from './exporters/mod.ts';
+export { SpanKind, SpanStatusCode } from './types/mod.ts';
+export type {
+  Attributes,
+  AttributeValue,
+  HeadersLike,
+  IdGenerator,
+  Sampler,
+  SamplingInput,
+  SpanContext,
+  SpanData,
+  SpanEvent,
+  SpanExporter,
+  SpanOptions,
+  SpanStatus,
+  TracerOptions,
+} from './types/mod.ts';
+export {
+  TracerConfigError,
+  type TracerConfigErrorMeta,
+  TracerError,
+} from './errors/mod.ts';

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@tundralibs/tracer",
+  "version": "0.1.0",
+  "description": "Cross-runtime distributed tracing — W3C Trace Context propagation, automatic span nesting via ambient async context, pluggable samplers and exporters",
+  "license": "MIT",
+  "type": "module",
+  "main": "mod.ts",
+  "exports": {
+    ".": "./mod.ts",
+    "./errors": "./errors/mod.ts",
+    "./exporters": "./exporters/mod.ts",
+    "./types": "./types/mod.ts"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@tundralibs/ambient": "workspace:*",
+    "@tundralibs/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@tundralibs/compat": "workspace:*"
+  }
+}

--- a/packages/tracer/propagation.test.ts
+++ b/packages/tracer/propagation.test.ts
@@ -1,0 +1,109 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { extract, FLAG_SAMPLED, inject } from './mod.ts';
+
+const TRACE_ID = '4bf92f3577b34da6a3ce929d0e0e4736';
+const SPAN_ID = '00f067aa0ba902b7';
+const VALID = `00-${TRACE_ID}-${SPAN_ID}-01`;
+
+describe('tracer.propagation', () => {
+  describe('extract', () => {
+    it('parses a valid traceparent from a Headers object', () => {
+      const context = extract(new Headers({ traceparent: VALID }));
+      asserts.assertEquals(context?.traceId, TRACE_ID);
+      asserts.assertEquals(context?.spanId, SPAN_ID);
+      asserts.assertEquals(context?.traceFlags, FLAG_SAMPLED);
+      asserts.assertEquals(context?.remote, true);
+    });
+
+    it('parses from a plain record, case-insensitively', () => {
+      asserts.assertEquals(extract({ traceparent: VALID })?.traceId, TRACE_ID);
+      asserts.assertEquals(extract({ TraceParent: VALID })?.traceId, TRACE_ID);
+    });
+
+    it('parses from a record whose value is an array', () => {
+      asserts.assertEquals(
+        extract({ traceparent: [VALID] })?.traceId,
+        TRACE_ID,
+      );
+    });
+
+    it('tolerates surrounding whitespace', () => {
+      asserts.assertEquals(
+        extract({ traceparent: ` ${VALID} ` })?.traceId,
+        TRACE_ID,
+      );
+    });
+
+    it('reads an unsampled flag', () => {
+      const context = extract({ traceparent: `00-${TRACE_ID}-${SPAN_ID}-00` });
+      asserts.assertEquals(context?.traceFlags, 0);
+    });
+
+    it('returns undefined when the header is absent', () => {
+      asserts.assertEquals(extract(new Headers()), undefined);
+      asserts.assertEquals(extract({}), undefined);
+    });
+
+    it('returns undefined for malformed headers rather than throwing', () => {
+      for (
+        const bad of [
+          'garbage',
+          '',
+          `00-${TRACE_ID}-${SPAN_ID}`, // too few fields
+          `00-${TRACE_ID}-${SPAN_ID}-0`, // short flags
+          `00-XYZ92f3577b34da6a3ce929d0e0e4736-${SPAN_ID}-01`, // non-hex
+          `00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-01`, // uppercase
+        ]
+      ) {
+        asserts.assertEquals(extract({ traceparent: bad }), undefined, bad);
+      }
+    });
+
+    it('rejects the reserved ff version', () => {
+      asserts.assertEquals(
+        extract({ traceparent: `ff-${TRACE_ID}-${SPAN_ID}-01` }),
+        undefined,
+      );
+    });
+
+    it('rejects all-zero ids', () => {
+      asserts.assertEquals(
+        extract({ traceparent: `00-${'0'.repeat(32)}-${SPAN_ID}-01` }),
+        undefined,
+      );
+      asserts.assertEquals(
+        extract({ traceparent: `00-${TRACE_ID}-${'0'.repeat(16)}-01` }),
+        undefined,
+      );
+    });
+  });
+
+  describe('inject', () => {
+    it('formats a version-00 traceparent', () => {
+      asserts.assertEquals(
+        inject({ traceId: TRACE_ID, spanId: SPAN_ID, traceFlags: 1 }),
+        VALID,
+      );
+    });
+
+    it('zero-pads the flags', () => {
+      asserts.assertEquals(
+        inject({ traceId: TRACE_ID, spanId: SPAN_ID, traceFlags: 0 }),
+        `00-${TRACE_ID}-${SPAN_ID}-00`,
+      );
+    });
+
+    it('round-trips through extract', () => {
+      const original = {
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        traceFlags: FLAG_SAMPLED,
+      };
+      const parsed = extract({ traceparent: inject(original) });
+      asserts.assertEquals(parsed?.traceId, original.traceId);
+      asserts.assertEquals(parsed?.spanId, original.spanId);
+      asserts.assertEquals(parsed?.traceFlags, original.traceFlags);
+    });
+  });
+});

--- a/packages/tracer/propagation.ts
+++ b/packages/tracer/propagation.ts
@@ -91,7 +91,7 @@ export function extract(headers: HeadersLike): SpanContext | undefined {
   return {
     traceId,
     spanId,
-    traceFlags: parseInt(flags, 16),
+    traceFlags: Number.parseInt(flags, 16),
     remote: true,
   };
 }

--- a/packages/tracer/propagation.ts
+++ b/packages/tracer/propagation.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview W3C Trace Context propagation — turning a `traceparent` header
+ * into a {@link SpanContext} and back. This is what makes a trace span process
+ * boundaries.
+ *
+ * Header format (version `00`):
+ * `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+ * `version-traceId-spanId-traceFlags`
+ *
+ * @author TundraSoft
+ *
+ * @module
+ *
+ * @example
+ * ```typescript
+ * import { extract, inject } from '@tundralibs/tracer';
+ *
+ * const parent = extract(request.headers);          // inbound: join the trace
+ * headers.set('traceparent', inject(span.context)); // outbound: continue it
+ * ```
+ */
+
+import type { HeadersLike, SpanContext } from './types/mod.ts';
+
+/** The W3C header carrying trace identity. */
+export const TRACEPARENT_HEADER = 'traceparent';
+
+/** Trace-flags bit 0 — the span was sampled. */
+export const FLAG_SAMPLED = 0x01;
+
+/** Version `00` traceparent: `00-<32hex>-<16hex>-<2hex>`. */
+const TRACEPARENT_PATTERN =
+  /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+/**
+ * Read a header case-insensitively from either a `Headers`-like object or a
+ * plain record.
+ */
+const readHeader = (
+  headers: HeadersLike,
+  name: string,
+): string | undefined => {
+  const getter = (headers as { get?: unknown }).get;
+  if (typeof getter === 'function') {
+    const value = (headers as { get(n: string): string | null | undefined })
+      .get(name);
+    return value ?? undefined;
+  }
+  const record = headers as Record<string, string | string[] | undefined>;
+  // Node lowercases inbound headers; scan case-insensitively for everything else.
+  let value = record[name] ?? record[name.toLowerCase()];
+  if (value === undefined) {
+    const match = Object.keys(record).find(
+      (key) => key.toLowerCase() === name.toLowerCase(),
+    );
+    if (match !== undefined) value = record[match];
+  }
+  return Array.isArray(value) ? value[0] : value;
+};
+
+/**
+ * Parse an inbound `traceparent` into a {@link SpanContext}.
+ *
+ * Never throws: a missing, malformed, or forbidden header yields `undefined`,
+ * meaning "no parent — start a new trace". A broken upstream header must not be
+ * able to break this service.
+ *
+ * @param headers - Inbound headers. See {@link HeadersLike}.
+ * @returns The parent {@link SpanContext} (with `remote: true`), or `undefined`.
+ */
+export function extract(headers: HeadersLike): SpanContext | undefined {
+  const header = readHeader(headers, TRACEPARENT_HEADER);
+  if (header === undefined) return undefined;
+
+  const parts = TRACEPARENT_PATTERN.exec(header.trim());
+  if (parts === null) return undefined;
+
+  const [, version, traceId, spanId, flags] = parts as unknown as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  // `ff` is reserved as invalid by the spec. Future versions stay parseable
+  // because the pattern reads the first four fields positionally.
+  if (version === 'ff') return undefined;
+  // All-zero ids are invalid per spec.
+  if (/^0+$/.test(traceId) || /^0+$/.test(spanId)) return undefined;
+
+  return {
+    traceId,
+    spanId,
+    traceFlags: parseInt(flags, 16),
+    remote: true,
+  };
+}
+
+/**
+ * Format a {@link SpanContext} as a `traceparent` header value, for attaching
+ * to an outbound request so the callee joins this trace.
+ *
+ * @param context - The context to serialise — normally `span.context`.
+ * @returns A version-`00` traceparent header value.
+ */
+export function inject(context: SpanContext): string {
+  const flags = (context.traceFlags & 0xff).toString(16).padStart(2, '0');
+  return `00-${context.traceId}-${context.spanId}-${flags}`;
+}

--- a/packages/tracer/samplers.test.ts
+++ b/packages/tracer/samplers.test.ts
@@ -1,0 +1,55 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import {
+  alwaysOffSampler,
+  alwaysOnSampler,
+  ratioSampler,
+  SpanKind,
+} from './mod.ts';
+import type { SamplingInput } from './mod.ts';
+
+const input = (traceId: string): SamplingInput => ({
+  traceId,
+  name: 'op',
+  kind: SpanKind.INTERNAL,
+  attributes: {},
+});
+
+const LOW = 'a'.repeat(24) + '00000000'; // low end of the id window
+const HIGH = 'a'.repeat(24) + 'ffffffff'; // high end
+
+describe('tracer.samplers', () => {
+  it('alwaysOn records everything, alwaysOff records nothing', () => {
+    asserts.assertEquals(alwaysOnSampler(input(LOW)), true);
+    asserts.assertEquals(alwaysOffSampler(input(LOW)), false);
+  });
+
+  it('ratioSampler(0) and below collapse to alwaysOff', () => {
+    asserts.assertEquals(ratioSampler(0), alwaysOffSampler);
+    asserts.assertEquals(ratioSampler(-1), alwaysOffSampler);
+  });
+
+  it('ratioSampler(1) and above collapse to alwaysOn', () => {
+    asserts.assertEquals(ratioSampler(1), alwaysOnSampler);
+    asserts.assertEquals(ratioSampler(2), alwaysOnSampler);
+  });
+
+  it('ratioSampler(NaN) collapses to alwaysOff', () => {
+    asserts.assertEquals(ratioSampler(NaN), alwaysOffSampler);
+  });
+
+  it('ratioSampler splits the id window at the ratio', () => {
+    const half = ratioSampler(0.5);
+    asserts.assertEquals(half(input(LOW)), true);
+    asserts.assertEquals(half(input(HIGH)), false);
+  });
+
+  it('ratioSampler is deterministic for a given trace id', () => {
+    const sampler = ratioSampler(0.5);
+    const traceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+    const first = sampler(input(traceId));
+    for (let i = 0; i < 20; i++) {
+      asserts.assertEquals(sampler(input(traceId)), first);
+    }
+  });
+});

--- a/packages/tracer/samplers.ts
+++ b/packages/tracer/samplers.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Built-in {@link Sampler}s.
+ *
+ * Sampling here is **head-based**: the decision is made once, when the span is
+ * created, before anything about its outcome is known. A sampler is only ever
+ * consulted for **root** spans — child spans inherit the parent's decision, so
+ * a trace is always sampled whole or not at all (a partially-sampled trace
+ * renders as a waterfall with holes in it).
+ *
+ * @author TundraSoft
+ *
+ * @module
+ *
+ * @example
+ * ```typescript
+ * import { ratioSampler, Tracer } from '@tundralibs/tracer';
+ *
+ * new Tracer({ serviceName: 'orders', sampler: ratioSampler(0.1) }); // 10%
+ * ```
+ */
+
+import type { Sampler } from './types/mod.ts';
+
+/** Record every span. The default. */
+export const alwaysOnSampler: Sampler = () => true;
+
+/** Record nothing — spans still propagate ids, but are never exported. */
+export const alwaysOffSampler: Sampler = () => false;
+
+/** Number of distinct values in the 32-bit window read from the trace id. */
+const ID_WINDOW = 0x1_0000_0000;
+
+/**
+ * Sample a deterministic fraction of traces.
+ *
+ * The decision derives from the trace id itself — never from a random draw —
+ * so every service in a distributed system that uses the same ratio reaches the
+ * *same* verdict for a given trace. That is what keeps a sampled trace complete
+ * end-to-end instead of fragmenting across service boundaries.
+ *
+ * @param ratio - Fraction to sample, `0` to `1`. Values at or below `0` select
+ *   {@link alwaysOffSampler}; at or above `1`, {@link alwaysOnSampler}.
+ * @returns A deterministic {@link Sampler}.
+ */
+export function ratioSampler(ratio: number): Sampler {
+  if (!(ratio > 0)) return alwaysOffSampler; // also catches NaN
+  if (ratio >= 1) return alwaysOnSampler;
+  const threshold = Math.floor(ratio * ID_WINDOW);
+  return ({ traceId }) => parseInt(traceId.slice(-8), 16) < threshold;
+}

--- a/packages/tracer/samplers.ts
+++ b/packages/tracer/samplers.ts
@@ -28,7 +28,7 @@ export const alwaysOnSampler: Sampler = () => true;
 export const alwaysOffSampler: Sampler = () => false;
 
 /** Number of distinct values in the 32-bit window read from the trace id. */
-const ID_WINDOW = 0x1_0000_0000;
+const ID_WINDOW = 2 ** 32;
 
 /**
  * Sample a deterministic fraction of traces.
@@ -43,8 +43,10 @@ const ID_WINDOW = 0x1_0000_0000;
  * @returns A deterministic {@link Sampler}.
  */
 export function ratioSampler(ratio: number): Sampler {
-  if (!(ratio > 0)) return alwaysOffSampler; // also catches NaN
+  // NaN is checked explicitly: `NaN <= 0` is false, so a comparison alone would
+  // let it through and produce a sampler that never fires predictably.
+  if (Number.isNaN(ratio) || ratio <= 0) return alwaysOffSampler;
   if (ratio >= 1) return alwaysOnSampler;
   const threshold = Math.floor(ratio * ID_WINDOW);
-  return ({ traceId }) => parseInt(traceId.slice(-8), 16) < threshold;
+  return ({ traceId }) => Number.parseInt(traceId.slice(-8), 16) < threshold;
 }

--- a/packages/tracer/types/AttributeValue.ts
+++ b/packages/tracer/types/AttributeValue.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview {@link AttributeValue} — the value types OTLP permits on a
+ * span attribute.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+/**
+ * A single attribute value. OTLP permits primitives and homogeneous arrays of
+ * primitives only — no nested objects, no mixed arrays. Values outside this
+ * union are dropped at encode time rather than silently mangled.
+ */
+export type AttributeValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | number[]
+  | boolean[];

--- a/packages/tracer/types/Attributes.ts
+++ b/packages/tracer/types/Attributes.ts
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview {@link Attributes} — a bag of key/value pairs on a span,
+ * event, or resource.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { AttributeValue } from './AttributeValue.ts';
+
+/**
+ * Key/value pairs attached to a span, span event, or resource. Keys should
+ * follow OpenTelemetry semantic conventions where one applies (`http.method`,
+ * `db.system`, …) so backends can interpret them.
+ */
+export type Attributes = Record<string, AttributeValue>;

--- a/packages/tracer/types/HeadersLike.ts
+++ b/packages/tracer/types/HeadersLike.ts
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview {@link HeadersLike} — the minimal header surface propagation
+ * accepts, so it works with any framework's request representation.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+/**
+ * Anything headers can be read from. Deliberately structural so propagation
+ * never depends on a framework: a Web-standard `Headers`, Node's
+ * `IncomingHttpHeaders`, a plain object, or an RPC envelope's metadata all
+ * satisfy it.
+ */
+export type HeadersLike =
+  | { get(name: string): string | null | undefined }
+  | Record<string, string | string[] | undefined>;

--- a/packages/tracer/types/IdGenerator.ts
+++ b/packages/tracer/types/IdGenerator.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview {@link IdGenerator} — pluggable trace/span id generation.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+/**
+ * Generates W3C-conformant trace and span ids. The default implementation
+ * (`randomIdGenerator`) uses `crypto.getRandomValues`; override it when a
+ * backend requires a different format — AWS X-Ray, for instance, needs a
+ * timestamp-prefixed trace id and rejects pure-random ones — or to make ids
+ * deterministic in tests.
+ *
+ * A custom generator is smoke-tested once at {@link Tracer} construction: its
+ * output must match the widths and character set below, or construction throws.
+ * Ids that look wrong are otherwise silently dropped by collectors, which is a
+ * miserable failure to debug.
+ */
+export type IdGenerator = {
+  /**
+   * A new trace id: 32 lowercase hex characters, never all-zero.
+   */
+  traceId(): string;
+
+  /**
+   * A new span id: 16 lowercase hex characters, never all-zero.
+   */
+  spanId(): string;
+};

--- a/packages/tracer/types/Sampler.ts
+++ b/packages/tracer/types/Sampler.ts
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview {@link Sampler} — the head-based decision of whether to record
+ * a span.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { SamplingInput } from './SamplingInput.ts';
+
+/**
+ * Decides whether a span is recorded and exported. Called once per span, at
+ * creation ("head-based" sampling).
+ *
+ * A sampler must be **deterministic for a given trace id** — otherwise one
+ * trace ends up partially sampled, producing broken waterfalls with missing
+ * middles. The built-in `ratioSampler` satisfies this by deriving its decision
+ * from the trace id itself rather than from a random draw per span.
+ *
+ * @param input - See {@link SamplingInput}.
+ * @returns `true` to record and export the span, `false` to drop it.
+ */
+export type Sampler = (input: SamplingInput) => boolean;

--- a/packages/tracer/types/SamplingInput.ts
+++ b/packages/tracer/types/SamplingInput.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview {@link SamplingInput} — everything a {@link Sampler} sees when
+ * deciding whether to record a span.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { Attributes } from './Attributes.ts';
+import type { SpanContext } from './SpanContext.ts';
+import type { SpanKind } from './SpanKind.ts';
+
+/**
+ * The information available to a sampler at span-creation time. Note there is
+ * no duration or status — sampling here is **head-based** (decided up front),
+ * so nothing about the span's outcome is knowable yet.
+ */
+export type SamplingInput = {
+  /** The trace this span would belong to. */
+  traceId: string;
+  /** The span's operation name. */
+  name: string;
+  /** The span's role. */
+  kind: SpanKind;
+  /** Attributes supplied at creation. */
+  attributes: Attributes;
+  /** The resolved parent context, when this span is not a trace root. */
+  parent?: SpanContext;
+};

--- a/packages/tracer/types/SpanContext.ts
+++ b/packages/tracer/types/SpanContext.ts
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview The {@link SpanContext} — the immutable, propagated identity
+ * of a span. This is the part that crosses process boundaries via the W3C
+ * `traceparent` header.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+/**
+ * The immutable identity of a span: which trace it belongs to, its own id, and
+ * the sampling decision. Everything here is serialisable — it is exactly what a
+ * W3C `traceparent` header carries.
+ */
+export type SpanContext = {
+  /** Trace identifier — 32 lowercase hex characters, never all-zero. */
+  traceId: string;
+  /** Span identifier — 16 lowercase hex characters, never all-zero. */
+  spanId: string;
+  /**
+   * W3C trace flags bitfield. Bit 0 (`0x01`) is the sampled flag; when unset,
+   * the span is not recorded or exported.
+   */
+  traceFlags: number;
+  /**
+   * `true` when this context was extracted from an inbound `traceparent`
+   * (i.e. it identifies a span in another process), `false`/absent when it was
+   * created locally.
+   */
+  remote?: boolean;
+};

--- a/packages/tracer/types/SpanData.ts
+++ b/packages/tracer/types/SpanData.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview {@link SpanData} — the immutable snapshot of a finished span
+ * handed to exporters.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { Attributes } from './Attributes.ts';
+import type { SpanContext } from './SpanContext.ts';
+import type { SpanEvent } from './SpanEvent.ts';
+import type { SpanKind } from './SpanKind.ts';
+import type { SpanStatus } from './SpanStatus.ts';
+
+/**
+ * A finished span, flattened into plain data for export. Exporters receive
+ * these rather than live `Span` instances, so a slow or async exporter can
+ * never observe (or mutate) a span that is still being written to.
+ */
+export type SpanData = {
+  /** Operation name, e.g. `GET /orders/:id`. */
+  name: string;
+  /** This span's propagated identity. */
+  context: SpanContext;
+  /** Parent span id within the same trace; absent when this is the root. */
+  parentSpanId?: string;
+  /** The span's role — see {@link SpanKind}. */
+  kind: SpanKind;
+  /** When the span started. */
+  startTime: Date;
+  /** When the span ended. */
+  endTime: Date;
+  /** Attributes accumulated over the span's lifetime. */
+  attributes: Attributes;
+  /** Timestamped events recorded on the span, in insertion order. */
+  events: SpanEvent[];
+  /** The span's outcome. */
+  status: SpanStatus;
+  /** `service.name` and any other resource-level attributes. */
+  resource: Attributes;
+};

--- a/packages/tracer/types/SpanEvent.ts
+++ b/packages/tracer/types/SpanEvent.ts
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview {@link SpanEvent} — a timestamped annotation on a span.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { Attributes } from './Attributes.ts';
+
+/**
+ * A timestamped point-in-time annotation within a span — "this happened at
+ * this moment", as opposed to a child span's "this took this long".
+ */
+export type SpanEvent = {
+  /** Event name, e.g. `exception` or `cache.miss`. */
+  name: string;
+  /** When the event occurred. */
+  time: Date;
+  /** Structured detail for the event. */
+  attributes: Attributes;
+};

--- a/packages/tracer/types/SpanExporter.ts
+++ b/packages/tracer/types/SpanExporter.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview {@link SpanExporter} — the pluggable destination for finished
+ * spans.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { SpanData } from './SpanData.ts';
+
+/**
+ * Receives finished spans and sends them somewhere — the console, an in-memory
+ * buffer (tests), or an OTLP collector.
+ *
+ * Implementations must never throw into the caller: a failed export is an
+ * observability problem, not an application problem, so errors are swallowed
+ * or reported out-of-band by the tracer.
+ */
+export type SpanExporter = {
+  /**
+   * Export a batch of finished spans.
+   *
+   * @param spans - The spans to export. Never empty.
+   */
+  export(spans: SpanData[]): Promise<void>;
+
+  /**
+   * Flush anything buffered and release resources. Called by
+   * `Tracer.shutdown()`.
+   */
+  shutdown?(): Promise<void>;
+};

--- a/packages/tracer/types/SpanKind.ts
+++ b/packages/tracer/types/SpanKind.ts
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview {@link SpanKind} — the span's role in a trace. Values match the
+ * OTLP `SpanKind` enum exactly, so they serialise without a lookup table.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+/**
+ * The span's role in a trace. The numeric values are OTLP-defined and are
+ * emitted verbatim by the OTLP exporter — do not renumber.
+ */
+export enum SpanKind {
+  /** Internal work with no remote counterpart. The default. */
+  INTERNAL = 1,
+  /** Handling an inbound request — the server side of a remote call. */
+  SERVER = 2,
+  /** Making an outbound request — the client side of a remote call. */
+  CLIENT = 3,
+  /** Producing a message for asynchronous consumption. */
+  PRODUCER = 4,
+  /** Consuming an asynchronously produced message. */
+  CONSUMER = 5,
+}

--- a/packages/tracer/types/SpanOptions.ts
+++ b/packages/tracer/types/SpanOptions.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview {@link SpanOptions} — per-span creation options.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { Attributes } from './Attributes.ts';
+import type { SpanContext } from './SpanContext.ts';
+import type { SpanKind } from './SpanKind.ts';
+
+/** Options accepted when starting a span. */
+export type SpanOptions = {
+  /** The span's role. Defaults to {@link SpanKind.INTERNAL}. */
+  kind?: SpanKind;
+  /**
+   * Explicit parent context — typically one {@link SpanContext} extracted from
+   * an inbound `traceparent`. When omitted the parent is the currently active
+   * span (via `ambient`); when there is none, the span starts a new trace.
+   *
+   * Pass `null` to force a new root trace even inside an active span.
+   */
+  parent?: SpanContext | null;
+  /** Attributes to set at creation — visible to the sampler. */
+  attributes?: Attributes;
+  /** Explicit start time. Defaults to now. */
+  startTime?: Date;
+};

--- a/packages/tracer/types/SpanStatus.ts
+++ b/packages/tracer/types/SpanStatus.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview {@link SpanStatus} — a span's outcome plus an optional
+ * description.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { SpanStatusCode } from './SpanStatusCode.ts';
+
+/** A span's outcome — see {@link SpanStatusCode}. */
+export type SpanStatus = {
+  /** The outcome code. */
+  code: SpanStatusCode;
+  /**
+   * Human-readable description. Per the OTLP spec this is only meaningful
+   * when `code` is `ERROR`, and is ignored otherwise.
+   */
+  message?: string;
+};

--- a/packages/tracer/types/SpanStatusCode.ts
+++ b/packages/tracer/types/SpanStatusCode.ts
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview {@link SpanStatusCode} — a span's outcome. Values match the
+ * OTLP `Status.StatusCode` enum.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+/**
+ * A span's outcome. Numeric values are OTLP-defined and emitted verbatim.
+ *
+ * `UNSET` is the default and means "no explicit judgement" — it is *not* a
+ * failure. Only set `ERROR` for genuine failures, so backends can compute
+ * meaningful error rates.
+ */
+export enum SpanStatusCode {
+  /** No explicit status — the default. */
+  UNSET = 0,
+  /** Explicitly successful. Rarely needed; `UNSET` already implies no error. */
+  OK = 1,
+  /** The operation failed. */
+  ERROR = 2,
+}

--- a/packages/tracer/types/TracerOptions.ts
+++ b/packages/tracer/types/TracerOptions.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview {@link TracerOptions} — configuration for a {@link Tracer}.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ */
+
+import type { Attributes } from './Attributes.ts';
+import type { IdGenerator } from './IdGenerator.ts';
+import type { Sampler } from './Sampler.ts';
+import type { SpanExporter } from './SpanExporter.ts';
+
+/** Configuration for a {@link Tracer}. */
+export type TracerOptions = {
+  /**
+   * Logical name of this service — becomes the `service.name` resource
+   * attribute, which is how backends group and name your traces. Required.
+   */
+  serviceName: string;
+  /**
+   * Where finished spans go. Defaults to a no-op: a tracer with no exporter
+   * still creates and propagates spans (so correlation ids keep working) but
+   * emits nothing.
+   */
+  exporter?: SpanExporter;
+  /**
+   * Whether to record each span. Defaults to `alwaysOnSampler`.
+   * See {@link Sampler} for the determinism requirement.
+   */
+  sampler?: Sampler;
+  /**
+   * Trace/span id generation. Defaults to `randomIdGenerator`. Validated once
+   * at construction — see {@link IdGenerator}.
+   */
+  idGenerator?: IdGenerator;
+  /**
+   * Extra resource attributes merged with `service.name` — e.g.
+   * `deployment.environment`, `service.version`.
+   */
+  resource?: Attributes;
+};

--- a/packages/tracer/types/mod.ts
+++ b/packages/tracer/types/mod.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Re-exports the public type surface of `@tundralibs/tracer`.
+ *
+ * @module
+ */
+
+// Enums are values as well as types, so they are exported as values.
+export { SpanKind } from './SpanKind.ts';
+export { SpanStatusCode } from './SpanStatusCode.ts';
+
+export type { AttributeValue } from './AttributeValue.ts';
+export type { Attributes } from './Attributes.ts';
+export type { HeadersLike } from './HeadersLike.ts';
+export type { IdGenerator } from './IdGenerator.ts';
+export type { Sampler } from './Sampler.ts';
+export type { SamplingInput } from './SamplingInput.ts';
+export type { SpanContext } from './SpanContext.ts';
+export type { SpanData } from './SpanData.ts';
+export type { SpanEvent } from './SpanEvent.ts';
+export type { SpanExporter } from './SpanExporter.ts';
+export type { SpanOptions } from './SpanOptions.ts';
+export type { SpanStatus } from './SpanStatus.ts';
+export type { TracerOptions } from './TracerOptions.ts';

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -216,6 +216,17 @@
         }
       ]
     },
+    "packages/tracer": {
+      "release-type": "node",
+      "component": "tracer",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
     "packages/utils": {
       "release-type": "node",
       "component": "utils",


### PR DESCRIPTION
## What

Adds **`@tundralibs/tracer`** — the span kernel: spans, W3C Trace Context propagation, head-based sampling, and pluggable exporters. It completes the observability triad with `slogger` (logs) and `metro-man` (metrics), and is the first real consumer of [`ambient`](https://github.com/TundraSoft/TundraLibs/pull/107).

Spans nest **automatically** — the active span lives in a dedicated `ambient` async context, so a span opened at any call depth (across any `await`) parents itself without being threaded through signatures.

```typescript
await tracer.startActiveSpan('checkout', async (span) => {
  span.setAttribute('order.id', 'ord_42');
  await chargeCard();   // spans in here auto-parent — no threading, no ctx
});
```

This is **stage 1 of 3**. Next: the OTLP exporter (its own subpath), then framework glue once `rAPId` exists. See `packages/tracer/ROADMAP.md`.

## Contents

| Area | |
|---|---|
| `Tracer` | `startSpan` / `startActiveSpan` / `active` / `shutdown`, on `utils/Options` with `_processOption` validation |
| `Span` | attributes, events, status, `recordException`; inert once ended or if sampling dropped it |
| `propagation` | W3C `traceparent` `extract`/`inject` — framework-agnostic (`Headers`, plain records, rpc metadata) |
| `samplers` | `alwaysOn` / `alwaysOff` / `ratio` |
| `ids` | `crypto.getRandomValues` → hex, pluggable `IdGenerator` |
| `exporters` | `Console` + `Memory` |
| docs | `README.md`, `RECIPES.md` (Express/Koa/Oak/Fetch adapters), `ROADMAP.md` |

## Design decisions (rationale in `ROADMAP.md`)

- **Nothing on a span throws.** Tracing must never break the code it observes — export failures are swallowed, post-`end()` writes ignored, a malformed inbound `traceparent` just means "start a new trace". **Config errors throw loudly** at construction instead.
- **`idGenerator` is smoke-tested once** at construction: collectors *silently drop* malformed ids, so traces would simply never appear. One-time check, off the hot path.
- **Sampling is parent-inherited** — children never re-sample, so a trace is sampled whole (a partially-sampled trace renders with holes). `ratioSampler` derives its verdict from the trace id so independent services agree.
- **No framework middleware in-tree.** RadRouter and RPC are both *generic* over their middleware type and never read `ctx`, so there's no canonical context to target — and a generic adapter can't *write* to a ctx it doesn't know (`ctx.span = span`). RECIPES documents ~10-line adapters that keep full type knowledge.
- **Core deps: `ambient` + `utils` only.** No `compat/async` (see ROADMAP for why); OTLP's HTTP client will stay behind its own subpath.

## Verification

| Gate | Result |
|---|---|
| Coverage | ✅ **100%** branch/function/line, every file |
| `deno test` | ✅ 6 suites, 84 steps |
| `bun test` | ✅ 73 pass |
| `node --test` | ✅ 73 pass |
| type-check · lint · fmt · JSR dry-run · drift | ✅ |

Single package (`packages/tracer/`) + regenerated config → `Single-package guard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)