### PR TITLE
feat(compat): report the actual bound port on WebServer

### DIFF
--- a/packages/compat/webserver/WebServer.test.ts
+++ b/packages/compat/webserver/WebServer.test.ts
@@ -2799,6 +2799,10 @@ h87g/qBXJrxZ7o+w+KxL/Q==
           throw new Error('Address should be null before starting');
         }
 
+        if (activeServer.port !== null) {
+          throw new Error('port should be null before starting');
+        }
+
         await activeServer.start();
         await delay(100);
 
@@ -2808,11 +2812,65 @@ h87g/qBXJrxZ7o+w+KxL/Q==
         if (!address) {
           throw new Error('Address should be set after starting');
         }
-        // Should contain localhost and some port number
-        if (!address.startsWith('localhost:')) {
+        // The ACTUAL bound port, not the configured 0.
+        const boundPort = activeServer.port;
+        if (boundPort === null || boundPort === 0) {
           throw new Error(
-            `Address should start with 'localhost:', got '${address}'`,
+            `port should report the OS-assigned port, got ${boundPort}`,
           );
+        }
+        if (address !== `localhost:${boundPort}`) {
+          throw new Error(
+            `Address should report the bound port, got '${address}'`,
+          );
+        }
+
+        // And the reported port must actually be reachable.
+        const response = await fetch(`http://localhost:${boundPort}/`);
+        if (await response.text() !== 'OK') {
+          throw new Error('Reported port did not serve the handler');
+        }
+
+        // Stopping clears the bound values.
+        await activeServer.stop(false);
+        await delay(100);
+        if (activeServer.port !== null) {
+          throw new Error('port should reset to null after stop');
+        }
+      });
+
+      it('should report the CONFIGURED port unchanged when explicit', async () => {
+        const port = getNextPort();
+        activeServer = new WebServer('Test', {
+          mode: 'TCP',
+          port,
+          hostname: 'localhost',
+          handler: () => new Response('OK'),
+        });
+        await activeServer.start();
+        await delay(100);
+        if (activeServer.port !== port) {
+          throw new Error(
+            `Expected port ${port}, got ${activeServer.port}`,
+          );
+        }
+        if (activeServer.address !== `localhost:${port}`) {
+          throw new Error(`Unexpected address '${activeServer.address}'`);
+        }
+      });
+
+      it('should return null port in UNIX mode', async () => {
+        if (RUNTIME === 'NODE') return; // unix sockets unsupported on node
+        const socketPath = `/tmp/test-port-getter-${Date.now()}.sock`;
+        activeServer = new WebServer('Test', {
+          mode: 'UNIX',
+          unixSocketPath: socketPath,
+          handler: () => new Response('OK'),
+        });
+        await activeServer.start();
+        await delay(100);
+        if (activeServer.port !== null) {
+          throw new Error('port must be null in UNIX mode');
         }
       });
     });

--- a/packages/compat/webserver/WebServer.ts
+++ b/packages/compat/webserver/WebServer.ts
@@ -419,11 +419,28 @@ export class WebServer<T = unknown> {
 
     if (this.mode === 'TCP') {
       const tcpOptions = this.options as ServerOptions<'TCP'>;
-      return `${tcpOptions.hostname}:${tcpOptions.port}`;
+      return `${tcpOptions.hostname}:${this.__boundPort ?? tcpOptions.port}`;
     } else {
       const unixOptions = this.options as ServerOptions<'UNIX'>;
       return unixOptions.unixSocketPath;
     }
+  }
+
+  /**
+   * The ACTUAL bound TCP port, or `null` when the server is not running
+   * or listens on a unix socket. With `port: 0` this is how you learn
+   * which port the OS picked:
+   *
+   * ```typescript
+   * const server = new WebServer('t', { mode: 'TCP', port: 0, handler });
+   * await server.start();
+   * await fetch(`http://localhost:${server.port}/`);
+   * ```
+   */
+  public get port(): number | null {
+    if (this._state !== 'RUNNING' || this.mode !== 'TCP') return null;
+    return this.__boundPort ??
+      (this.options as ServerOptions<'TCP'>).port ?? null;
   }
 
   /**
@@ -442,6 +459,18 @@ export class WebServer<T = unknown> {
     | InstanceType<typeof nodeHttp.Server>
     | InstanceType<typeof nodeHttps.Server>
     | null = null;
+
+  /**
+   * The ACTUAL bound TCP port, captured at listen time. This is what
+   * makes `port: 0` usable: the runtime picks a free port, and
+   * {@link address} / {@link port} report the real one instead of the
+   * configured `0`. The HOSTNAME stays the configured one — runtimes
+   * report resolved loopback literals (`::1`) where users configured
+   * `localhost`, and the display contract predates this field.
+   * `null` while stopped and in UNIX mode.
+   * @private
+   */
+  private __boundPort: number | null = null;
 
   /**
    * Registry of event listeners keyed by event name.
@@ -887,6 +916,7 @@ export class WebServer<T = unknown> {
           );
         }
         this._state = 'STOPPED';
+        this.__boundPort = null;
         this._emit('onClose', this.name, this.mode);
       }).catch((error) => {
         this._state = 'RUNNING';
@@ -1433,6 +1463,14 @@ export class WebServer<T = unknown> {
     this._client = Bun.serve(
       options as unknown as Parameters<typeof Bun.serve>[0],
     );
+    if (this.mode === 'TCP') {
+      // Bun's handle exposes the ACTUAL bound port (the minimal handle
+      // type omits it to keep `typeof Bun` out of public types).
+      const bound = this._client as unknown as { port?: number };
+      if (typeof bound.port === 'number') {
+        this.__boundPort = bound.port;
+      }
+    }
     // Bun.serve is synchronously listening by the time it returns; no
     // microtask-bind race like Deno or Node, so resolve immediately.
     return Promise.resolve();
@@ -1635,7 +1673,14 @@ export class WebServer<T = unknown> {
     // ECONNREFUSED. We register an `onListen` callback that resolves a
     // promise once the listener is actually accepting connections.
     const ready = new Promise<void>((resolve) => {
-      options.onListen = () => resolve();
+      options.onListen = (localAddr: unknown) => {
+        // TCP gives a NetAddr ({ hostname, port }); unix gives a path.
+        const addr = localAddr as { port?: number };
+        if (typeof addr?.port === 'number') {
+          this.__boundPort = addr.port;
+        }
+        resolve();
+      };
     });
     this._client = Deno.serve(options, denoProcessor);
     return ready;
@@ -1872,7 +1917,14 @@ export class WebServer<T = unknown> {
           tcpOptions.port,
           tcpOptions.hostname,
           tcpOptions.backlog,
-          () => resolve(),
+          () => {
+            // `address()` is an AddressInfo object once listening on TCP.
+            const bound = server.address();
+            if (bound !== null && typeof bound === 'object') {
+              this.__boundPort = bound.port;
+            }
+            resolve();
+          },
         );
       } else {
         const unixOptions = this.options as ServerOptions<'UNIX'>;

--- a/packages/compat/webserver/types/ServerOptions.ts
+++ b/packages/compat/webserver/types/ServerOptions.ts
@@ -32,7 +32,11 @@ import type { WebSocketHandler } from './WebSocketHandler.ts';
 export type ServerOptions<M extends ServerMode = ServerMode, T = unknown> = (
   & (M extends 'TCP' ? {
       mode: 'TCP';
-      /** 0–65535. `0` picks a random free port. @default 8008 */
+      /**
+       * 0–65535. `0` picks a random free port — read the ACTUAL one from
+       * the server's `port` / `address` getters after `start()`.
+       * @default 8008
+       */
       port?: number;
       /** `'0.0.0.0'` for all IPv4, `'::'` for all IPv6. @default 'localhost' */
       hostname?: string;


### PR DESCRIPTION
## Summary
`port: 0` has always bound correctly, but `WebServer.address` echoed the *configured* options — callers got `localhost:0` back with no way to discover the real port (the reason rAPId's scratch prototype grew its race-prone `FreePort.ts`, and the same pattern every consumer reinvents).

- Capture the bound TCP port at listen time on all three runtimes: Deno's `onListen` addr, Bun's serve handle, Node's `server.address()`.
- `address` now reports the bound port. The **hostname stays the configured one** — runtimes resolve `localhost` to loopback literals (`::1`), and the documented `localhost:port` display contract predates this change.
- New `WebServer.port` getter — the actual bound TCP port; `null` when stopped or in UNIX mode.
- Bound port resets on `stop()`.

Backward compatible: explicit ports report exactly as before; only `port: 0` becomes truthful.

## Tests
Strengthened the existing port-0 edge-case test into the real contract (port getter non-zero, address matches, **reported port actually serves**, reset after stop), plus explicit-port and UNIX-mode getter cases. Green: deno 168 steps / bun 122 / node 119, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)