### PR TITLE
feat(tracer): wrapClient + propagation outbound adapters

### DIFF
--- a/packages/tracer/README.md
+++ b/packages/tracer/README.md
@@ -95,6 +95,17 @@ await tracer.startActiveSpan(
 );
 ```
 
+For clients built on `@tundralibs/restler` (≥ 1.1) the outbound side is two
+lines of wiring — a CLIENT span per request, `traceparent` carrying that
+request's own span id:
+
+```typescript
+const api = new PaymentsAPI(token, {
+  witness: tracer.wrapClient, // span per outbound request
+  headerProvider: tracer.propagation, // traceparent per request
+});
+```
+
 ### 3. Correlate logs with traces
 
 Slogger's `contextProvider` is called for every record, so trace ids land on

--- a/packages/tracer/ROADMAP.md
+++ b/packages/tracer/ROADMAP.md
@@ -115,13 +115,14 @@ inline.
 - **Sampling is head-based and parent-inherited.** Child spans never re-sample;
   a partially-sampled trace renders as a waterfall with holes. `ratioSampler`
   derives its verdict from the trace id so independent services agree.
-- **Outbound tracing (restler, drivers) stays a recipe, not code.** A
-  first-class `tracer/restler` or driver hook would make outbound calls and
-  queries traced by default rather than by discipline, and unlike Express these
-  are our own APIs — so the usual "we can't track their churn" argument does not
-  apply. It was still declined: it would couple tracer to those packages (or
-  those packages to tracer) for something a ~10-line wrapper already does, and
-  the wrappers are documented in
+- **Outbound tracing couples through generic seams, never imports.**
+  Originally "stays a recipe, not code"; **revised 2026-08 for restler** —
+  but the part worth not relitigating survived: no `tracer/restler` module,
+  no import in either direction. Restler grew two _generic_ hooks
+  (`witness`, `headerProvider`), tracer ships the matching bound adapters
+  (`wrapClient`, `propagation`), and the app connects them at the
+  composition root — same shape as norm's witness and slogger's
+  `contextProvider`. The raw-`fetch` wrapper remains a recipe in
   [Tracer-Recipes](docs/Tracer-Recipes.md#outbound-propagating-the-trace).
 
   `drivers` settles it further: its engines already emit `query`, `slowQuery`,

--- a/packages/tracer/ROADMAP.md
+++ b/packages/tracer/ROADMAP.md
@@ -22,6 +22,12 @@ shaped the package.
   keys that `otelLogFormatter` hoists — the names that once shipped wrong in
   our own docs now live in code). Both bound arrows, both structural, no new
   dependencies in either direction.
+- **Outbound propagation adapters** — `tracer.wrapClient` (the Witness
+  adapter at `SpanKind.CLIENT`, for restler's `witness` hook) and
+  `tracer.propagation` (restler's `headerProvider`: the active span as a
+  W3C `traceparent` header, `{}` outside a span, sampled flag clear on
+  unsampled spans). Completes the seam rule: leaf = events, container =
+  witness, propagator = pre-send headers.
 
 ### Encoder: Guardian, decided by measurement
 

--- a/packages/tracer/Tracer.test.ts
+++ b/packages/tracer/Tracer.test.ts
@@ -488,4 +488,95 @@ describe('tracer.adapters', () => {
       asserts.assertEquals(provider(), {});
     });
   });
+
+  describe('wrapClient (the outbound Witness adapter)', () => {
+    it('opens a CLIENT-kind span, same witness contract as wrap', async () => {
+      const { tracer, exporter } = tracerWith();
+      const result = await tracer.wrapClient(
+        {
+          name: 'restler.github GET',
+          attributes: { 'restler.vendor': 'github', dropped: { deep: true } },
+        },
+        () => Promise.resolve(42),
+      );
+      asserts.assertEquals(result, 42);
+      const span = exporter.find('restler.github GET')!;
+      asserts.assertEquals(span.kind, SpanKind.CLIENT);
+      asserts.assertEquals(span.attributes['restler.vendor'], 'github');
+      asserts.assertEquals('dropped' in span.attributes, false);
+    });
+
+    it('is ambient-active while fn runs — the propagation precondition', async () => {
+      const { tracer } = tracerWith();
+      const witness = tracer.wrapClient; // detached — must stay bound
+      await witness({ name: 'out' }, () => {
+        asserts.assert('traceId' in tracer.logContext());
+        return Promise.resolve();
+      });
+    });
+
+    it('records and rethrows errors', async () => {
+      const { tracer, exporter } = tracerWith();
+      await asserts.assertRejects(
+        () =>
+          tracer.wrapClient(
+            { name: 'boom.client' },
+            () => Promise.reject(new Error('down')),
+          ),
+        Error,
+        'down',
+      );
+      asserts.assertEquals(
+        exporter.find('boom.client')!.events[0]!.attributes[
+          'exception.message'
+        ],
+        'down',
+      );
+    });
+  });
+
+  describe('propagation (the headerProvider adapter)', () => {
+    it('returns {} outside any span — request goes out unpropagated', () => {
+      const { tracer } = tracerWith();
+      asserts.assertEquals(tracer.propagation(), {});
+    });
+
+    it('returns a valid traceparent carrying the ACTIVE span', () => {
+      const { tracer } = tracerWith();
+      tracer.startActiveSpan('op', (span) => {
+        const headers = tracer.propagation();
+        asserts.assertEquals(
+          headers['traceparent'],
+          `00-${span.context.traceId}-${span.context.spanId}-01`,
+        );
+        // The output is itself a valid carrier — round-trips through extract.
+        const parent = extract(headers);
+        asserts.assertEquals(parent!.traceId, span.context.traceId);
+      });
+    });
+
+    it('serialises unsampled spans with the flag CLEAR', () => {
+      const { tracer } = tracerWith({ sampler: alwaysOffSampler });
+      tracer.startActiveSpan('dropped', (span) => {
+        asserts.assertEquals(
+          tracer.propagation()['traceparent'],
+          `00-${span.context.traceId}-${span.context.spanId}-00`,
+        );
+      });
+    });
+
+    it('carries the wrapClient span when composed — restler wiring', async () => {
+      const { tracer } = tracerWith();
+      const provider = tracer.propagation; // detached — must stay bound
+      await tracer.wrapClient({ name: 'out' }, () => {
+        const inner = tracer.logContext() as { spanId: string };
+        // The header carries THIS request's span, not some outer one.
+        asserts.assert(
+          provider()['traceparent']!.includes(inner.spanId),
+        );
+        return Promise.resolve();
+      });
+      asserts.assertEquals(provider(), {});
+    });
+  });
 });

--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -28,7 +28,7 @@ import { activeSpan } from './activeSpan.ts';
 import { Span } from './Span.ts';
 import { randomIdGenerator } from './ids.ts';
 import { alwaysOnSampler } from './samplers.ts';
-import { FLAG_SAMPLED } from './propagation.ts';
+import { FLAG_SAMPLED, inject } from './propagation.ts';
 import { TracerConfigError } from './errors/mod.ts';
 import type {
   Attributes,
@@ -285,6 +285,50 @@ export class Tracer extends Options<TracerOptions> {
     info: { name: string; attributes?: Record<string, unknown> },
     fn: () => Promise<T>,
   ): Promise<T> => {
+    return this.startActiveSpan(
+      info.name,
+      { attributes: this.__witnessAttributes(info) },
+      fn,
+    );
+  };
+
+  /**
+   * {@link Tracer.wrap} with `SpanKind.CLIENT` — the Witness-shaped adapter
+   * for **outbound** operations (an HTTP request, a call into another
+   * service). CLIENT kind is what trace backends use to draw
+   * service-dependency edges, so a wrapped outbound call shows up as an edge
+   * in the service map rather than internal work.
+   *
+   * A bound arrow, so it works detached:
+   *
+   * ```ts
+   * const api = new GitHubAPI(token, {
+   *   witness: tracer.wrapClient, // span per outbound request
+   *   headerProvider: tracer.propagation, // traceparent per request
+   * });
+   * ```
+   *
+   * Same contract and attribute sanitisation as {@link Tracer.wrap}.
+   */
+  public readonly wrapClient = <T>(
+    info: { name: string; attributes?: Record<string, unknown> },
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    return this.startActiveSpan(
+      info.name,
+      { kind: SpanKind.CLIENT, attributes: this.__witnessAttributes(info) },
+      fn,
+    );
+  };
+
+  /**
+   * Attribute values outside the OTLP-representable set (strings, numbers,
+   * booleans, and arrays of those) are dropped rather than exported
+   * malformed — witness callers pass `Record<string, unknown>`.
+   */
+  private __witnessAttributes(
+    info: { attributes?: Record<string, unknown> },
+  ): Attributes {
     const attributes: Attributes = {};
     for (const [key, value] of Object.entries(info.attributes ?? {})) {
       if (
@@ -299,8 +343,8 @@ export class Tracer extends Options<TracerOptions> {
         attributes[key] = value as Attributes[string];
       }
     }
-    return this.startActiveSpan(info.name, { attributes }, fn);
-  };
+    return attributes;
+  }
 
   /**
    * Composition-root adapter for slogger's `contextProvider`: the active
@@ -329,6 +373,31 @@ export class Tracer extends Options<TracerOptions> {
     return span === undefined
       ? {}
       : { traceId: span.context.traceId, spanId: span.context.spanId };
+  };
+
+  /**
+   * Composition-root adapter for **outbound propagation** (restler's
+   * `headerProvider`, or any per-request header seam): the active span's
+   * context as a W3C `traceparent` header, so the downstream service joins
+   * this trace instead of starting its own.
+   *
+   * Returns `{}` outside any span — the request simply goes out
+   * unpropagated. An **unsampled** span still serialises (with the sampled
+   * flag clear), so downstream learns the sampling decision rather than
+   * re-deciding for itself. A bound arrow, so it works detached:
+   *
+   * ```ts
+   * // restler (>= 1.1): every outbound request carries traceparent
+   * const api = new GitHubAPI(token, { headerProvider: tracer.propagation });
+   *
+   * // pairs with the per-request CLIENT span from `witness: tracer.wrapClient`
+   * // — the provider runs inside the witnessed window, so the header carries
+   * // that request's own span id.
+   * ```
+   */
+  public readonly propagation = (): Record<string, string> => {
+    const span = activeSpan.get();
+    return span === undefined ? {} : { traceparent: inject(span.context) };
   };
 
   /**

--- a/packages/tracer/docs/Tracer-Recipes.md
+++ b/packages/tracer/docs/Tracer-Recipes.md
@@ -365,6 +365,24 @@ router.use(tracing);
 Open a `CLIENT` span and inject `traceparent`, so the callee joins this trace
 rather than starting its own.
 
+For API clients built on [`@tundralibs/restler`](../../restler/README.md)
+(≥ 1.1) this is wiring, not code — restler's two hooks compose through the
+ambient store with no coupling in either direction:
+
+```typescript
+const api = new GitHubAPI(token, {
+  witness: tracer.wrapClient, // CLIENT span per outbound request
+  headerProvider: tracer.propagation, // traceparent — carries THAT span's id
+});
+```
+
+`headerProvider` runs inside the witnessed window, so the header carries the
+per-request span, not the distant server span. Either hook also works alone:
+`headerProvider` by itself still propagates (downstream parents to whatever
+span is active), `witness` by itself still draws the client edge in the
+service map. For raw `fetch` — or any client without a header seam — wrap it
+yourself:
+
 ```typescript
 const tracedFetch = (input: string, init: RequestInit = {}) =>
   tracer.startActiveSpan(


### PR DESCRIPTION
## Summary
The outbound half of the composition-root adapters (#140 shipped wrap/logContext):

- **`tracer.wrapClient`** — `tracer.wrap` at `SpanKind.CLIENT`; the Witness adapter for outbound operations (restler's `witness` hook). CLIENT kind is what backends use to draw service-dependency edges.
- **`tracer.propagation`** — the `headerProvider` adapter: active span → `{ traceparent }` (W3C), `{}` outside a span; unsampled spans serialise with the flag clear so downstream inherits the sampling decision.

Composition property (tested): a `headerProvider` running inside a `wrapClient`-witnessed window carries **that request's** span id — restler wires both without knowing either exists.

Docs: README quick-start outbound section, Recipes outbound section (restler wiring first, raw-fetch recipe kept), ROADMAP shipped bullet. The restler hooks (`witness`/`headerProvider`) ship separately as feat(restler).

## Tests
- wrapClient: CLIENT kind, attribute sanitisation, witness error contract, ambient-active window
- propagation: `{}` outside span, valid traceparent (round-trips through `extract`), unsampled flag clear, composed wrapClient+propagation carrying the inner span id
- 44/44 pass deno + bun locally (collector conformance test needs the CI service container, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)