### PR TITLE
docs(pact): remove stale unpublished-status banner

### DIFF
--- a/packages/pact/README.md
+++ b/packages/pact/README.md
@@ -11,8 +11,6 @@ orchestrates, and emits events.
 ![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
 ![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
 
-> ⚠️ **Status: in active development.** Not yet published.
-
 ## Overview
 
 PACT is a **kernel**, not a framework. It owns two things — evaluating


### PR DESCRIPTION
## Summary
- Remove the "⚠️ Status: in active development. Not yet published." banner from packages/pact/README.md — @tundralibs/pact is live on JSR (0.1.0 → 0.4.1).
- Checked the rest of the README for pre-publish phrasing: install commands are already JSR-correct; the "Planned hardening (not yet shipped)" section refers to deferred features, not publication status, so it stays.

Docs-only, single package; this intentionally triggers a pact patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)