### PR TITLE
test(cacher): de-flake the memcached window-mode expiry test

### DIFF
--- a/packages/cacher/engines/memcached/MemCacher.test.ts
+++ b/packages/cacher/engines/memcached/MemCacher.test.ts
@@ -337,23 +337,35 @@ describe({
           const key = 'test-window-mode';
           const value = 'window-mode-value';
 
-          // Set with 3 second expiry and window mode enabled
-          await memcached.set(key, value, { expiry: 3, window: true });
+          // TIMING: memcached expiry has WHOLE-SECOND granularity — an item
+          // set at wall time S with TTL n gets `exptime = floor(S) + n`, so
+          // it is only guaranteed alive while age < n-1, and guaranteed dead
+          // once age >= n. The margins below are chosen against those two
+          // bounds, NOT against the nominal TTL (this test used TTL 3 with a
+          // read at age 2.0s — a zero-margin race that flaked on loaded CI
+          // runners). Total runtime must also stay under bun's 5s default
+          // per-test timeout, which rules out simply using a bigger TTL.
+          await memcached.set(key, value, { expiry: 4, window: true });
 
           // Verify it exists immediately
           let result = await memcached.get(key);
           asserts.assertEquals(result, value);
 
-          // Wait 2 seconds (less than expiry)
+          // Read at age ~2.0s: guaranteed alive until age 3.0 → ~1s margin.
+          // This get re-arms the sliding window (touch back to TTL 4).
           await new Promise((resolve) => setTimeout(resolve, 2000));
-
-          // Get it again - this should extend the expiry
           result = await memcached.get(key);
           asserts.assertEquals(result, value);
 
-          // Wait 2 more seconds - it should still exist because expiry was extended
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-
+          // Read at age ~4.3s. Two things must hold:
+          // - the ORIGINAL item is guaranteed dead by age 4.0, so surviving
+          //   here proves the window extension did it (setTimeout never
+          //   fires early, so age >= 4.3 always);
+          // - the EXTENDED item (re-armed at age >= 2.0) is guaranteed alive
+          //   until at least age 5.0 → >= 0.7s margin, and a late first read
+          //   pushes that bound later by the same amount, so sleep overshoot
+          //   cannot flip this.
+          await new Promise((resolve) => setTimeout(resolve, 2300));
           result = await memcached.get(key);
           asserts.assertEquals(result, value);
         },


### PR DESCRIPTION
The **4th low-frequency flake** (hunted since the PR #26 sweep in July, finally caught by name on the slogger 1.1.1 release PR): `cacher.engines.memcached → "should extend expiry when window mode is enabled"`.

**Root cause:** memcached expiry has **whole-second granularity** — an item set at wall time `S` with TTL `n` gets `exptime = floor(S) + n`, so it's only *guaranteed alive* while `age < n−1` and *guaranteed dead* at `age ≥ n`. The test set TTL 3 and read at age 2.0s — guaranteed-alive only below 2.0s, i.e. a **zero-margin race** flipped by any CI jitter. (The redis sibling test is safe: redis expiry is ms-exact; only memcached floors.)

**Fix:** TTL 4, reads at ~2.0s / ~4.3s — 1s margin on the first read, the second read lands after the *original* item's guaranteed death (proving the extension did the surviving) and ≥0.7s before the *extended* item's earliest death, with sleep-overshoot provably unable to flip either bound. The math is documented in the test so it doesn't get "simplified" back.

One wrinkle worth knowing: a first attempt used TTL 5 (~5.3s runtime) and **tripped bun's 5s default per-test timeout** — compat's `it` has no timeout option, so total-runtime-under-5s is now a documented constraint of the timing.

**Verified against live memcached:** deno ×2, node ×2, bun ×3, plus the full cacher suite — all green. `test:` type → no release. Single package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)