### PR TITLE
feat(restler): witness + headerProvider propagator hooks

### DIFF
--- a/packages/restler/README.md
+++ b/packages/restler/README.md
@@ -455,13 +455,38 @@ api.on('call', (vendor, request, response) => {
 
 RESTler imports no logging or tracing package — observability wires up at
 the application's **composition root** through two generic constructor
-options, plus the events above:
+options, plus the events above. The vendor client stays
+observability-agnostic; it just lets the hooks flow through to `super`
+(the `RESTlerHooks` type is exported for exactly this):
 
 ```typescript
+import { RESTler, type RESTlerHooks } from '@tundralibs/restler';
+
+class GitHubAPI extends RESTler {
+  public readonly vendor = 'github';
+
+  constructor(token: string, hooks: RESTlerHooks = {}) {
+    super({
+      baseURL: 'https://api.github.com',
+      auth: { type: 'BEARER', token },
+      ...hooks, // witness? headerProvider? — never inspected here
+    });
+  }
+
+  getUser(login: string) {
+    return this._makeRequest<{ id: number; login: string }>({
+      path: `/users/${login}`,
+      method: 'GET',
+    });
+  }
+}
+
+// The app wires observability once; domain calls don't change:
 const api = new GitHubAPI(token, {
   witness: tracer.wrapClient, // a CLIENT span per outbound request
   headerProvider: tracer.propagation, // traceparent per request (tracer >= 0.5)
 });
+const res = await api.getUser('octocat'); // traced + propagated, nothing new here
 ```
 
 **`witness`** — the suite's [Witness convention](../norm/README.md#tracing-witness)

--- a/packages/restler/README.md
+++ b/packages/restler/README.md
@@ -133,17 +133,19 @@ console.log(res.status, res.body?.title);
 `RESTlerOptions` is passed to `super(...)` in your subclass constructor. Only
 `baseURL` is required.
 
-| Option        | Type                     | Default  | Notes                                                                |
-| ------------- | ------------------------ | -------- | -------------------------------------------------------------------- |
-| `baseURL`     | `string`                 | —        | Required. May contain a `{version}` placeholder.                     |
-| `port`        | `number`                 | —        | 1–65535.                                                             |
-| `headers`     | `Record<string, string>` | `{}`     | Default headers sent with every request.                             |
-| `timeout`     | `number`                 | `30`     | Seconds. Must be `>= 1` and `<= 120`.                                |
-| `contentType` | `RESTlerContentType`     | `'JSON'` | Default body content type (`JSON \| XML \| FORM \| TEXT \| BLOB`).   |
-| `version`     | `string`                 | —        | Replaces `{version}` in URLs, query values, and headers.             |
-| `socketPath`  | `string`                 | —        | Route over a Unix socket (Deno/Bun). Must point to an existing path. |
-| `tls`         | `TLSOptions`             | —        | TLS client auth (Deno/Bun). See [TLS](#tls-client-authentication).   |
-| `auth`        | `RESTlerAuth`            | —        | Default authentication. See [Authentication](#authentication).       |
+| Option           | Type                     | Default  | Notes                                                                                             |
+| ---------------- | ------------------------ | -------- | ------------------------------------------------------------------------------------------------- |
+| `baseURL`        | `string`                 | —        | Required. May contain a `{version}` placeholder.                                                  |
+| `port`           | `number`                 | —        | 1–65535.                                                                                          |
+| `headers`        | `Record<string, string>` | `{}`     | Default headers sent with every request.                                                          |
+| `timeout`        | `number`                 | `30`     | Seconds. Must be `>= 1` and `<= 120`.                                                             |
+| `contentType`    | `RESTlerContentType`     | `'JSON'` | Default body content type (`JSON \| XML \| FORM \| TEXT \| BLOB`).                                |
+| `version`        | `string`                 | —        | Replaces `{version}` in URLs, query values, and headers.                                          |
+| `socketPath`     | `string`                 | —        | Route over a Unix socket (Deno/Bun). Must point to an existing path.                              |
+| `tls`            | `TLSOptions`             | —        | TLS client auth (Deno/Bun). See [TLS](#tls-client-authentication).                                |
+| `auth`           | `RESTlerAuth`            | —        | Default authentication. See [Authentication](#authentication).                                    |
+| `witness`        | `Witness`                | —        | Observability wrap hook (suite convention). See [Observability](#observability).                  |
+| `headerProvider` | `RESTlerHeaderProvider`  | —        | Per-request outbound headers (traceparent, correlation ids). See [Observability](#observability). |
 
 Values are validated in the constructor; an invalid value — or a missing
 required `baseURL` (including when it's absent from loosely-typed config loaded
@@ -451,23 +453,49 @@ api.on('call', (vendor, request, response) => {
 
 ## Observability
 
-The events above are the integration seam — RESTler imports no logging or
-tracing package.
+RESTler imports no logging or tracing package — observability wires up at
+the application's **composition root** through two generic constructor
+options, plus the events above:
 
-**Correlated logs.** Listeners fire inside the calling request's async
+```typescript
+const api = new GitHubAPI(token, {
+  witness: tracer.wrapClient, // a CLIENT span per outbound request
+  headerProvider: tracer.propagation, // traceparent per request (tracer >= 0.5)
+});
+```
+
+**`witness`** — the suite's [Witness convention](../norm/README.md#tracing-witness)
+(shared shape with norm): every request runs through the hook with a
+span-style name (`restler.github GET`) and low-cardinality attributes
+(vendor, method, raw path — never the resolved URL or query string, which
+can carry credentials). A witness observes and must not interfere: it calls
+the wrapped `fn` exactly once, returns its result unchanged, and re-throws
+its errors.
+
+**`headerProvider`** — a per-request thunk whose headers go out on the wire,
+layered `defaults < provider < endpoint.headers` (auth always wins). It runs
+**inside the witnessed window**, which is the property propagation depends
+on: `tracer.propagation` reads the active span at send time, so the
+`traceparent` carries _that request's_ span id and the downstream service
+joins the trace correctly parented. A throwing provider is contained — the
+request proceeds without its headers. It is not tracing-specific:
+
+```typescript
+headerProvider: () => ({
+  'x-correlation-id': String(ambient.get()?.correlationId ?? ''),
+}),
+```
+
+**Correlated logs.** Event listeners fire inside the calling request's async
 context, so a logger wired with a `contextProvider`
 ([ambient](../ambient/README.md) request bag, trace identity via
 `tracer.logContext`) stamps correlation ids on every line a listener emits —
 no argument threading. See
 [Slogger-Correlation](../slogger/docs/Slogger-Correlation.md).
 
-**Outbound traces.** To make the downstream service join your trace, wrap
-calls in a `CLIENT` span and send a `traceparent` header —
-`@tundralibs/tracer` documents the ready-made shape in
+For the raw-`fetch` shape these hooks replace — or clients not built on
+RESTler — see
 [Outbound: propagating the trace](../tracer/docs/Tracer-Recipes.md#outbound-propagating-the-trace).
-The header must be injected **per request** — each call carries its own span
-id — so wrap the call site as in the recipe, or add it from an
-`_authInjector`-style endpoint override, which runs per request.
 
 ## Vendor Response Handling
 

--- a/packages/restler/RESTler.ts
+++ b/packages/restler/RESTler.ts
@@ -783,7 +783,35 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * @throws {@link RESTlerError} Subclasses thrown by the response handler
    *   surface unwrapped (with the `request` in their `context` redacted)
    */
-  protected async _makeRequest<B = ResponseBody>(
+  protected _makeRequest<B = ResponseBody>(
+    endpoint: RESTlerEndpoint,
+    responseHandler?: RESTlerResponseHandler,
+  ): Promise<RESTlerResponse<B>> {
+    const witness = this.getOption('witness');
+    if (witness === undefined) {
+      return this.__request<B>(endpoint, responseHandler);
+    }
+    // The whole request — endpoint resolution, headerProvider, fetch, body
+    // parsing — runs inside the witnessed window, so a tracer's span is
+    // ambient-active when the headerProvider fires (that composition is what
+    // puts THIS request's span id into an injected `traceparent`). Name and
+    // attributes stay low-cardinality and redaction-safe: the raw `path` is
+    // passed as given (no query string, no resolved URL, no userinfo).
+    return witness(
+      {
+        name: `restler.${this.vendor} ${endpoint.method}`,
+        attributes: {
+          'restler.vendor': this.vendor,
+          'http.request.method': endpoint.method,
+          'url.path': endpoint.path,
+        },
+      },
+      () => this.__request<B>(endpoint, responseHandler),
+    );
+  }
+
+  /** The request pipeline {@link _makeRequest} runs (witnessed or not). */
+  private async __request<B = ResponseBody>(
     endpoint: RESTlerEndpoint,
     responseHandler?: RESTlerResponseHandler,
   ): Promise<RESTlerResponse<B>> {
@@ -1133,6 +1161,21 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     Object.entries(this._defaultHeaders).forEach(([key, value]) => {
       headers[key] = this._replaceVersion(value, version);
     });
+    // Per-request outbound headers (traceparent, correlation ids). Layered
+    // over the defaults but under the endpoint's own headers and auth —
+    // explicit always beats ambient. Values are runtime-computed, so no
+    // {version} replacement. A throwing provider is contained: observability
+    // wiring must never break the request it decorates.
+    const headerProvider = this.getOption('headerProvider');
+    if (headerProvider !== undefined) {
+      try {
+        for (const [key, value] of Object.entries(headerProvider() ?? {})) {
+          headers[key] = String(value);
+        }
+      } catch {
+        // contained by design — see the option's contract
+      }
+    }
     // Handle auth (may be async — e.g. token refresh before the request)
     await this._authInjector(endpoint);
     if (endpoint.headers) {
@@ -1335,6 +1378,22 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
               key: key,
               value: this.__redactedOption(key, value),
             },
+          );
+        }
+        break;
+      case 'witness':
+        if (value !== undefined && typeof value !== 'function') {
+          throw new RESTlerConfigError(
+            `witness must be a function (the suite's Witness shape).`,
+            { vendor: this.vendor, key: key, value: value },
+          );
+        }
+        break;
+      case 'headerProvider':
+        if (value !== undefined && typeof value !== 'function') {
+          throw new RESTlerConfigError(
+            `headerProvider must be a function returning a header record.`,
+            { vendor: this.vendor, key: key, value: value },
           );
         }
         break;

--- a/packages/restler/mod.ts
+++ b/packages/restler/mod.ts
@@ -20,12 +20,15 @@ export type {
   RESTlerContentTypePayload,
   RESTlerEndpoint,
   RESTlerEvents,
+  RESTlerHeaderProvider,
   RESTlerMethod,
   RESTlerMethodPayload,
   RESTlerOptions,
   RESTlerRequest,
   RESTlerResponse,
   RESTlerResponseHandler,
+  Witness,
+  WitnessInfo,
 } from './types/mod.ts';
 export {
   RESTlerConfigError,

--- a/packages/restler/mod.ts
+++ b/packages/restler/mod.ts
@@ -21,6 +21,7 @@ export type {
   RESTlerEndpoint,
   RESTlerEvents,
   RESTlerHeaderProvider,
+  RESTlerHooks,
   RESTlerMethod,
   RESTlerMethodPayload,
   RESTlerOptions,

--- a/packages/restler/tests/RESTlerHooks.test.ts
+++ b/packages/restler/tests/RESTlerHooks.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @fileoverview The observability hooks: `headerProvider` (per-request
+ * outbound headers, contained on throw, correct precedence) and `witness`
+ * (the suite convention — wraps the WHOLE request, so the provider fires
+ * inside the witnessed window: the composition tracing depends on).
+ * @module
+ */
+
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { RESTler } from '../mod.ts';
+import { RESTlerConfigError } from '../errors/mod.ts';
+import type {
+  RESTlerHeaderProvider,
+  RESTlerOptions,
+  Witness,
+  WitnessInfo,
+} from '../types/mod.ts';
+
+class HookedRESTler extends RESTler {
+  public readonly vendor = 'hooked';
+
+  constructor(options: Partial<RESTlerOptions> = {}) {
+    super({ baseURL: 'https://api.example.dev', ...options });
+  }
+
+  /** Capture the headers the wire would actually see. */
+  public captureFetch(sink: { headers?: Record<string, string> }) {
+    this._fetch = (_input, init) => {
+      sink.headers = { ...(init?.headers as Record<string, string>) };
+      return Promise.resolve(
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    };
+  }
+
+  public get(path: string, headers?: Record<string, string>) {
+    return this._makeRequest<{ ok: boolean }>({ path, method: 'GET', headers });
+  }
+}
+
+describe('restler.hooks', () => {
+  describe('headerProvider', () => {
+    it('puts provider headers on the wire, fresh per request', async () => {
+      let n = 0;
+      const client = new HookedRESTler({
+        headerProvider: () => ({ 'x-request-n': String(++n) }),
+      });
+      const sink: { headers?: Record<string, string> } = {};
+      client.captureFetch(sink);
+
+      await client.get('/a');
+      asserts.assertEquals(sink.headers!['x-request-n'], '1');
+      await client.get('/b');
+      asserts.assertEquals(sink.headers!['x-request-n'], '2');
+    });
+
+    it('layers between defaults and endpoint headers (explicit beats ambient)', async () => {
+      const client = new HookedRESTler({
+        headers: { 'x-layer': 'default', 'x-from-default': 'yes' },
+        headerProvider: () => ({
+          'x-layer': 'provider',
+          'x-explicit': 'provider',
+          'x-from-provider': 'yes',
+        }),
+      });
+      const sink: { headers?: Record<string, string> } = {};
+      client.captureFetch(sink);
+
+      await client.get('/a', { 'x-explicit': 'endpoint' });
+      asserts.assertEquals(sink.headers!['x-layer'], 'provider'); // provider > default
+      asserts.assertEquals(sink.headers!['x-explicit'], 'endpoint'); // endpoint > provider
+      asserts.assertEquals(sink.headers!['x-from-default'], 'yes');
+      asserts.assertEquals(sink.headers!['x-from-provider'], 'yes');
+    });
+
+    it('does not clobber auth (auth always wins)', async () => {
+      const client = new HookedRESTler({
+        auth: { type: 'BEARER', token: 'real-token' },
+        headerProvider: () => ({ Authorization: 'Bearer forged' }),
+      });
+      const sink: { headers?: Record<string, string> } = {};
+      client.captureFetch(sink);
+
+      await client.get('/a');
+      asserts.assertEquals(
+        sink.headers!['Authorization'],
+        'BEARER real-token',
+      );
+    });
+
+    it('contains a throwing provider — the request still succeeds', async () => {
+      const client = new HookedRESTler({
+        headerProvider: () => {
+          throw new Error('observability bug');
+        },
+      });
+      const sink: { headers?: Record<string, string> } = {};
+      client.captureFetch(sink);
+
+      const res = await client.get('/a');
+      asserts.assertEquals(res.status, 200);
+      asserts.assertEquals('x-anything' in sink.headers!, false);
+    });
+
+    it('rejects a non-function at construction', () => {
+      asserts.assertThrows(
+        () =>
+          new HookedRESTler(
+            { headerProvider: 'nope' as unknown as RESTlerHeaderProvider },
+          ),
+        RESTlerConfigError,
+        'headerProvider',
+      );
+    });
+  });
+
+  describe('witness', () => {
+    it('wraps the request with span-style info; result passes through', async () => {
+      const log: Array<{ kind: string; info?: WitnessInfo }> = [];
+      const witness: Witness = async (info, fn) => {
+        log.push({ kind: 'start', info });
+        try {
+          return await fn();
+        } finally {
+          log.push({ kind: 'end' });
+        }
+      };
+      const client = new HookedRESTler({ witness });
+      client.captureFetch({});
+
+      const res = await client.get('/users/42');
+      asserts.assertEquals(res.body?.ok, true);
+      asserts.assertEquals(log[0]!.info!.name, 'restler.hooked GET');
+      asserts.assertEquals(log[0]!.info!.attributes, {
+        'restler.vendor': 'hooked',
+        'http.request.method': 'GET',
+        'url.path': '/users/42',
+      });
+      asserts.assertEquals(log.map((l) => l.kind), ['start', 'end']);
+    });
+
+    it('fires the headerProvider INSIDE the witnessed window (the propagation precondition)', async () => {
+      const order: string[] = [];
+      const client = new HookedRESTler({
+        witness: async (_info, fn) => {
+          order.push('witness:start');
+          try {
+            return await fn();
+          } finally {
+            order.push('witness:end');
+          }
+        },
+        headerProvider: () => {
+          order.push('provider');
+          return {};
+        },
+      });
+      client.captureFetch({});
+
+      await client.get('/a');
+      asserts.assertEquals(order, ['witness:start', 'provider', 'witness:end']);
+    });
+
+    it('propagates request errors through the witness unchanged', async () => {
+      let sawLifecycle = 0;
+      const client = new HookedRESTler({
+        witness: async (_info, fn) => {
+          sawLifecycle++;
+          try {
+            return await fn();
+          } finally {
+            sawLifecycle++;
+          }
+        },
+      });
+      client['_fetch'] = () => Promise.reject(new TypeError('fetch failed'));
+
+      await asserts.assertRejects(() => client.get('/a'));
+      asserts.assertEquals(sawLifecycle, 2);
+    });
+
+    it('rejects a non-function at construction', () => {
+      asserts.assertThrows(
+        () => new HookedRESTler({ witness: 'nope' as unknown as Witness }),
+        RESTlerConfigError,
+        'witness',
+      );
+    });
+
+    it('behaves identically with no hooks configured', async () => {
+      const client = new HookedRESTler();
+      const sink: { headers?: Record<string, string> } = {};
+      client.captureFetch(sink);
+      const res = await client.get('/a');
+      asserts.assertEquals(res.status, 200);
+    });
+  });
+});

--- a/packages/restler/types/RESTlerHooks.ts
+++ b/packages/restler/types/RESTlerHooks.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview The observability hooks — the suite's `Witness` convention
+ * and the per-request `headerProvider` seam. Both are structural: RESTler
+ * imports no logging or tracing package, and the matching adapters
+ * (`tracer.wrapClient`, `tracer.propagation`) satisfy these shapes without
+ * either package knowing the other exists.
+ *
+ * @module
+ */
+
+/**
+ * What a {@link Witness} learns about the operation it wraps: a span-style
+ * name and flat attributes. RESTler names requests
+ * `restler.<vendor> <METHOD>` and passes the vendor, method, and raw path
+ * as attributes — never the resolved URL or query string, which can carry
+ * credentials or PII.
+ */
+export type WitnessInfo = {
+  /** Span-style operation name, e.g. `restler.github GET`. */
+  name: string;
+  /** Flat descriptive attributes, e.g. `{ 'restler.vendor': 'github' }`. */
+  attributes?: Record<string, unknown>;
+};
+
+/**
+ * The suite's **Witness** convention (shared shape with `@tundralibs/norm`):
+ * a wrap hook that observes an operation without interfering. A witness
+ * MUST call `fn` exactly once, return its result unchanged, and re-throw
+ * its errors — `tracer.wrapClient` satisfies the contract by construction
+ * and opens a `CLIENT` span per request.
+ */
+export type Witness = <T>(
+  info: WitnessInfo,
+  fn: () => Promise<T>,
+) => Promise<T>;
+
+/**
+ * Per-request outbound header seam. Called once per request while the
+ * request is being assembled — inside the {@link Witness} window when both
+ * hooks are configured, which is what lets `tracer.propagation` emit a
+ * `traceparent` carrying that request's own span id.
+ *
+ * Sync by design (mirrors slogger's `contextProvider`); a thrown error is
+ * contained — the request proceeds without the provider's headers, because
+ * observability wiring must never break the operation.
+ */
+export type RESTlerHeaderProvider = () => Record<string, string>;

--- a/packages/restler/types/RESTlerHooks.ts
+++ b/packages/restler/types/RESTlerHooks.ts
@@ -45,3 +45,22 @@ export type Witness = <T>(
  * observability wiring must never break the operation.
  */
 export type RESTlerHeaderProvider = () => Record<string, string>;
+
+/**
+ * Convenience bag for threading the observability hooks from the
+ * application's composition root through a vendor client's constructor:
+ *
+ * ```ts
+ * class GitHubAPI extends RESTler {
+ *   constructor(token: string, hooks: RESTlerHooks = {}) {
+ *     super({ baseURL: 'https://api.github.com', auth: { type: 'BEARER', token }, ...hooks });
+ *   }
+ * }
+ * ```
+ */
+export type RESTlerHooks = {
+  /** See {@link Witness}. */
+  witness?: Witness;
+  /** See {@link RESTlerHeaderProvider}. */
+  headerProvider?: RESTlerHeaderProvider;
+};

--- a/packages/restler/types/RESTlerOptions.ts
+++ b/packages/restler/types/RESTlerOptions.ts
@@ -5,6 +5,7 @@
  */
 import type { RESTlerContentType } from './RESTlerContentType.ts';
 import type { RESTlerAuth } from './RESTlerAuth.ts';
+import type { RESTlerHeaderProvider, Witness } from './RESTlerHooks.ts';
 import type { TLSOptions } from '@tundralibs/compat/common';
 
 /**
@@ -71,4 +72,24 @@ export type RESTlerOptions = {
    * @see {@link RESTlerAuth}
    */
   auth?: RESTlerAuth;
+
+  /**
+   * Optional observability wrap hook — the suite's **Witness** convention.
+   * Every request runs through it (`tracer.wrapClient` opens a CLIENT span
+   * per request). Wired at the application's composition root; RESTler
+   * never imports a tracing package.
+   * @see {@link Witness}
+   */
+  witness?: Witness;
+
+  /**
+   * Optional per-request outbound header seam. Called once per request;
+   * its headers layer between the client's default `headers` and the
+   * endpoint's own (`defaults < provider < endpoint.headers`, auth always
+   * wins). `tracer.propagation` supplies a W3C `traceparent` here; a plain
+   * thunk over the ambient bag propagates a correlation id. A thrown
+   * provider is contained — the request proceeds without its headers.
+   * @see {@link RESTlerHeaderProvider}
+   */
+  headerProvider?: RESTlerHeaderProvider;
 };

--- a/packages/restler/types/mod.ts
+++ b/packages/restler/types/mod.ts
@@ -13,6 +13,7 @@ export type { RESTlerEndpoint } from './RESTlerEndpoint.ts';
 export type { RESTlerEvents } from './RESTlerEvents.ts';
 export type {
   RESTlerHeaderProvider,
+  RESTlerHooks,
   Witness,
   WitnessInfo,
 } from './RESTlerHooks.ts';

--- a/packages/restler/types/mod.ts
+++ b/packages/restler/types/mod.ts
@@ -11,6 +11,11 @@ export type { RESTlerContentType } from './RESTlerContentType.ts';
 export type { RESTlerContentTypePayload } from './RESTlerContentTypePayload.ts';
 export type { RESTlerEndpoint } from './RESTlerEndpoint.ts';
 export type { RESTlerEvents } from './RESTlerEvents.ts';
+export type {
+  RESTlerHeaderProvider,
+  Witness,
+  WitnessInfo,
+} from './RESTlerHooks.ts';
 export type { RESTlerMethod } from './RESTlerMethod.ts';
 export type { RESTlerMethodPayload } from './RESTlerMethodPayload.ts';
 export type { RESTlerOptions } from './RESTlerOptions.ts';


### PR DESCRIPTION
## Summary
The propagator seam — completes the suite's observability rule (leaf = events, container = witness, propagator = pre-send headers):

- **`witness?: Witness`** — the suite convention (same structural shape norm ships). Every request runs through it: name `restler.<vendor> <METHOD>`, attributes vendor/method/raw path (never the resolved URL or query string). The entire request pipeline runs inside the witnessed window.
- **`headerProvider?: RESTlerHeaderProvider`** — per-request outbound headers, layered `defaults < provider < endpoint.headers` with auth always winning; no `{version}` replacement; a throwing provider is contained (request proceeds without its headers).

Composition property (tested): the provider fires **inside** the witnessed window, so `tracer.propagation` (tracer ≥ 0.5, PR #163) emits a `traceparent` carrying that request's own CLIENT span. Zero imports in either direction; wiring is two lines at the composition root:

```ts
const api = new GitHubAPI(token, {
  witness: tracer.wrapClient,
  headerProvider: tracer.propagation,
});
```

Both options validated at construction (function or absent → else `RESTlerConfigError`). Types exported: `Witness`, `WitnessInfo`, `RESTlerHeaderProvider`. README: Configuration table + Observability section rewritten around the hooks.

## Tests
`tests/RESTlerHooks.test.ts` — provider headers on the wire + fresh per request, precedence layers, auth not clobbered, throwing provider contained, witness lifecycle/info/attributes, provider-inside-witness ordering, error passthrough, non-function rejection, no-hooks baseline. Green on deno (12 steps), bun (10), node (10); pre-existing local unix-socket/TLS failures unchanged (pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)