### PR TITLE
feat(norm): add the witness observability hook

### DIFF
--- a/packages/norm/Norm.ts
+++ b/packages/norm/Norm.ts
@@ -53,6 +53,7 @@ import {
   type DecryptFailurePolicy,
   type NormEvents,
   type Runtime,
+  type Witness,
 } from './compile.ts';
 import {
   type CryptoOverrides,
@@ -109,6 +110,21 @@ export type NormConfig = {
    * `'null'` (default) degrades the cell to `null` and emits a
    * `decryptError` event; `'throw'` raises a `NormCryptoError`. */
   onDecryptFailure?: DecryptFailurePolicy;
+  /**
+   * Observability wrap hook ({@link Witness}) — every repo operation and
+   * `raw()` runs through it, so a tracer wired at the composition root makes
+   * each operation an active span and driver query events nest under it:
+   *
+   * ```ts
+   * new Norm({ engine, witness: (info, fn) =>
+   *   tracer.startActiveSpan(info.name, fn) });
+   * ```
+   *
+   * Held out of the options bag (reference-critical, like the crypto
+   * callbacks); a witness must observe without interfering — see
+   * {@link Witness} for the contract.
+   */
+  witness?: Witness;
 };
 
 /** `_on<event>` handler keys accepted inline in the constructor. */
@@ -134,6 +150,8 @@ type NormEventHandlers = {
  */
 export class Norm extends Options<NormConfig, NormEvents> {
   private readonly __executor: Executor;
+  /** See {@link NormConfig.witness}; threaded into every runtime. */
+  private readonly __witness?: Witness;
   private readonly __compileCfg: {
     secret: string | undefined;
     algorithm: EncryptAlgorithm | undefined;
@@ -157,10 +175,12 @@ export class Norm extends Options<NormConfig, NormEvents> {
       database: _database,
       crypto: _crypto,
       secret: _secret,
+      witness: _witness,
       ...storable
     } = cfg;
     this._setOptions(storable as EventOptionKeys<NormConfig, NormEvents>);
     const resolved = resolveEngine(cfg);
+    this.__witness = cfg.witness;
     this.__executor = resolved.executor;
     this.__forwardEngineEvents(resolved.engine);
     this.__compileCfg = {
@@ -239,6 +259,7 @@ export class Norm extends Options<NormConfig, NormEvents> {
       this.__compileCfg,
       this.__executor,
       (event, ...args) => void this.emit(event, ...args),
+      this.__witness,
     );
     // NOT intersected with Record<string, AnyDefinition> — that would
     // collapse `keyof R` to string and repo() would accept any typo.
@@ -417,6 +438,13 @@ export class NormDb<R, Scope extends string = never> {
         );
         break;
     }
+    // Observability boundary: with a witness configured, the accessor's
+    // operation methods are wrapped ONCE here (and cached wrapped), so every
+    // call site gets witnessed without Repo/ReadRepo/QueryAccessor knowing.
+    const witness = this.__runtime.witness;
+    if (witness !== undefined) {
+      accessor = witnessAccessor(accessor as object, key, witness);
+    }
     this.__repoCache.set(key, accessor);
     return accessor as RepoFor<R, K, Scope>;
   }
@@ -536,7 +564,12 @@ export class NormDb<R, Scope extends string = never> {
       'db.raw() executed hand-written SQL — no decrypt / validation / ' +
         'scope applied.',
     );
-    const res = await this.__executor.raw<Res>(sql, params, this.__txId);
+    const witness = this.__runtime.witness;
+    const run = () => this.__executor.raw<Res>(sql, params, this.__txId);
+    const res = witness === undefined ? await run() : await witness(
+      { name: 'norm.raw', attributes: { 'norm.operation': 'RAW' } },
+      run,
+    );
     this.__runtime.emit('call', '<raw>', 'RAW', res.time, res.isSlow, id);
     return makeResult<Res[]>({
       id,
@@ -751,4 +784,80 @@ function resolveEngine(cfg: NormConfig): ResolvedEngine {
       );
     }
   }
+}
+
+// ---------------------------------------------------------------------
+// Witness wiring (see NormConfig.witness / Witness in compile.ts)
+// ---------------------------------------------------------------------
+
+/**
+ * The accessor methods that count as operations. Everything else —
+ * getters, internal helpers — passes through the proxy untouched.
+ * Covers Repo (all nine), ReadRepo (find/findOne/count) and
+ * QueryAccessor (find); a name missing from a given accessor kind is
+ * simply never hit.
+ */
+const WITNESSED_OPS = new Set([
+  'find',
+  'findOne',
+  'count',
+  'getByPK',
+  'insert',
+  'upsert',
+  'update',
+  'delete',
+  'truncate',
+]);
+
+/**
+ * Wrap an accessor so its operation methods run through `witness`.
+ *
+ * A Proxy at the accessor boundary instead of edits inside nine method
+ * bodies: one implementation point covers Repo, ReadRepo and
+ * QueryAccessor alike, and internal calls (an operation invoking a
+ * sibling on `this`) run against the RAW target — so an operation is
+ * witnessed exactly once, at the boundary the application called.
+ *
+ * `Reflect.get(target, prop, target)` and `apply(target, …)` keep
+ * `this` bound to the raw accessor, so field access inside methods is
+ * unaffected by the proxy. Wrapped methods are cached per accessor for
+ * stable function identity across property reads.
+ *
+ * @param accessor - The raw Repo / ReadRepo / QueryAccessor.
+ * @param entity - Registry key, used in the span-style name.
+ * @param witness - See {@link Witness}.
+ * @returns The proxied accessor, cached by `repo()` in place of the raw one.
+ */
+function witnessAccessor<T extends object>(
+  accessor: T,
+  entity: string,
+  witness: Witness,
+): T {
+  const wrapped = new Map<PropertyKey, unknown>();
+  return new Proxy(accessor, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== 'function' || !WITNESSED_OPS.has(prop as string)) {
+        return value;
+      }
+      let fn = wrapped.get(prop);
+      if (fn === undefined) {
+        const op = String(prop);
+        fn = (...args: unknown[]) =>
+          witness(
+            {
+              name: `norm.${entity}.${op}`,
+              attributes: { 'norm.entity': entity, 'norm.operation': op },
+            },
+            () =>
+              (value as (...a: unknown[]) => Promise<unknown>).apply(
+                target,
+                args,
+              ),
+          );
+        wrapped.set(prop, fn);
+      }
+      return fn;
+    },
+  }) as T;
 }

--- a/packages/norm/README.md
+++ b/packages/norm/README.md
@@ -338,6 +338,45 @@ plus the engine's own events proxied from the driver — `connect`,
 and `slowQuery`. All subscribe inline via `_on<event>` keys (or
 `norm.on(event, fn)`).
 
+## Tracing (`witness`)
+
+Events give you _flat_ observability — per-operation `call` and per-query
+`query` records. For **nested** spans (an operation as the parent of the
+queries it caused), configure a `witness`: every repo operation and `raw()`
+runs through it, so a tracer's active span is open while the driver events
+fire, and their spans parent to it automatically via
+[ambient](../ambient/README.md).
+
+```typescript
+import { SpanKind, Tracer } from '@tundralibs/tracer';
+
+const norm = new Norm({
+  engine,
+  secret,
+  witness: (info, fn) =>
+    tracer.startActiveSpan(
+      info.name, // e.g. 'norm.Users.find', 'norm.raw'
+      { kind: SpanKind.INTERNAL, attributes: info.attributes },
+      fn,
+    ),
+});
+```
+
+```text
+GET /orders                      ← request span (middleware)
+└─ norm.Orders.find              ← the witness
+   ├─ db.query                   ← driver event, parents automatically
+   └─ db.query   (relation load)
+```
+
+The `witness` is a generic wrap hook, not a tracer dependency — norm never
+imports tracer; you wire them at the composition root, exactly like
+slogger's `contextProvider`. **A witness observes and must not interfere:**
+it must call `fn` exactly once, return its result unchanged, and re-throw
+its errors. The operation-span-minus-query-spans gap also surfaces norm's
+own overhead (validation, hooks, and per-cell crypto on encrypted columns)
+per operation, for free.
+
 ## Supported databases
 
 | Feature                       | PostgreSQL | MariaDB/MySQL | SQLite | MongoDB |

--- a/packages/norm/compile.ts
+++ b/packages/norm/compile.ts
@@ -53,6 +53,35 @@ import { NormCryptoError, NormDefinitionError } from './errors/mod.ts';
 import type { DefinitionIssue } from './errors/mod.ts';
 
 /** Metadata-only event surface. NEVER row data, plaintext, or secrets. */
+/** The operation descriptor a {@link Witness} receives. */
+export type WitnessInfo = {
+  /** Span-style operation name, e.g. `norm.Users.find` or `norm.raw`. */
+  name: string;
+  /** Structured detail — `norm.entity`, `norm.operation`. */
+  attributes?: Record<string, unknown>;
+};
+
+/**
+ * The suite-wide observability wrap hook: run `fn` on behalf of the caller,
+ * observing it without interfering. Norm routes every repo operation (and
+ * `raw()`) through the configured witness, so a tracer wired as
+ * `witness: (info, fn) => tracer.startActiveSpan(info.name, fn)` makes each
+ * operation an ACTIVE span — and the driver `query` events that fire during
+ * `fn` then parent to it automatically via ambient. Events alone cannot
+ * provide that nesting: a span created in an event handler is never active
+ * across the operation's continuation.
+ *
+ * CONTRACT (the name is the rule): a witness observes and must not
+ * interfere — it must invoke `fn` exactly once, return its result
+ * unchanged, and re-throw its errors. Norm does not defend against a
+ * misbehaving witness; it is composition-root plumbing, trusted like an
+ * exporter or a log handler.
+ */
+export type Witness = <T>(
+  info: WitnessInfo,
+  fn: () => Promise<T>,
+) => Promise<T>;
+
 export type NormEvents = {
   /** A repo/query operation executed. `id` is the SAME ULID returned
    * in the operation's NormResult envelope — correlate logs with it. */
@@ -277,6 +306,8 @@ export type Runtime = {
    * (`@`-less FK aliases with `project: true` + hasOne reverse names
    * with `reverseProject: true`). Empty map entries are omitted. */
   readonly eager: ReadonlyMap<string, ReadonlyArray<string>>;
+  /** Observability wrapper from `NormConfig.witness`; see {@link Witness}. */
+  readonly witness?: Witness;
 };
 
 /** Where a hashed filter's digest lands. */
@@ -383,6 +414,7 @@ export function compileRuntime(
   cfg: CompileConfig,
   executor: Executor,
   emit: NormEmit,
+  witness?: Witness,
 ): Runtime {
   const algorithm = cfg.algorithm ?? DEFAULT_ENCRYPT_ALGORITHM;
 
@@ -470,6 +502,7 @@ export function compileRuntime(
   return {
     registry,
     reverseMap,
+    witness,
     encryptedFqn,
     nonFilterableFqn,
     hashedFqn,

--- a/packages/norm/mod.ts
+++ b/packages/norm/mod.ts
@@ -50,6 +50,8 @@ export {
   type ReverseMap,
   type ReverseRelation,
   type Runtime,
+  type Witness,
+  type WitnessInfo,
 } from './compile.ts';
 export {
   buildCellGuardian,

--- a/packages/norm/witness.test.ts
+++ b/packages/norm/witness.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview The `witness` observability hook, end-to-end over live
+ * SQLite: every repo operation (and `raw()`) runs through the configured
+ * witness with the right name/attributes, results and errors pass through
+ * unchanged, and — the property tracing depends on — driver `query` events
+ * fire WHILE the witnessed fn is executing, so a tracer's active span
+ * parents them.
+ * @module
+ */
+
+import { afterAll, beforeAll, describe, it } from '@tundralibs/compat/test';
+import { makeTempDir, removeDir } from '@tundralibs/compat/file';
+import * as asserts from '@std/asserts';
+import { SQLiteEngine } from '@tundralibs/drivers';
+import {
+  Column,
+  Entity,
+  Norm,
+  Schema,
+  type Witness,
+  type WitnessInfo,
+} from './mod.ts';
+import { Migrator } from './migrations/mod.ts';
+
+const Users = Entity('users', {
+  id: Column.int(),
+  name: Column.clob(),
+}, { pk: ['id'] });
+
+/** One captured lifecycle entry — flat so ordering is assertable. */
+type Log =
+  | { kind: 'start'; info: WitnessInfo }
+  | { kind: 'end'; name: string }
+  | { kind: 'query-event' };
+
+let dir = '';
+let migDir = '';
+let norm: Norm;
+// deno-lint-ignore no-explicit-any
+let db: any;
+const log: Log[] = [];
+
+/** Records start/end around the operation without interfering. */
+const witness: Witness = async (info, fn) => {
+  log.push({ kind: 'start', info });
+  try {
+    return await fn();
+  } finally {
+    log.push({ kind: 'end', name: info.name });
+  }
+};
+
+describe('norm.witness — observability wrap hook (live SQLite)', () => {
+  beforeAll(async () => {
+    dir = await makeTempDir({ prefix: 'norm-witness-db-' });
+    migDir = await makeTempDir({ prefix: 'norm-witness-mig-' });
+    // Migrations run on an UN-witnessed handle — the hook wraps repo
+    // operations, and DDL noise would only muddy the assertions below.
+    const setupNorm = new Norm({
+      engine: new SQLiteEngine('witness', { path: dir }),
+      secret: 'witness-secret',
+    });
+    const setup = setupNorm.use(Schema('App', { Users }));
+    await new Migrator(setup, { dir: migDir }).snapshot();
+    await new Migrator(setup, { dir: migDir }).apply();
+    // Same db file (engine name = filename); release the setup handle.
+    await setupNorm.disconnect();
+
+    norm = new Norm({
+      engine: new SQLiteEngine('witness', { path: dir }),
+      secret: 'witness-secret',
+      witness,
+    });
+    norm.on('query', () => void log.push({ kind: 'query-event' }));
+    db = norm.use(Schema('App', { Users }));
+  });
+
+  afterAll(async () => {
+    await norm.disconnect();
+    await removeDir(dir, { recursive: true });
+    await removeDir(migDir, { recursive: true });
+  });
+
+  it('wraps operations with span-style names and attributes', async () => {
+    log.length = 0;
+    await db.repo('Users').insert([{ id: 1, name: 'ada' }]);
+    await db.repo('Users').find();
+
+    const starts = log.filter((l) => l.kind === 'start') as Array<
+      { kind: 'start'; info: WitnessInfo }
+    >;
+    asserts.assertEquals(starts.map((s) => s.info.name), [
+      'norm.Users.insert',
+      'norm.Users.find',
+    ]);
+    asserts.assertEquals(starts[0]!.info.attributes, {
+      'norm.entity': 'Users',
+      'norm.operation': 'insert',
+    });
+  });
+
+  it('passes results through unchanged', async () => {
+    const res = await db.repo('Users').count();
+    asserts.assertEquals(res.count, 1); // the row inserted above
+    const found = await db.repo('Users').findOne({ '@id': 1 });
+    asserts.assertEquals(found.data?.name, 'ada');
+  });
+
+  it('fires driver query events INSIDE the witnessed window (the nesting precondition)', async () => {
+    log.length = 0;
+    await db.repo('Users').find();
+    const kinds = log.map((l) => l.kind);
+    const start = kinds.indexOf('start');
+    const query = kinds.indexOf('query-event');
+    const end = kinds.indexOf('end');
+    asserts.assert(start >= 0 && query >= 0 && end >= 0, `saw: ${kinds}`);
+    asserts.assert(
+      start < query && query < end,
+      `query event must fire between start and end — a tracer's active span ` +
+        `only parents children created inside the window (saw: ${kinds})`,
+    );
+  });
+
+  it('wraps raw() as norm.raw', async () => {
+    log.length = 0;
+    const r = await db.raw('SELECT count(*) AS n FROM users');
+    asserts.assertEquals(Number(r.data[0]!.n), 1);
+    const start = log.find((l) => l.kind === 'start') as
+      | { kind: 'start'; info: WitnessInfo }
+      | undefined;
+    asserts.assertEquals(start?.info.name, 'norm.raw');
+    asserts.assertEquals(start?.info.attributes, { 'norm.operation': 'RAW' });
+  });
+
+  it('propagates operation errors through the witness', async () => {
+    log.length = 0;
+    await asserts.assertRejects(() => db.raw('SELECT definitely not sql'));
+    // The witness still observed a complete start/end lifecycle.
+    asserts.assertEquals(log.filter((l) => l.kind === 'start').length, 1);
+    asserts.assertEquals(log.filter((l) => l.kind === 'end').length, 1);
+  });
+
+  it('returns the same wrapped accessor from the repo cache', () => {
+    asserts.assertStrictEquals(db.repo('Users'), db.repo('Users'));
+  });
+
+  it('does not wrap non-operation members', () => {
+    // `definition` is a getter, not an operation — it must pass through.
+    const def = db.repo('Users').definition;
+    asserts.assert(def !== undefined);
+  });
+
+  it('operations work identically with no witness configured', async () => {
+    const plain = new Norm({
+      engine: new SQLiteEngine('witness', { path: dir }),
+      secret: 'witness-secret',
+    });
+    try {
+      const pdb = plain.use(Schema('App', { Users }));
+      const res = await pdb.repo('Users').count();
+      asserts.assertEquals(res.count, 1);
+    } finally {
+      await plain.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## What

The suite-wide **Witness** convention, with norm as first adopter: a generic wrap hook every repo operation (and `raw()`) runs through.

```typescript
const norm = new Norm({
  engine,
  witness: (info, fn) => tracer.startActiveSpan(info.name, { attributes: info.attributes }, fn),
});
```

```text
GET /orders                      ← request span
└─ norm.Orders.find              ← the witness (ACTIVE during the operation)
   ├─ db.query                   ← driver event → parents automatically via ambient
   └─ db.query   (relation load)
```

**Why a wrap hook and not more events:** a span created in an event handler is never ambient-active across the operation's continuation — ALS physics. Nesting requires the operation to *execute inside* an active span, and only norm can wrap its own execution. Events (`call`, forwarded `query`) remain the flat layer; the witness adds exactly the nesting.

## Design

- **One wrap point, not nine method edits**: a Proxy at the accessor boundary (`NormDb.repo()`) covers `Repo`, `ReadRepo` and `QueryAccessor` with a single implementation. Internal sibling calls run against the raw target, so an operation is witnessed **exactly once**, at the boundary the application called. Wrapped accessors are cached, so `repo(k) === repo(k)` still holds.
- **Threaded via `Runtime`**, so `scope()` and transaction-bound clones inherit it with zero extra plumbing.
- **Zero coupling** — norm imports nothing new; `Witness` is a structural type (`<T>(info, fn) => Promise<T>`), wired at the composition root exactly like slogger's `contextProvider`. relay/herald adopt the identical shape later.
- **The contract is the name**: a witness observes and must not interfere — invoke `fn` exactly once, return unchanged, re-throw. Documented on the type; norm trusts it like a log handler.
- Kept **out of the options bag** (reference-critical, like the crypto callbacks).

## Tests

Live-SQLite suite, 8 steps, green on **deno / bun / node**: span-style naming + attributes, result/error passthrough, `raw()` as `norm.raw`, cache identity, non-operation members untouched, the no-witness path — and the property tracing depends on: **driver `query` events fire inside the witnessed window** (asserted by event ordering).

Full norm suite locally matches main exactly (the 2 live-DB env-probe failures pre-exist on main and pass in CI where the service containers run).

Companion PR updates tracer's recipes with the Layer 1 (events) / Layer 2 (witness) guidance.

Single package → `Single-package guard` passes. `feat:` → norm 1.1.0 on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)