### PR TITLE
docs(norm): adopt tracer.wrap in the witness example

### DIFF
--- a/packages/norm/README.md
+++ b/packages/norm/README.md
@@ -348,19 +348,14 @@ fire, and their spans parent to it automatically via
 [ambient](../ambient/README.md).
 
 ```typescript
-import { SpanKind, Tracer } from '@tundralibs/tracer';
-
-const norm = new Norm({
-  engine,
-  secret,
-  witness: (info, fn) =>
-    tracer.startActiveSpan(
-      info.name, // e.g. 'norm.Users.find', 'norm.raw'
-      { kind: SpanKind.INTERNAL, attributes: info.attributes },
-      fn,
-    ),
-});
+const norm = new Norm({ engine, secret, witness: tracer.wrap });
 ```
+
+`tracer.wrap` (tracer ≥ 0.4) is the ready-made Witness-shaped adapter: it
+opens an `INTERNAL` span named `info.name` (`'norm.Users.find'`,
+`'norm.raw'`, …), seeds the attributes, and honours the witness contract.
+Hand-roll via `startActiveSpan` only when you want a different `SpanKind`
+or extra attributes.
 
 ```text
 GET /orders                      ← request span (middleware)


### PR DESCRIPTION
The README's manual `startActiveSpan` witness wiring collapses to `witness: tracer.wrap` (tracer ≥ 0.4). The manual form stays documented as the escape hatch for a custom SpanKind or extra attributes. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)