### PR TITLE
docs(rpc): link the tracer middleware recipe

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -673,6 +673,9 @@ that primitive supports. Today that means:
   conformance test harness
 - [Extending](docs/Rpc-Extending.md) — the override surface,
   pattern subscribe via subclass, custom frame inspection
+- [Tracing middleware](../tracer/docs/Tracer-Recipes.md#radrouter--rpc) —
+  ready-made `@tundralibs/tracer` middleware for RPC's generic chain
+  (a span per message, parented from inbound `traceparent`)
 - [Examples](examples/) — runnable demos
 - [`@tundralibs/compat/websocket`](../compat/websocket/Compat-WebSocket.md) —
   the underlying middleware-aware WebSocket primitive this package is built on


### PR DESCRIPTION
Tracer-Recipes covers RPC's generic middleware chain (span per message, parented from inbound `traceparent`); surface it from Related Documentation. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)