### PR TITLE
feat(tracer): ship the composition-root adapters — wrap and logContext

### DIFF
--- a/packages/tracer/README.md
+++ b/packages/tracer/README.md
@@ -105,20 +105,20 @@ import { LogManager } from '@tundralibs/slogger';
 
 const log = LogManager.createSlogger({
   appName: 'orders',
-  contextProvider: () => {
-    const span = tracer.active();
-    // Keys are camelCase ON PURPOSE: slogger's otelLogFormatter hoists
-    // context.traceId / context.spanId into the OTel log record's first-class
-    // TraceId/SpanId fields (its `traceFields` defaults) — so logs arrive in
-    // an OTel backend already linked to their traces. Different keys work,
-    // but then the formatter needs a matching `traceFields` override.
-    return span
-      ? { traceId: span.context.traceId, spanId: span.context.spanId }
-      : {};
-  },
+  contextProvider: tracer.logContext, // ← the whole integration
 });
 
 log.info('charging'); // → { traceId: '4bf92f…', spanId: '00f067…' }
+```
+
+`tracer.logContext` emits the **canonical camelCase keys** — the exact names
+slogger's `otelLogFormatter` hoists into the OTel log record's first-class
+TraceId/SpanId fields, so logs arrive in a backend already linked to their
+traces, and the load-bearing key names live in code rather than in docs.
+Composing with the ambient request bag stays one line:
+
+```typescript
+contextProvider: () => ({ ...ambient.get(), ...tracer.logContext() }),
 ```
 
 ### 4. Sample a fraction of traces

--- a/packages/tracer/ROADMAP.md
+++ b/packages/tracer/ROADMAP.md
@@ -16,6 +16,12 @@ shaped the package.
   on overflow. It _is_ a `SpanExporter` wrapping another one, so it needed no
   support from `Tracer` at all.
 - **`SemConv`** — the attribute keys a service actually reaches for.
+- **Composition-root adapters** — `tracer.wrap` (the suite's Witness
+  convention: `new Norm({ witness: tracer.wrap })`) and `tracer.logContext`
+  (slogger's `contextProvider`, emitting the canonical `traceId`/`spanId`
+  keys that `otelLogFormatter` hoists — the names that once shipped wrong in
+  our own docs now live in code). Both bound arrows, both structural, no new
+  dependencies in either direction.
 
 ### Encoder: Guardian, decided by measurement
 

--- a/packages/tracer/Tracer.test.ts
+++ b/packages/tracer/Tracer.test.ts
@@ -386,3 +386,106 @@ describe('tracer.Tracer', () => {
     });
   });
 });
+
+describe('tracer.adapters', () => {
+  describe('wrap (the Witness adapter)', () => {
+    it('runs fn inside an active span with the given name and attributes', async () => {
+      const { tracer, exporter } = tracerWith();
+      const result = await tracer.wrap(
+        { name: 'norm.Users.find', attributes: { 'norm.entity': 'Users' } },
+        async () => {
+          // Auto-parenting must hold inside the wrapped fn.
+          tracer.startSpan('child').end();
+          return 42;
+        },
+      );
+      asserts.assertEquals(result, 42);
+      const op = exporter.find('norm.Users.find')!;
+      asserts.assertEquals(op.attributes['norm.entity'], 'Users');
+      asserts.assertEquals(
+        exporter.find('child')!.parentSpanId,
+        op.context.spanId,
+      );
+    });
+
+    it('drops attribute values OTLP cannot represent', async () => {
+      const { tracer, exporter } = tracerWith();
+      await tracer.wrap({
+        name: 'op',
+        attributes: {
+          ok: 'yes',
+          n: 1,
+          list: ['a', 'b'],
+          nested: { not: 'representable' },
+          mixed: ['a', { b: 1 }],
+        },
+      }, () => Promise.resolve());
+      const attrs = exporter.find('op')!.attributes;
+      asserts.assertEquals(attrs.ok, 'yes');
+      asserts.assertEquals(attrs.n, 1);
+      asserts.assertEquals(attrs.list, ['a', 'b']);
+      asserts.assertEquals('nested' in attrs, false);
+      asserts.assertEquals('mixed' in attrs, false);
+    });
+
+    it('records and rethrows errors (witness contract)', async () => {
+      const { tracer, exporter } = tracerWith();
+      await asserts.assertRejects(
+        () =>
+          tracer.wrap({ name: 'boom' }, () => {
+            return Promise.reject(new Error('op failed'));
+          }),
+        Error,
+        'op failed',
+      );
+      asserts.assertEquals(
+        exporter.find('boom')!.events[0]!.attributes['exception.message'],
+        'op failed',
+      );
+    });
+
+    it('works detached, as norm receives it', async () => {
+      const { tracer, exporter } = tracerWith();
+      const witness = tracer.wrap; // detached — must stay bound
+      await witness({ name: 'detached' }, () => Promise.resolve('ok'));
+      asserts.assertEquals(exporter.find('detached')!.name, 'detached');
+    });
+  });
+
+  describe('logContext (the contextProvider adapter)', () => {
+    it('returns {} outside any span', () => {
+      const { tracer } = tracerWith();
+      asserts.assertEquals(tracer.logContext(), {});
+    });
+
+    it('returns the CANONICAL camelCase keys inside a span', () => {
+      const { tracer } = tracerWith();
+      tracer.startActiveSpan('op', (span) => {
+        // traceId/spanId exactly — otelLogFormatter's hoisting defaults.
+        asserts.assertEquals(tracer.logContext(), {
+          traceId: span.context.traceId,
+          spanId: span.context.spanId,
+        });
+      });
+    });
+
+    it('still reports ids for unsampled spans (correlation without export)', () => {
+      const { tracer } = tracerWith({ sampler: alwaysOffSampler });
+      tracer.startActiveSpan('dropped', (span) => {
+        asserts.assertEquals(
+          (tracer.logContext() as { traceId?: string }).traceId,
+          span.context.traceId,
+        );
+      });
+    });
+
+    it('works detached, as slogger receives it', () => {
+      const { tracer } = tracerWith();
+      const provider = tracer.logContext; // detached — must stay bound
+      tracer.startActiveSpan('op', () => {
+        asserts.assert('traceId' in provider());
+      });
+      asserts.assertEquals(provider(), {});
+    });
+  });
+});

--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -265,6 +265,73 @@ export class Tracer extends Options<TracerOptions> {
   }
 
   /**
+   * Composition-root adapter for the suite's **Witness** convention (norm's
+   * `witness` option, and future adopters): runs `fn` inside an active span
+   * named `info.name`, so child spans — and driver-event spans created while
+   * it runs — parent to it automatically.
+   *
+   * A bound arrow, so it works detached:
+   *
+   * ```ts
+   * const norm = new Norm({ engine, witness: tracer.wrap });
+   * ```
+   *
+   * Attribute values outside the OTLP-representable set (strings, numbers,
+   * booleans, and arrays of those) are dropped rather than exported malformed.
+   * Satisfies the witness contract by construction: `fn` is invoked exactly
+   * once, its result returned unchanged, its errors recorded and re-thrown.
+   */
+  public readonly wrap = <T>(
+    info: { name: string; attributes?: Record<string, unknown> },
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    const attributes: Attributes = {};
+    for (const [key, value] of Object.entries(info.attributes ?? {})) {
+      if (
+        typeof value === 'string' || typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        (Array.isArray(value) &&
+          value.every((v) =>
+            typeof v === 'string' || typeof v === 'number' ||
+            typeof v === 'boolean'
+          ))
+      ) {
+        attributes[key] = value as Attributes[string];
+      }
+    }
+    return this.startActiveSpan(info.name, { attributes }, fn);
+  };
+
+  /**
+   * Composition-root adapter for slogger's `contextProvider`: the active
+   * span's identity under the **canonical key names** — `traceId` / `spanId`,
+   * the exact keys slogger's `otelLogFormatter` hoists into the OTel log
+   * record's first-class TraceId/SpanId fields (its `traceFields` defaults).
+   * Those names are load-bearing; this adapter exists so they live in code
+   * rather than in documentation.
+   *
+   * Returns `{}` outside any span. Unsampled spans still report their ids —
+   * correlation keeps working even when nothing is exported. A bound arrow,
+   * so it works detached:
+   *
+   * ```ts
+   * // tracer only:
+   * LogManager.createSlogger({ appName, contextProvider: tracer.logContext });
+   * // composed with the ambient request bag:
+   * LogManager.createSlogger({
+   *   appName,
+   *   contextProvider: () => ({ ...ambient.get(), ...tracer.logContext() }),
+   * });
+   * ```
+   */
+  public readonly logContext = (): Record<string, unknown> => {
+    const span = activeSpan.get();
+    return span === undefined
+      ? {}
+      : { traceId: span.context.traceId, spanId: span.context.spanId };
+  };
+
+  /**
    * Flush and release the exporter. Call before process exit so buffered spans
    * are not lost.
    */

--- a/packages/tracer/docs/Tracer-Recipes.md
+++ b/packages/tracer/docs/Tracer-Recipes.md
@@ -497,15 +497,10 @@ span to the queries it caused, because a span created in an event handler is
 never _active_ while the operation runs. The witness closes exactly that gap:
 
 ```typescript
-const norm = new Norm({
-  engine,
-  witness: (info, fn) =>
-    tracer.startActiveSpan(
-      info.name, // 'norm.Users.find', 'norm.raw', …
-      { kind: SpanKind.INTERNAL, attributes: info.attributes },
-      fn,
-    ),
-});
+const norm = new Norm({ engine, witness: tracer.wrap });
+// tracer.wrap is the bound Witness adapter — equivalent to wiring
+// startActiveSpan(info.name, { attributes: info.attributes }, fn) by hand,
+// with non-OTLP-representable attribute values dropped for you.
 ```
 
 ```text


### PR DESCRIPTION
## What

The two integrations every app writes by hand become two-word wires:

| adapter | before | after |
|---|---|---|
| `tracer.wrap` (Witness) | 6-line `startActiveSpan` arrow | `new Norm({ witness: tracer.wrap })` |
| `tracer.logContext` (contextProvider) | 6-line thunk with **footgun keys** | `createSlogger({ appName, contextProvider: tracer.logContext })` |

## Why these two details matter

- **`logContext` encodes the canonical keys in code.** `traceId`/`spanId` (camelCase) are what `otelLogFormatter` hoists into first-class OTel fields — the exact names *our own docs shipped wrong* until #132. Load-bearing details don't belong in documentation.
- **`wrap` sanitizes attributes.** `startSpan` seeds attributes without per-value filtering, so an unsanitized `Record<string, unknown>` from a witness's `info.attributes` would reach the OTLP encoder; values outside the representable set are dropped instead.
- Both are **bound arrows** (Slogger's `public error = this.err` precedent) — they work detached, which is precisely how norm and slogger receive them. Tests pin the detached form for both, plus: auto-parenting inside `wrap`, the witness error contract, `{}` outside spans, and ids-for-unsampled-spans (correlation without export).

Docs updated in-package: README §3 (logs↔traces becomes one line), the norm recipe (`witness: tracer.wrap`), ROADMAP (adapters recorded as shipped). Sibling-package doc examples (Slogger-Correlation, norm README) remain valid as the manual form; a follow-up can shorten them.

Zero new dependencies in either direction — the shapes are structural.

| Gate | Result |
|---|---|
| Coverage | ✅ 100% every tracer file |
| deno / bun / node | ✅ 135 / 124 / 119 |
| type-check · lint · fmt · JSR dry-run | ✅ |

Single package → guard passes. `feat:` → tracer 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)