### PR TITLE
ci: add an OTLP collector service for tracer conformance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       # both suites call the global memcached flush() (no logical DBs to isolate).
       MEMCACHED_PORT: '11211'
       MEMCACHED_PORT2: '11212'
+      # Tracer's OTLP conformance test probes this and SKIPS when unreachable,
+      # so a contributor without a local collector still gets a green suite.
+      OTLP_ENDPOINT: http://localhost:4318
       # Coverage/analysis upload credentials. Job-level so the token-presence
       # guards (`env.*_TOKEN != ''`) on the upload steps can read them — the
       # steps self-disable until the secrets are configured, and on fork PRs
@@ -178,6 +181,22 @@ jobs:
         image: memcached:1
         ports:
           - 11212:11211
+      # OTLP collector for tracer's conformance test. The point is to assert a
+      # REAL collector accepts our payload, rather than only that it matches
+      # our own fixtures — a self-agreeing encoder can still be wrong.
+      #
+      # No config file is mounted: the stock image ships a default config with
+      # OTLP receivers on 4317 (gRPC) and 4318 (HTTP), and only HTTP is used.
+      # That matters because service containers start BEFORE checkout, so a
+      # repo config file would not exist yet.
+      #
+      # Version-pinned to what the payload was verified against. Note the
+      # collector is deliberately lenient about int64-as-number, so it does NOT
+      # catch a numeric `*TimeUnixNano`; that stays a unit-test assertion.
+      otel-collector:
+        image: otel/opentelemetry-collector:0.158.0
+        ports:
+          - 4318:4318
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Adds `otel/opentelemetry-collector` to the CI test job, so tracer's OTLP encoder can be verified against a **real collector** rather than only against our own fixtures. A self-agreeing encoder can still be wrong — and when a collector rejects a payload, it's silent from the application's point of view, which is the exact failure mode worth guarding.

**Workflow only** — no package code. The test that uses it lands in [#123](https://github.com/TundraSoft/TundraLibs/pull/123).

## Why this ships first

This repo's CI runs on **push to any branch**, so the workflow file in effect is the one on the PR's *own* branch. The service has to be on `main` first and merged down into `feat/tracer-otlp`, or the conformance test would just skip and prove nothing.

## Verified locally before writing it

I ran the stock image and probed it with our encoder's actual output:

| payload | collector |
|---|---|
| **our encoder** | ✅ **200** `{"partialSuccess":{}}` |
| base64 ids (not hex) | ✅ rejected **400** |
| bare attribute values (no `AnyValue` wrapper) | ✅ rejected **400** |
| numeric `*TimeUnixNano` (not a string) | ⚠️ **accepted 200** |

Two conclusions, both baked into the comments:

1. **Our payload is accepted by a real collector** — now verified rather than assumed.
2. **The collector is lenient about int64-as-number**, so it does *not* catch a numeric timestamp. That assertion has to stay a unit test. The collector check **complements** the fixtures; it doesn't replace them.

## Details worth knowing

- **No config file is mounted.** The stock image ships a default config with OTLP receivers on 4317 (gRPC) and 4318 (HTTP); only HTTP is used. This is load-bearing — service containers start *before* checkout, so a repo config file wouldn't exist yet.
- **Version-pinned** to the release the payload was verified against, matching how the other service images are pinned.
- **`OTLP_ENDPOINT`** is read by the test, which probes and **skips** when unreachable — so a contributor without a local collector still gets a green suite, the same pattern `drivers` uses for live databases.

Touches no `packages/` files → `Single-package guard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)