### PR TITLE
docs(slogger): adopt tracer.logContext in correlation guide

### DIFF
--- a/packages/slogger/README.md
+++ b/packages/slogger/README.md
@@ -295,9 +295,10 @@ filters, so muted lines never invoke it. Like formatters, it is compared by
 **reference identity** for `LogManager` caching: hoist it to a stable `const`
 rather than passing a fresh arrow to each `createSlogger` call.
 
-For the full correlation story — adding trace ids from `tracer`, and getting
-`otelLogFormatter` to hoist them into first-class OTel fields — see
-[Slogger-Correlation](docs/Slogger-Correlation.md).
+For trace ids, `tracer` (>= 0.4) ships the bound adapter for this seam —
+`contextProvider: tracer.logContext` — emitting the canonical keys
+`otelLogFormatter` hoists into first-class OTel fields. The full correlation
+story is in [Slogger-Correlation](docs/Slogger-Correlation.md).
 
 ## Core API
 

--- a/packages/slogger/docs/Slogger-Correlation.md
+++ b/packages/slogger/docs/Slogger-Correlation.md
@@ -73,17 +73,17 @@ it writes nothing into the request bag. Read it in the same provider:
 ```typescript
 import { tracer } from './telemetry.ts'; // your Tracer instance
 
-contextProvider: () => {
-  const span = tracer.active();
-  return span
-    ? { traceId: span.context.traceId, spanId: span.context.spanId }
-    : {};
-},
+contextProvider: tracer.logContext, // ← the whole integration (tracer >= 0.4)
 ```
 
-**The key names are load-bearing.** `traceId` / `spanId` (camelCase) are what
-`otelLogFormatter` hoists by default — see the next section. Other names work,
-but then the formatter needs a matching `traceFields` override.
+`tracer.logContext` is the bound adapter tracer ships for exactly this seam:
+it returns `{}` outside a span, still reports ids for **unsampled** spans
+(correlation keeps working when nothing is exported), and emits the
+**canonical key names** — `traceId` / `spanId` (camelCase), which is what
+`otelLogFormatter` hoists by default (see the next section). The names are
+load-bearing, which is exactly why they're encoded in the adapter rather than
+retyped in every app. Other names work, but then the formatter needs a
+matching `traceFields` override.
 
 ## The payoff: otelLogFormatter hoisting
 
@@ -121,15 +121,10 @@ provider, still zero coupling:
 ```typescript
 import { ambient } from '@tundralibs/ambient';
 
-const contextProvider = () => {
-  const span = tracer.active();
-  return {
-    ...ambient.get(), // correlationId, userId, …
-    ...(span
-      ? { traceId: span.context.traceId, spanId: span.context.spanId }
-      : {}),
-  };
-};
+const contextProvider = () => ({
+  ...ambient.get(), // correlationId, userId, …
+  ...tracer.logContext(), // trace identity, canonical keys
+});
 
 const log = LogManager.createSlogger({
   appName: 'orders',


### PR DESCRIPTION
## Summary
tracer 0.4 ships bound adapters for the composition-root seams (#140). This updates slogger's docs to use them instead of the hand-rolled thunk:

- **Slogger-Correlation.md** — "Trace identity via tracer" is now one line (`contextProvider: tracer.logContext`) with prose covering what the adapter guarantees: `{}` outside a span, ids for unsampled spans, and the load-bearing camelCase keys (`traceId`/`spanId`) that `otelLogFormatter` hoists — encoded in code rather than retyped per app. The composed full-wiring example spreads `tracer.logContext()`.
- **README** — the contextProvider section now names the adapter next to the correlation-guide pointer.

Docs-only; slogger imports nothing new — the coupling stays at the app's composition root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)