### PR TITLE
docs(tracer): fix trace_id key name in sampling guide

### DIFF
--- a/packages/tracer/docs/Tracer-Sampling.md
+++ b/packages/tracer/docs/Tracer-Sampling.md
@@ -93,8 +93,9 @@ inject(span.context); // 00-…-…-00  ← flag clear
 ```
 
 So correlation keeps working even when nothing is exported: log lines can still
-carry `trace_id`, and a downstream service still learns that this trace is not
-being sampled rather than deciding again for itself.
+carry `traceId` (`tracer.logContext` reports ids for unsampled spans too), and
+a downstream service still learns that this trace is not being sampled rather
+than deciding again for itself.
 
 Use `isRecording()` to skip work you would only do for the exporter's benefit:
 


### PR DESCRIPTION
## Summary
The unsampled-span correlation paragraph in Tracer-Sampling.md used snake_case `trace_id`; the canonical context key — what `otelLogFormatter` hoists and what `tracer.logContext` emits — is camelCase `traceId`. Fixed, and the sentence now points at `tracer.logContext`, which implements exactly this guarantee (ids keep flowing for unsampled spans).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)