### PR TITLE
docs(ambient): add how-it-works guides and refresh the roadmap

### DIFF
--- a/packages/ambient/README.md
+++ b/packages/ambient/README.md
@@ -147,6 +147,14 @@ Ambient is **in-process only**. Propagating context across a network boundary
 request is the web/rpc middleware's job. Ambient just owns "the context that
 survives `await`."
 
+## Documentation
+
+- [Concepts](docs/Ambient-Concepts.md) - AsyncLocalStorage, scopes, the mutable
+  bag, and your own stores via `createContext`
+- [Integration](docs/Ambient-Integration.md) - Wiring slogger, tracer, and
+  request boundaries without coupling them
+- [Roadmap](ROADMAP.md) - Decisions and deferred items
+
 ## License
 
 MIT

--- a/packages/ambient/ROADMAP.md
+++ b/packages/ambient/ROADMAP.md
@@ -1,35 +1,47 @@
 # Ambient — Roadmap
 
-What's intentionally not built yet. `ambient` ships deliberately small — a typed
-`AsyncLocalStorage` wrapper plus the shared `RequestContext` — so most items here
-are integrations and extractions that earn their place only once a second
-consumer exists.
+What's intentionally not built. `ambient` ships deliberately small — a typed
+`AsyncLocalStorage` wrapper plus the shared `RequestContext` — and its two
+planned integrations have both since shipped, so this file is now mostly
+records and triggers.
 
-## slogger auto-correlation (next)
+## Shipped integrations
 
-Correlating logs works today, one line at the call site:
-`log.info(msg, () => ({ ...ambient.get() }))`. The ergonomic finish is a
-slogger-side enricher — a dynamic `scope(thunk)` variant, or a handler that folds
-`ambient.get()` into every record — so no per-call thunk is needed. That change
-lives in `slogger`, not here, and is tracked as its own PR.
+- **slogger auto-correlation** — landed as slogger 1.1.0's `contextProvider`
+  (a generic logger-level thunk, wired at the composition root:
+  `contextProvider: () => ambient.get() ?? {}`). slogger takes no ambient
+  dependency; see
+  [Ambient-Integration](docs/Ambient-Integration.md#slogger-automatic-log-correlation).
+- **tracer** — depends on ambient for `createContext`, keeping its active span
+  in its **own** store rather than the shared request bag; see
+  [Ambient-Integration](docs/Ambient-Integration.md#tracer-who-owns-what).
 
-## `compat/async` extraction (on second consumer)
+## `compat/async` extraction — decided against
 
-The `AsyncLocalStorage` primitive currently lives in
-[createContext.ts](createContext.ts), imported straight from `node:async_hooks`.
-When a second package needs raw ALS (`tracer` is the likely trigger), lift the
-primitive into a `@tundralibs/compat/async` subpath and have ambient source it
-from there. Deferred until that consumer exists — building it now would add a
-compat dependency to serve exactly one caller. `compat/async` would also be the
-natural seam to adopt the TC39 `AsyncContext` proposal (a platform-native
-replacement for `async_hooks`) once runtimes ship it.
+The original plan deferred extracting the `AsyncLocalStorage` primitive into
+`@tundralibs/compat/async` "until a second raw-ALS consumer exists". `tracer`
+became that second consumer — and the extraction was **still declined**, because
+the facts cut against it:
+
+- direct `node:` imports are already the house norm for **uniform** builtins
+  (`drivers` and `restler` both do it); compat earns its keep only where
+  runtimes _differ_, and ALS does not.
+- depending on compat would hand this zero-dependency leaf a 47-file package
+  that pulls `ws` — backwards layering for no gain.
+- [createContext.ts](createContext.ts) is already the one-file seam a future
+  TC39 `AsyncContext` migration would touch; moving it buys a different
+  one-file seam.
+
+Revisit only if a supported runtime needs an ALS **shim** (a genuine compat
+concern), or a package that cannot depend on ambient needs raw ALS.
 
 ## `id`-backed correlation helper (optional)
 
-A convenience such as `ambient.withCorrelation(fn)` that mints a correlation id
-via `@tundralibs/id` and opens a scope in one call. Deferred to keep ambient
-dependency-free; callers mint their own id today
-(`ambient.run({ correlationId: crypto.randomUUID() }, fn)`).
+A convenience such as `ambient.withCorrelation(fn)` that mints an id via
+`@tundralibs/id` and opens a scope in one call. Still deferred, still optional:
+ambient stays **carry-only** so the id-scheme choice (UUID, ULID, CUID2)
+belongs to the application, and `crypto.randomUUID()` covers the default case
+with zero dependencies.
 
 ## ALS-less runtimes
 
@@ -38,5 +50,4 @@ is enforced by a load-time guard in `createContext` that throws an actionable
 error, and declared via `engines.node >= 22` — never as a package dependency,
 since it is a runtime built-in. Runtimes without `AsyncLocalStorage` are
 unsupported by design; a no-op degraded mode is not planned. The guard's throw
-path is not unit-tested — every supported test runtime provides ALS, so it
-cannot be simulated cleanly.
+path is tested via its injectable `candidate` parameter.

--- a/packages/ambient/docs/Ambient-Concepts.md
+++ b/packages/ambient/docs/Ambient-Concepts.md
@@ -1,0 +1,158 @@
+# Ambient Concepts
+
+How a value survives `await`, and why concurrent requests never see each
+other's context.
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## Table of Contents
+
+- [The problem: prop drilling](#the-problem-prop-drilling)
+- [The mechanism: AsyncLocalStorage](#the-mechanism-asynclocalstorage)
+- [Scopes: run and child](#scopes-run-and-child)
+- [The bag is mutable and live](#the-bag-is-mutable-and-live)
+- [Nothing throws outside a scope](#nothing-throws-outside-a-scope)
+- [Your own stores: createContext](#your-own-stores-createcontext)
+- [Runtime requirements](#runtime-requirements)
+
+## The problem: prop drilling
+
+To tag every log line of a request with its id, the id has to _reach_ every
+function that logs — which classically means threading it through every
+signature in between:
+
+```typescript
+async function handleOrder(reqId: string, order: Order) {
+  await chargeCard(reqId, order); // carried
+}
+async function chargeCard(reqId: string, order: Order) {
+  await fraudCheck(reqId, order); // carried again
+}
+```
+
+Every intermediate function pays for a value it never uses. Ambient inverts
+this: set the context **once** at the boundary, read it **anywhere** below.
+
+```typescript
+ambient.run({ correlationId: crypto.randomUUID() }, () => handleOrder(order));
+
+// five frames deep, after any number of awaits:
+ambient.get()?.correlationId;
+```
+
+## The mechanism: AsyncLocalStorage
+
+A module-level variable cannot do this: two concurrent requests interleave on
+one event loop, so the second `run` would overwrite the first and request A
+would read request B's context.
+
+`AsyncLocalStorage` (from `node:async_hooks`, uniform across Deno, Bun and
+Node) is "a thread-local, but for async": the value set by `run` follows the
+**logical** flow of that call — across `await`, timers, promise chains — and
+each concurrent flow sees only its own value.
+
+```typescript
+await Promise.all([
+  ambient.run({ correlationId: 'A' }, work), // work() sees A
+  ambient.run({ correlationId: 'B' }, work), // work() sees B — same code,
+]); // same moment, no bleed
+```
+
+That isolation property is the entire reason this package exists, and the
+reason `tracer` (span parenting) and `slogger` (log correlation) build on it.
+
+## Scopes: run and child
+
+`run(seed, fn)` establishes a fresh context for the duration of `fn`. The seed
+is **shallow-copied**, so later mutation via `set` never leaks back into the
+caller's object:
+
+```typescript
+const seed = { correlationId: 'c1' };
+ambient.run(seed, () => ambient.set('userId', 'u1'));
+seed.userId; // undefined — the scope worked on a copy
+```
+
+`child(patch, fn)` overlays on the inherited context — the parent scope is
+untouched once `fn` returns:
+
+```typescript
+ambient.run({ correlationId: 'c1', tenant: 't1' }, () => {
+  ambient.child({ tenant: 't2' }, () => {
+    ambient.get()?.tenant; // 't2', correlationId still 'c1'
+  });
+  ambient.get()?.tenant; // 't1' again
+});
+```
+
+Outside any scope, `child` behaves like `run` over the patch alone.
+
+## The bag is mutable and live
+
+`get()` returns the live {@linkcode RequestContext}, not a snapshot, and
+`set()` writes into it. Anything reading later in the same scope — a log line,
+an error handler — observes the enrichment:
+
+```typescript
+ambient.run({ correlationId: 'c1' }, async () => {
+  ambient.set('userId', await authenticate(token));
+  // every later reader in this scope sees userId
+});
+```
+
+This is deliberate: request context _accumulates_ (authentication resolves a
+user, a router resolves a tenant), and consumers like slogger's
+`contextProvider` should see the accumulated state at the moment they read, not
+the state at scope creation.
+
+## Nothing throws outside a scope
+
+Every accessor is total, because context is plumbing — it must never be able to
+break the code it flows through:
+
+| call outside any `run` | result       |
+| ---------------------- | ------------ |
+| `ambient.get()`        | `undefined`  |
+| `ambient.set(k, v)`    | silent no-op |
+| `ambient.active()`     | `false`      |
+| `ctx.getOr(fallback)`  | the fallback |
+
+The one place ambient _does_ throw is {@linkcode createContext} on a runtime
+without `AsyncLocalStorage` — a misconfiguration, surfaced loudly at startup
+rather than as silently-missing context later.
+
+## Your own stores: createContext
+
+`ambient` is one blessed store with one blessed shape. When you need context
+that is not request-shaped — a tenant in a job worker, a transaction handle —
+{@linkcode createContext} gives you an independent, typed store with the same
+semantics:
+
+```typescript
+const tenant = createContext<{ id: string; schema: string }>();
+
+await tenant.run(job.tenant, () => handle(job.payload));
+
+// deep in the data layer:
+tenant.getOr({ id: 'public', schema: 'public' }).schema;
+```
+
+Distinct stores never observe each other — `tracer` keeps its active span in
+its own `createContext` store precisely so span lifecycle stays out of the
+shared request bag.
+
+One subtlety: `getOr` falls back only on `undefined`. A stored `null` is a
+value, and is returned as-is.
+
+## Runtime requirements
+
+`node:async_hooks` is a **runtime built-in** on Deno, Bun and Node ≥ 22 — it is
+not an npm dependency, which is why `dependencies` is empty and the requirement
+lives in `engines.node` instead. The guard in `createContext` turns the exotic
+ALS-less-runtime case into an immediate, actionable error.
+
+A future TC39 `AsyncContext` (a platform-native replacement for
+`async_hooks`) would be adopted inside `createContext.ts` — one file, no API
+change. See [ROADMAP.md](../ROADMAP.md).

--- a/packages/ambient/docs/Ambient-Integration.md
+++ b/packages/ambient/docs/Ambient-Integration.md
@@ -1,0 +1,156 @@
+# Ambient Integration
+
+Wiring ambient into the suite — logging, tracing, and request boundaries —
+without coupling any of them to each other.
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## Table of Contents
+
+- [The composition-root pattern](#the-composition-root-pattern)
+- [Opening the scope: middleware](#opening-the-scope-middleware)
+- [slogger: automatic log correlation](#slogger-automatic-log-correlation)
+- [tracer: who owns what](#tracer-who-owns-what)
+- [Correlation ids](#correlation-ids)
+- [Background work and queues](#background-work-and-queues)
+
+## The composition-root pattern
+
+Nothing in the suite imports ambient to talk to anything else. `slogger` does
+not know ambient exists; `tracer` uses it only for its own span store. The
+**application** wires them together at startup — each integration is one line,
+and each package stays independently usable.
+
+That is deliberate. If slogger read ambient directly, every consumer of a
+logging package would drag in async-context machinery; if tracer wrote spans
+into the shared request bag, span lifecycle would leak into application state.
+The seams below keep the arrows pointing one way: packages expose hooks, the
+app connects them.
+
+## Opening the scope: middleware
+
+Exactly one place should call `ambient.run` per request — the outermost
+boundary. Everything below it, at any depth, reads the same bag.
+
+```typescript
+// Fetch-standard (Deno.serve, Bun.serve, compat/webserver, Workers)
+async function withRequestContext(
+  req: Request,
+  next: () => Promise<Response>,
+): Promise<Response> {
+  const correlationId = req.headers.get('x-correlation-id') ??
+    crypto.randomUUID();
+  const { pathname } = new URL(req.url);
+  return ambient.run(
+    { correlationId, method: req.method, path: pathname },
+    next,
+  );
+}
+```
+
+Reusing an inbound `x-correlation-id` (when you trust the caller) is what makes
+one id follow a request across your own services. For untrusted edges, always
+mint fresh.
+
+Later enrichment goes through `set` — authentication is the classic case:
+
+```typescript
+ambient.set('userId', user.id); // every subsequent log line carries it
+```
+
+## slogger: automatic log correlation
+
+`slogger`'s `contextProvider` (shipped in slogger 1.1.0) is a logger-level
+thunk invoked per emitted record and merged **under** the call/scope context —
+explicit fields always win:
+
+```typescript
+const log = LogManager.createSlogger({
+  appName: 'orders',
+  contextProvider: () => ambient.get() ?? {}, // ← the whole integration
+});
+
+ambient.run({ correlationId: 'c1' }, () => {
+  log.info('charging'); // → { correlationId: 'c1', ... } with no argument
+});
+```
+
+Two properties worth knowing:
+
+- **Lazy** — the provider runs only for records that pass the level/handler
+  filters, so muted lines never touch ambient.
+- **Reference-cached** — `LogManager` compares configs by function identity;
+  hoist the provider to a `const` rather than passing a fresh arrow per
+  `createSlogger` call.
+
+## tracer: who owns what
+
+`tracer` depends on ambient, but **not** for the request bag — it keeps its
+active span in its own `createContext` store. The shared `RequestContext`'s
+`traceId`/`spanId` fields are a _convention for you to fill_, not something
+tracer writes.
+
+The correlation between logs and traces happens, again, at the composition
+root:
+
+```typescript
+const log = LogManager.createSlogger({
+  appName: 'orders',
+  contextProvider: () => {
+    const span = tracer.active(); // tracer's own store
+    return {
+      ...ambient.get(), // the request bag
+      ...(span
+        ? { trace_id: span.context.traceId, span_id: span.context.spanId }
+        : {}),
+    };
+  },
+});
+```
+
+One provider, three sources joined: request context, plus live trace identity
+when a span is open. Neither slogger nor tracer learned about the other.
+
+## Correlation ids
+
+Ambient is **carry-only**: it stores whatever id you hand it and mints nothing.
+`crypto.randomUUID()` is the zero-dependency default; reach for
+`@tundralibs/id` (ULID, CUID2) when you want sortable or shorter ids — that
+choice belongs to the application, which is why ambient has no `id` dependency.
+
+Propagating the id **outward** is also yours — set the header on outbound
+calls:
+
+```typescript
+await fetch(url, {
+  headers: { 'x-correlation-id': String(ambient.get()?.correlationId ?? '') },
+});
+```
+
+(W3C `traceparent` propagation is `tracer`'s job and rides a different header;
+the two travel independently.)
+
+## Background work and queues
+
+Request context dies with its request — a job picked up later must _rebuild_
+its scope from whatever travelled with the message:
+
+```typescript
+// producer: snapshot what the job needs
+await queue.enqueue({
+  payload,
+  correlationId: ambient.get()?.correlationId,
+});
+
+// consumer: open a fresh scope per job
+await ambient.run(
+  { correlationId: job.correlationId ?? crypto.randomUUID() },
+  () => process(job.payload),
+);
+```
+
+For non-request context in workers — the current tenant, say — prefer a
+dedicated `createContext` store over overloading the request bag; see
+[Ambient-Concepts](Ambient-Concepts.md#your-own-stores-createcontext).


### PR DESCRIPTION
Closes the same documentation gap for ambient that #123 closed for tracer: **zero `docs/` guides**, so the wiki carried only the README.

- **Ambient-Concepts** — prop drilling → ALS isolation, `run`/`child` scopes, the mutable live bag (and why), `createContext` for your own stores, the `getOr` null-vs-undefined subtlety, runtime requirements.
- **Ambient-Integration** — the composition-root pattern (slogger never learns about ambient, tracer keeps its own store), middleware boundary, `contextProvider` wiring, correlation ids, rebuilding scope in queue consumers.

ROADMAP refreshed — two entries had gone stale:
- *"slogger auto-correlation (next)"* → **shipped** (slogger 1.1.0 `contextProvider`)
- *"compat/async extraction (on second consumer)"* → tracer **became** the second consumer and the extraction was still declined; the entry now records the reasoning and the surviving revisit triggers instead of an outdated plan.

Verified wiki-sync emits `Ambient-Concepts.md` / `Ambient-Integration.md` alongside `Ambient.md`. Docs-only; single package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)