### PR TITLE
chore(tracer): clear SonarCloud findings in BatchSpanProcessor

### DIFF
--- a/packages/tracer/BatchSpanProcessor.ts
+++ b/packages/tracer/BatchSpanProcessor.ts
@@ -77,7 +77,7 @@ export class BatchSpanProcessor implements SpanExporter {
   private readonly __delayMs: number;
   private readonly __onDrop?: (dropped: number) => void;
 
-  private __queue: SpanData[] = [];
+  private readonly __queue: SpanData[] = [];
   private __timer: ReturnType<typeof setTimeout> | undefined;
   /** In-flight flushes, awaited by {@link BatchSpanProcessor.shutdown}. */
   private readonly __inFlight: Set<Promise<void>> = new Set();
@@ -178,10 +178,16 @@ export class BatchSpanProcessor implements SpanExporter {
     if (this.__queue.length === 0) this.__clearTimer();
 
     let promise: Promise<void>;
-    try {
+    // Same shape as Tracer.__export, same reasoning: `.catch()` absorbs a
+    // REJECTED export, while the try absorbs a SYNCHRONOUS throw from a
+    // misbehaving exporter — which happens before a promise exists and so can
+    // never reach `.catch()`. BatchSpanProcessor.test.ts covers that path
+    // ("survives an exporter that throws synchronously"). S4822 reads the
+    // `.catch()` and concludes the try is redundant; it is not.
+    try { //NOSONAR - guards a sync throw, which .catch() cannot see
       promise = this.__exporter.export(batch).catch(() => {});
     } catch {
-      return; // synchronous throw from a misbehaving exporter
+      return;
     }
     this.__inFlight.add(promise);
     void promise.finally(() => this.__inFlight.delete(promise));


### PR DESCRIPTION
Post-merge cleanup of the two new-code findings from #123: `__queue` marked `readonly` (S2933 — only ever push/spliced), and the `__flush` try/catch gets the same justified `//NOSONAR` as `Tracer.__export` (S4822 — the try guards a synchronous throw, which `.catch()` cannot see; covered by an existing test). Ships before the tracer release so 0.3.0 goes out clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)