### PR TITLE
fix(norm): remove polynomial-ReDoS backtracking from Migrator dir trim

### DIFF
--- a/packages/norm/migrations/Migrator.ts
+++ b/packages/norm/migrations/Migrator.ts
@@ -192,7 +192,13 @@ export class Migrator {
   /** @param db The handle returned by `norm.use(...)`. */
   constructor(db: object, options: MigratorOptions) {
     this.#runtime = runtimeOf(db);
-    this.#dir = options.dir.replace(/\/+$/, '');
+    // Trailing slashes are trimmed by scanning back from the end rather than
+    // with `/\/+$/`: that pattern re-tries from every position and re-scans the
+    // run each time, so a path of many slashes costs O(n^2). This is O(n) with
+    // a single allocation.
+    let dirEnd = options.dir.length;
+    while (dirEnd > 0 && options.dir[dirEnd - 1] === '/') dirEnd--;
+    this.#dir = options.dir.slice(0, dirEnd);
     // A non-positive chunk is nonsense for the rebuild pager: `limit: 0`
     // means UNBOUNDED downstream and `offset += 0` never advances, so the
     // copy loop would re-read the same page forever. Floor at one row.

--- a/packages/norm/migrations/migrations.test.ts
+++ b/packages/norm/migrations/migrations.test.ts
@@ -339,7 +339,10 @@ describe('norm.migrations (real SQLite end to end)', () => {
   it('v2: renamedFrom renames the column (data survives), add column + reindex', async () => {
     const norm = new Norm({ engine: engine as never, secret: SECRET });
     const db = norm.use(Schema('App', { Users: UsersV2 }));
-    const mig = new Migrator(db, { dir: migDir });
+    // Trailing slashes on `dir` are normalised away — this version continues
+    // the same migration chain as v1 above (which passed the bare `migDir`),
+    // so it only reaches version 2 if the two spellings resolve identically.
+    const mig = new Migrator(db, { dir: `${migDir}///` });
 
     asserts.assertEquals((await mig.snapshot()).version, 2);
     const [step] = await mig.plan();


### PR DESCRIPTION
## What

Clears the `js/polynomial-redos` code-scanning alert (**high**, pre-existing on `main` since 2026-08-01) at [Migrator.ts:195](packages/norm/migrations/Migrator.ts#L195). Third of four alerts of this class — `utils` is [#116](https://github.com/TundraSoft/TundraLibs/pull/116), `crypt` follows.

## The problem

```ts
this.#dir = options.dir.replace(/\/+$/, '');
```

`/\/+$/` retries from every start position, and at each one `\/+` greedily consumes the slash run before discovering `$` doesn't hold — so a path of many slashes costs **O(n²)**.

## The fix

A backward index scan — O(n), a single allocation, no regex engine:

```ts
let dirEnd = options.dir.length;
while (dirEnd > 0 && options.dir[dirEnd - 1] === '/') dirEnd--;
this.#dir = options.dir.slice(0, dirEnd);
```

## Verification

**Equivalent** to the old expression across `'/a/b/'`, `'/a/b///'`, `''`, `'/'`, `'////'`, `'a'`, `'a/'`, `'./x//'`, `'/////a/////'`.

**Timing** on 40k slashes: `703.8ms` → `0.0ms`.

Type-check, lint and fmt pass. (The norm suite needs live DB containers, so it runs in CI rather than locally — this change is confined to the constructor's path normalisation and is covered by the equivalence check above.)

Single package (`packages/norm/`) → `Single-package guard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)