### PR TITLE
docs(radrouter): link the tracer middleware recipe

### DIFF
--- a/packages/radrouter/README.md
+++ b/packages/radrouter/README.md
@@ -91,13 +91,14 @@ if (match) {
 
 ## Documentation
 
-| Topic                                        | Description                                                      |
-| -------------------------------------------- | ---------------------------------------------------------------- |
-| [Patterns](docs/RadRouter-Patterns.md)       | Variable, suffix-literal, and greedy patterns; matching priority |
-| [Routing](docs/RadRouter-Routing.md)         | Versioned endpoints, case sensitivity, slash handling            |
-| [API](docs/RadRouter-API.md)                 | Full reference: constructor, registration, lookup, maintenance   |
-| [Wire-up](docs/RadRouter-WireUp.md)          | Integration with `compat/webserver`, Express, Oak                |
-| [Performance](docs/RadRouter-Performance.md) | Benchmarks: per-shape, case-mode, router shootout                |
+| Topic                                                      | Description                                                              |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [Patterns](docs/RadRouter-Patterns.md)                     | Variable, suffix-literal, and greedy patterns; matching priority         |
+| [Routing](docs/RadRouter-Routing.md)                       | Versioned endpoints, case sensitivity, slash handling                    |
+| [API](docs/RadRouter-API.md)                               | Full reference: constructor, registration, lookup, maintenance           |
+| [Wire-up](docs/RadRouter-WireUp.md)                        | Integration with `compat/webserver`, Express, Oak                        |
+| [Performance](docs/RadRouter-Performance.md)               | Benchmarks: per-shape, case-mode, router shootout                        |
+| [Tracing](../tracer/docs/Tracer-Recipes.md#radrouter--rpc) | Ready-made `@tundralibs/tracer` middleware for RadRouter's generic chain |
 
 ## When to use this
 


### PR DESCRIPTION
Tracer-Recipes ships a ready-made tracing middleware for RadRouter's generic chain; surface it from the Documentation table. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)