### PR TITLE
feat(cronus): cross-runtime minute-resolution cron scheduler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,7 @@ body:
         - ambient
         - cacher
         - compat
+        - cronus
         - crypt
         - doctor
         - drivers

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,6 +12,7 @@ body:
         - ambient
         - cacher
         - compat
+        - cronus
         - crypt
         - doctor
         - drivers

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -56,6 +56,14 @@ component_management:
         - type: project
           target: auto
           threshold: 1%
+    - component_id: cronus
+      name: cronus
+      paths:
+        - packages/cronus/**
+      statuses:
+        - type: project
+          target: auto
+          threshold: 1%
     - component_id: crypt
       name: crypt
       paths:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,9 @@
 'pkg: compat':
   - changed-files:
       - any-glob-to-any-file: packages/compat/**
+'pkg: cronus':
+  - changed-files:
+      - any-glob-to-any-file: packages/cronus/**
 'pkg: crypt':
   - changed-files:
       - any-glob-to-any-file: packages/crypt/**

--- a/.github/workspace-meta.json
+++ b/.github/workspace-meta.json
@@ -4,6 +4,7 @@
     "ambient": "Ambient",
     "cacher": "Cacher",
     "compat": "compat",
+    "cronus": "Cronus",
     "crypt": "crypt",
     "doctor": "Doctor",
     "drivers": "drivers",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,8 @@
 {
   "packages/ambient": "0.2.2",
   "packages/cacher": "1.0.0",
-  "packages/compat": "1.0.0",
+  "packages/compat": "1.1.0",
+  "packages/cronus": "0.0.0",
   "packages/crypt": "1.0.1",
   "packages/doctor": "1.0.0",
   "packages/drivers": "1.0.1",
@@ -12,9 +13,9 @@
   "packages/oql": "1.0.0",
   "packages/pact": "0.4.2",
   "packages/radrouter": "1.0.1",
-  "packages/restler": "1.0.1",
+  "packages/restler": "1.1.0",
   "packages/rpc": "1.0.1",
   "packages/slogger": "1.1.2",
-  "packages/tracer": "0.4.1",
+  "packages/tracer": "0.5.0",
   "packages/utils": "1.0.1"
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ published to [JSR](https://jsr.io) under the `@tundralibs` scope.
 - **[Ambient](packages/ambient/README.md)** — Cross-runtime request-scoped context over AsyncLocalStorage — correlation/trace ids and custom fields that survive await, no threading
 - **[Cacher](packages/cacher/README.md)** — Cross-runtime caching with a unified API over Memory, Redis, and Memcached engines
 - **[compat](packages/compat/README.md)** — Compatibility layer smoothing API differences across Deno, Bun, and Node.js
+- **[Cronus](packages/cronus/README.md)** — Cross-runtime minute-resolution cron scheduler — tick-and-match (impossible expressions never crash), per-job overlap prevention, cron/run-once/run-now triggers.
 - **[crypt](packages/crypt/README.md)** — Cross-runtime cryptography — hashing, AES/RSA encryption, HMAC/RSA signing, JWT, OTP, key derivation, and secure random
 - **[Doctor](packages/doctor/README.md)** — Decorator-driven dependency injection with Singleton, Scoped, and Transient vial lifecycles. The Doctor prescribes vials, dispenses doses, and treats patients.
 - **[drivers](packages/drivers/README.md)** — Cross-runtime connection drivers for SQL (PostgreSQL, MariaDB/MySQL, SQLite), MongoDB, Redis, and Memcached

--- a/packages/cronus/Cronus.test.ts
+++ b/packages/cronus/Cronus.test.ts
@@ -1,0 +1,615 @@
+/**
+ * @fileoverview The scheduler: registration + validation, run-now
+ * (`trigger`), the overlap guard (a job in flight is not re-entered),
+ * one-shot auto-removal, the event lifecycle, and error isolation.
+ * Firing logic is tested via `trigger` and the pure matcher — no test
+ * waits a real minute.
+ * @module
+ */
+
+import * as asserts from '@std/asserts';
+import { afterEach, describe, it } from '@tundralibs/compat/test';
+import { Cronus } from './mod.ts';
+import {
+  DuplicateJobError,
+  InvalidActionError,
+  InvalidScheduleError,
+  JobNotFoundError,
+} from './errors/mod.ts';
+
+const defer = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('cronus.Cronus', () => {
+  let cron: Cronus;
+  afterEach(() => {
+    cron?.stop();
+  });
+
+  describe('registration', () => {
+    it('adds, reads, lists, and removes jobs', () => {
+      cron = new Cronus();
+      cron.add('a', '* * * * *', () => {});
+      cron.add('b', '0 6 * * *', () => {});
+      asserts.assertEquals(cron.size, 2);
+      asserts.assert(cron.has('a'));
+      asserts.assertEquals(cron.get('a').schedule, '* * * * *');
+      asserts.assertEquals(cron.list().map((j) => j.name).sort(), ['a', 'b']);
+      cron.remove('a');
+      asserts.assert(!cron.has('a'));
+      asserts.assertEquals(cron.size, 1);
+    });
+
+    it('validates loudly', () => {
+      cron = new Cronus();
+      cron.add('dup', '* * * * *', () => {});
+      asserts.assertThrows(
+        () => cron.add('dup', '* * * * *', () => {}),
+        DuplicateJobError,
+      );
+      asserts.assertThrows(
+        () => cron.add('bad', 'not a cron', () => {}),
+        InvalidScheduleError,
+      );
+      asserts.assertThrows(
+        () => cron.add('nofn', '* * * * *', 'x' as unknown as () => void),
+        InvalidActionError,
+      );
+      asserts.assertThrows(() => cron.get('missing'), JobNotFoundError);
+      asserts.assertThrows(() => cron.remove('missing'), JobNotFoundError);
+      asserts.assertThrows(() => cron.enable('missing'), JobNotFoundError);
+    });
+
+    it('enable/disable toggles the flag', () => {
+      cron = new Cronus();
+      cron.add('a', '* * * * *', () => {}, { enabled: false });
+      asserts.assertEquals(cron.get('a').enabled, false);
+      cron.enable('a');
+      asserts.assertEquals(cron.get('a').enabled, true);
+      cron.disable('a');
+      asserts.assertEquals(cron.get('a').enabled, false);
+    });
+  });
+
+  describe('trigger (run-now)', () => {
+    it('runs a job immediately, bypassing the schedule', async () => {
+      cron = new Cronus();
+      let ran = 0;
+      cron.add('now', '0 0 1 1 *', () => { // Jan 1 — would rarely fire
+        ran++;
+      });
+      const fired = await cron.trigger('now');
+      asserts.assertEquals(fired, true);
+      asserts.assertEquals(ran, 1);
+      asserts.assertEquals(cron.get('now').runCount, 1);
+    });
+
+    it('runs even a DISABLED job', async () => {
+      cron = new Cronus();
+      let ran = false;
+      cron.add('d', '* * * * *', () => {
+        ran = true;
+      }, { enabled: false });
+      asserts.assertEquals(await cron.trigger('d'), true);
+      asserts.assert(ran);
+    });
+
+    it('marks the run as triggered in the context', async () => {
+      cron = new Cronus();
+      let sawTriggered: boolean | undefined;
+      cron.add('t', '* * * * *', (ctx) => {
+        sawTriggered = ctx.triggered;
+      });
+      await cron.trigger('t');
+      asserts.assertEquals(sawTriggered, true);
+    });
+
+    it('throws for an unknown job', async () => {
+      cron = new Cronus();
+      await asserts.assertRejects(
+        () => cron.trigger('ghost'),
+        JobNotFoundError,
+      );
+    });
+  });
+
+  describe('overlap prevention', () => {
+    it('does not re-enter a job already running (trigger resolves false)', async () => {
+      cron = new Cronus();
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      cron.add('slow', '* * * * *', async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await defer(60);
+        concurrent--;
+      });
+      const first = cron.trigger('slow'); // in flight
+      await defer(10);
+      const second = await cron.trigger('slow'); // should be skipped
+      asserts.assertEquals(second, false);
+      asserts.assert(cron.isRunning('slow'));
+      await first;
+      asserts.assertEquals(maxConcurrent, 1); // never concurrent
+      asserts.assertEquals(cron.get('slow').runCount, 1); // the skip did not count
+    });
+  });
+
+  describe('one-shot', () => {
+    it('runs once then auto-removes', async () => {
+      cron = new Cronus();
+      let ran = 0;
+      cron.addOnce('once', '* * * * *', () => {
+        ran++;
+      });
+      asserts.assert(cron.has('once'));
+      await cron.trigger('once');
+      asserts.assertEquals(ran, 1);
+      asserts.assert(!cron.has('once')); // gone after its single run
+    });
+
+    it('removes even when the single run throws', async () => {
+      cron = new Cronus();
+      cron.addOnce('boom', '* * * * *', () => {
+        throw new Error('once-and-done');
+      });
+      cron.on('error', () => {}); // swallow
+      await cron.trigger('boom');
+      asserts.assert(!cron.has('boom'));
+    });
+  });
+
+  describe('events & error isolation', () => {
+    it('emits run → success → finish with timing and result', async () => {
+      cron = new Cronus();
+      const seen: string[] = [];
+      let result: unknown;
+      cron.on('run', () => seen.push('run'));
+      cron.on('success', (_id, _n, _at, _ms, r) => {
+        seen.push('success');
+        result = r;
+      });
+      cron.on('finish', () => seen.push('finish'));
+      cron.add('ok', '* * * * *', () => 42);
+      await cron.trigger('ok');
+      asserts.assertEquals(seen, ['run', 'success', 'finish']);
+      asserts.assertEquals(result, 42);
+    });
+
+    it('routes a throwing action to error (never escapes) then finish', async () => {
+      cron = new Cronus();
+      const seen: string[] = [];
+      let normalized: unknown;
+      cron.on('error', (_id, _n, _at, _ms, err) => {
+        seen.push('error');
+        normalized = err;
+      });
+      cron.on('finish', () => seen.push('finish'));
+      cron.add('bad', '* * * * *', () => {
+        throw new Error('kaput');
+      });
+      // trigger must NOT reject — the error is an event, not a throw.
+      const fired = await cron.trigger('bad');
+      asserts.assertEquals(fired, true);
+      asserts.assertEquals(seen, ['error', 'finish']);
+      asserts.assertEquals((normalized as Error).message, 'kaput');
+    });
+  });
+
+  describe('listener containment', () => {
+    // Silence the containment report and count invocations.
+    const muteConsole = () => {
+      const original = console.error;
+      let calls = 0;
+      console.error = () => {
+        calls++;
+      };
+      return { restore: () => (console.error = original), calls: () => calls };
+    };
+
+    it('a throwing run listener cannot wedge the job', async () => {
+      const mute = muteConsole();
+      try {
+        cron = new Cronus();
+        let ran = 0;
+        cron.on('run', () => {
+          throw new Error('bad listener');
+        });
+        cron.add('victim', '* * * * *', () => {
+          ran++;
+        });
+        // trigger resolves (never rejects), the action RAN, and the
+        // job is not stuck running.
+        asserts.assertEquals(await cron.trigger('victim'), true);
+        asserts.assertEquals(ran, 1);
+        asserts.assertEquals(cron.isRunning('victim'), false);
+        asserts.assertEquals(await cron.trigger('victim'), true);
+        asserts.assertEquals(ran, 2);
+        asserts.assert(mute.calls() >= 2); // contained + reported
+      } finally {
+        mute.restore();
+      }
+    });
+
+    it('a throwing success listener is not misclassified as job failure', async () => {
+      const mute = muteConsole();
+      try {
+        cron = new Cronus();
+        let errorEvent = false;
+        cron.on('success', () => {
+          throw new Error('listener bug');
+        });
+        cron.on('error', () => {
+          errorEvent = true;
+        });
+        cron.add('ok', '* * * * *', () => 42);
+        asserts.assertEquals(await cron.trigger('ok'), true);
+        asserts.assertEquals(errorEvent, false);
+      } finally {
+        mute.restore();
+      }
+    });
+
+    it('a throwing finish listener cannot block once-cleanup', async () => {
+      const mute = muteConsole();
+      try {
+        cron = new Cronus();
+        cron.on('finish', () => {
+          throw new Error('finish bug');
+        });
+        cron.addOnce('once', '* * * * *', () => {});
+        await cron.trigger('once');
+        asserts.assert(!cron.has('once'));
+      } finally {
+        mute.restore();
+      }
+    });
+
+    it('a throwing error listener leaves trigger resolved', async () => {
+      const mute = muteConsole();
+      try {
+        cron = new Cronus();
+        cron.on('error', () => {
+          throw new Error('error-listener bug');
+        });
+        cron.add('bad', '* * * * *', () => {
+          throw new Error('job failure');
+        });
+        asserts.assertEquals(await cron.trigger('bad'), true);
+        asserts.assertEquals(cron.isRunning('bad'), false);
+      } finally {
+        mute.restore();
+      }
+    });
+  });
+
+  describe('round-2 hardening', () => {
+    const mute = () => {
+      const original = console.error;
+      let calls = 0;
+      console.error = () => {
+        calls++;
+      };
+      return { restore: () => (console.error = original), calls: () => calls };
+    };
+
+    it('an ASYNC rejecting listener is contained (no unhandled rejection)', async () => {
+      const m = mute();
+      try {
+        cron = new Cronus();
+        cron.on('success', async () => {
+          throw new Error('async listener boom');
+        });
+        cron.add('j', '* * * * *', () => 42);
+        asserts.assertEquals(await cron.trigger('j'), true);
+        await defer(5); // let the rejection land in the isolation wrapper
+        asserts.assert(m.calls() >= 1); // reported, not fatal
+      } finally {
+        m.restore();
+      }
+    });
+
+    it('a re-entrant trigger from a success listener hits the guard', async () => {
+      cron = new Cronus();
+      let runs = 0;
+      let reentrant: boolean | undefined;
+      cron.add('j', '* * * * *', () => {
+        runs++;
+      });
+      cron.on('success', () => {
+        void cron.trigger('j').then((fired) => {
+          reentrant ??= fired;
+        });
+      });
+      await cron.trigger('j');
+      await defer(5);
+      asserts.assertEquals(reentrant, false); // guard held through emits
+      asserts.assertEquals(runs, 1);
+    });
+
+    it('a finish listener re-triggering a ONCE job cannot crash', async () => {
+      cron = new Cronus();
+      let outcome: unknown = 'pending';
+      cron.addOnce('o', '* * * * *', () => {});
+      cron.on('finish', () => {
+        void cron.trigger('o').then(
+          (fired) => (outcome = fired),
+          (err) => (outcome = err),
+        );
+      });
+      await cron.trigger('o');
+      await defer(5);
+      // Still registered during finish → guard says false; no rejection.
+      asserts.assertEquals(outcome, false);
+      asserts.assert(!cron.has('o')); // cleanup still happened after
+    });
+
+    it('a job mutating its scheduledAt cannot corrupt sibling matching', async () => {
+      class ManualCronus extends Cronus {
+        public tick(at: Date): void {
+          this._tick(at);
+        }
+      }
+      const manual = new ManualCronus();
+      let victimRan = false;
+      manual.add('evil', '30 10 * * *', (ctx) => {
+        ctx.scheduledAt.setMinutes(31);
+      });
+      manual.add('victim', '30 10 * * *', () => {
+        victimRan = true;
+      });
+      manual.tick(new Date(2026, 0, 1, 10, 30));
+      await defer(5);
+      asserts.assert(victimRan);
+    });
+
+    it('a job added DURING a tick does not run in that tick', () => {
+      class ManualCronus extends Cronus {
+        public tick(at: Date): void {
+          this._tick(at);
+        }
+      }
+      const manual = new ManualCronus();
+      let lateRan = false;
+      manual.add('first', '* * * * *', () => {
+        manual.add('late', '* * * * *', () => {
+          lateRan = true;
+        });
+      });
+      manual.tick(new Date(2026, 0, 1, 0, 0));
+      asserts.assertEquals(lateRan, false); // waits for the next minute
+      asserts.assert(manual.has('late'));
+    });
+
+    it('a forward-poisoned watermark self-heals (clock-change resync)', async () => {
+      class ManualCronus extends Cronus {
+        public tick(at: Date): void {
+          this._tick(at);
+        }
+      }
+      const manual = new ManualCronus();
+      let runs = 0;
+      manual.add('j', '* * * * *', () => {
+        runs++;
+      });
+      manual.tick(new Date(Date.now() + 365 * 24 * 3600 * 1000)); // +1 year
+      await defer(5);
+      asserts.assertEquals(runs, 1);
+      manual.tick(new Date()); // NOW — a year "behind" → resync, not wedge
+      await defer(5);
+      asserts.assertEquals(runs, 2);
+    });
+
+    it('off(original) removes a once listener (wrapper translation)', async () => {
+      cron = new Cronus();
+      let fired = 0;
+      const listener = () => {
+        fired++;
+      };
+      cron.once('success', listener);
+      cron.off('success', listener);
+      cron.add('j', '* * * * *', () => {});
+      await cron.trigger('j');
+      asserts.assertEquals(fired, 0);
+    });
+
+    it('a throwing listener does not stop OTHER listeners (isolation)', async () => {
+      const m = mute();
+      try {
+        cron = new Cronus();
+        let secondRan = false;
+        cron.on('success', () => {
+          throw new Error('first listener');
+        });
+        cron.on('success', () => {
+          secondRan = true;
+        });
+        cron.add('j', '* * * * *', () => {});
+        await cron.trigger('j');
+        asserts.assertEquals(secondRan, true);
+      } finally {
+        m.restore();
+      }
+    });
+  });
+
+  describe('registration identity', () => {
+    it('a stale once-run cannot delete a NEW same-name job', async () => {
+      cron = new Cronus();
+      cron.addOnce('x', '* * * * *', async () => {
+        await defer(60);
+      });
+      const inflight = cron.trigger('x');
+      await defer(10);
+      cron.remove('x'); // replace mid-flight
+      cron.add('x', '0 6 * * *', () => {});
+      await inflight; // old once-run settles
+      asserts.assert(cron.has('x')); // the NEW registration survives
+      asserts.assertEquals(cron.get('x').schedule, '0 6 * * *');
+    });
+  });
+
+  describe('snapshots', () => {
+    it('get() returns copies — mutating lastRun cannot corrupt state', async () => {
+      cron = new Cronus();
+      cron.add('j', '* * * * *', () => {});
+      await cron.trigger('j');
+      const info = cron.get('j');
+      const original = info.lastRun!.getTime();
+      info.lastRun!.setTime(0);
+      asserts.assertEquals(cron.get('j').lastRun!.getTime(), original);
+    });
+
+    it('lastRun/runCount stamp at run START (documented semantics)', async () => {
+      cron = new Cronus();
+      let during: { runCount: number; lastRun: Date | null } | undefined;
+      cron.add('j', '* * * * *', () => {
+        during = cron.get('j');
+      });
+      await cron.trigger('j');
+      asserts.assertEquals(during!.runCount, 1);
+      asserts.assert(during!.lastRun !== null);
+    });
+  });
+
+  describe('ticker', () => {
+    /** Drive the protected _tick seam from a controlled clock. */
+    class ManualCronus extends Cronus {
+      public tick(at: Date): void {
+        this._tick(at);
+      }
+    }
+    const minute = (n: number) => new Date(n * 60_000);
+
+    it('fires matching jobs and honours enabled', () => {
+      const manual = new ManualCronus();
+      let ran = 0;
+      manual.add('a', '* * * * *', () => {
+        ran++;
+      });
+      manual.add('b', '* * * * *', () => {
+        ran += 100;
+      }, { enabled: false });
+      manual.tick(minute(1000));
+      asserts.assertEquals(ran, 1); // a fired, disabled b did not
+    });
+
+    it('never evaluates the same minute twice (double-fire guard)', () => {
+      const manual = new ManualCronus();
+      let ran = 0;
+      manual.add('a', '* * * * *', () => {
+        ran++;
+      });
+      manual.tick(minute(1000));
+      manual.tick(minute(1000)); // duplicate boundary
+      manual.tick(new Date(1000 * 60_000 + 30_000)); // same minute, +30s
+      asserts.assertEquals(ran, 1);
+    });
+
+    it('never re-fires after a wall-clock step backwards', async () => {
+      const manual = new ManualCronus();
+      let ran = 0;
+      manual.add('a', '* * * * *', () => {
+        ran++;
+      });
+      manual.tick(minute(1000));
+      await defer(1); // let the sync run settle (running=false)
+      manual.tick(minute(998)); // NTP stepped back — must not re-fire
+      asserts.assertEquals(ran, 1);
+      manual.tick(minute(1001));
+      asserts.assertEquals(ran, 2);
+    });
+
+    it('skips a still-running job and resumes after it finishes', async () => {
+      const manual = new ManualCronus();
+      const skips: string[] = [];
+      manual.on('skip', (name) => skips.push(name));
+      let release!: () => void;
+      const gate = new Promise<void>((r) => (release = r));
+      let runs = 0;
+      manual.add('slow', '* * * * *', async () => {
+        runs++;
+        await gate;
+      });
+      manual.tick(minute(1)); // starts the slow run
+      manual.tick(minute(2)); // still running → skip
+      manual.tick(minute(3)); // still running → skip
+      asserts.assertEquals(runs, 1);
+      asserts.assertEquals(skips, ['slow', 'slow']);
+      release();
+      await defer(1);
+      manual.tick(minute(4)); // finished → resumes
+      asserts.assertEquals(runs, 2);
+    });
+
+    it('a throwing skip listener cannot kill the tick loop', async () => {
+      const original = console.error;
+      console.error = () => {};
+      try {
+        const manual = new ManualCronus();
+        let laterJobRan = false;
+        manual.on('skip', () => {
+          throw new Error('skip bug');
+        });
+        manual.add('slow', '* * * * *', async () => {
+          await defer(200);
+        });
+        manual.add('later', '* * * * *', () => {
+          laterJobRan = true;
+        });
+        manual.tick(minute(1)); // starts slow AND later
+        await defer(1); // later (sync) settles; slow stays in flight
+        laterJobRan = false;
+        manual.tick(minute(2)); // slow skips (listener throws), later must still run
+        asserts.assertEquals(laterJobRan, true);
+      } finally {
+        console.error = original;
+      }
+    });
+
+    it('a stale timer chain dies after stop()/start() (no double ticker)', () => {
+      const realSetTimeout = globalThis.setTimeout;
+      const arms: Array<() => void> = [];
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).setTimeout = (cb: () => void, _ms?: number) => {
+        arms.push(cb);
+        return 0;
+      };
+      try {
+        cron = new Cronus();
+        cron.add('a', '* * * * *', () => {});
+        cron.start();
+        asserts.assertEquals(arms.length, 1); // chain A armed
+        cron.stop();
+        cron.start();
+        asserts.assertEquals(arms.length, 2); // chain B armed
+        const before = arms.length;
+        arms[0]!(); // stale chain A fires — must NOT re-arm
+        asserts.assertEquals(arms.length, before);
+        arms[1]!(); // current chain B fires — re-arms exactly once
+        asserts.assertEquals(arms.length, before + 1);
+      } finally {
+        globalThis.setTimeout = realSetTimeout;
+      }
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('start()/stop() toggle active and are idempotent', () => {
+      cron = new Cronus();
+      asserts.assertEquals(cron.active, false);
+      cron.start().start();
+      asserts.assertEquals(cron.active, true);
+      cron.stop().stop();
+      asserts.assertEquals(cron.active, false);
+    });
+
+    it('static validators', () => {
+      asserts.assertEquals(Cronus.isValid('*/5 * * * *'), true);
+      asserts.assertEquals(Cronus.isValid('nope'), false);
+      asserts.assertEquals(
+        Cronus.matches('30 6 * * *', new Date(2026, 0, 1, 6, 30)),
+        true,
+      );
+    });
+  });
+});

--- a/packages/cronus/Cronus.ts
+++ b/packages/cronus/Cronus.ts
@@ -1,0 +1,584 @@
+/**
+ * @fileoverview {@link Cronus} — a cross-runtime, minute-resolution cron
+ * scheduler. Tick-and-match architecture: a self-correcting timer fires
+ * at each minute boundary and runs every job whose schedule matches the
+ * current time. It never computes a "next run", so an impossible
+ * expression (`0 0 30 2 *`) simply never fires rather than crashing, and
+ * there is no far-future timer to overflow.
+ *
+ * Like classic cron, minutes that pass while the process is blocked,
+ * suspended, or stopped are NOT replayed — there is no catch-up.
+ *
+ * @author TundraSoft
+ *
+ * @module
+ *
+ * @example
+ * ```typescript
+ * import { Cronus } from '@tundralibs/cronus';
+ *
+ * const cron = new Cronus();
+ * cron.on('error', (_id, name, _at, _ms, err) =>
+ *   console.error(`job ${name} failed:`, err.message));
+ *
+ * cron.add('cleanup', '0 * * * *', async () => {
+ *   await purgeExpired();
+ * });
+ *
+ * cron.start();
+ * ```
+ */
+
+import { type EventCallback, Events } from '@tundralibs/utils';
+import {
+  CronusError,
+  DuplicateJobError,
+  InvalidActionError,
+  JobNotFoundError,
+} from './errors/mod.ts';
+import { isValidSchedule, matches, parseSchedule } from './schedule.ts';
+import type {
+  CronusAction,
+  CronusEvents,
+  CronusJobInfo,
+  CronusJobOptions,
+  CronusOptions,
+  ParsedSchedule,
+} from './types/mod.ts';
+
+const MINUTE_MS = 60_000;
+
+/**
+ * A wall-clock step backwards of at most this many minutes is treated
+ * as jitter and deduplicated; a larger step is a clock CHANGE — the
+ * ticker resynchronises to the new time (without replaying anything).
+ */
+const CLOCK_JITTER_MINUTES = 2;
+
+/**
+ * A cross-runtime timer handle (Deno returns numbers; Node and Bun
+ * return Timeout objects).
+ */
+type TimerHandle = number | { unref?: () => void };
+
+/** A registered job — the scheduler's internal mutable record. */
+type CronusJob = {
+  name: string;
+  schedule: string;
+  action: CronusAction;
+  once: boolean;
+  enabled: boolean;
+  /** Guards against concurrent runs of the same job (overlap prevention). */
+  running: boolean;
+  runCount: number;
+  lastRun: Date | null;
+};
+
+/** `unref` a timer where the runtime supports it (no-op elsewhere). */
+function unrefTimer(handle: TimerHandle): void {
+  if (typeof handle === 'number') {
+    (globalThis as { Deno?: { unrefTimer?: (id: number) => void } })
+      .Deno?.unrefTimer?.(handle);
+  } else {
+    handle.unref?.();
+  }
+}
+
+/**
+ * The scheduler. Register jobs with {@link Cronus.add}, then
+ * {@link Cronus.start}. Concurrency-safe per job: while a job's action
+ * is running, matching ticks are SKIPPED — a job scheduled every minute
+ * that takes five minutes to run resumes on the sixth minute, never
+ * overlapping itself. (The guard is per registration: removing and
+ * re-adding a name while its old run is still in flight starts a fresh
+ * guard. It also assumes actions SETTLE — an action that never resolves
+ * wedges its job until `remove()` + `add()`.)
+ *
+ * Listeners are isolated: each listener is wrapped at registration, so
+ * one that throws synchronously OR rejects asynchronously is caught and
+ * reported via `console.error` — it never affects the run, other
+ * listeners, the ticker, or the process.
+ */
+export class Cronus extends Events<CronusEvents> {
+  private readonly __jobs: Map<string, CronusJob> = new Map();
+  private readonly __parsed: Map<string, ParsedSchedule> = new Map();
+  /** Original listener → isolation wrapper (lets `off(original)` work). */
+  private readonly __wrapped: WeakMap<EventCallback, EventCallback> =
+    new WeakMap();
+  private readonly __unref: boolean;
+  private __timer: TimerHandle | undefined;
+  private __active = false;
+  /** Invalidates in-flight timer chains on stop()/start(). */
+  private __generation = 0;
+  /** Last epoch-minute evaluated — guards against double evaluation. */
+  private __lastTickMinute = -1;
+
+  constructor(options: CronusOptions = {}) {
+    super();
+    this.__unref = options.unref ?? false;
+  }
+
+  /**
+   * Register a listener. The callback is wrapped for isolation: a sync
+   * throw or async rejection is caught and reported via
+   * `console.error`, never propagated.
+   */
+  public override on<K extends keyof CronusEvents>(
+    event: K,
+    callback: CronusEvents[K],
+  ): this;
+  public override on<K extends keyof CronusEvents>(
+    event: K,
+    callback: CronusEvents[K][],
+  ): this;
+  public override on(
+    event: string,
+    callback: EventCallback | EventCallback[],
+  ): this {
+    if (Array.isArray(callback)) {
+      for (const cb of callback) this.on(event as never, cb as never);
+      return this;
+    }
+    return super.on(event as never, this.__isolate(callback) as never);
+  }
+
+  /**
+   * Remove listener(s). Accepts the ORIGINAL callback passed to
+   * `on`/`once` (the isolation wrapper is resolved internally).
+   */
+  public override off<K extends keyof CronusEvents>(
+    event: K,
+    callback?: CronusEvents[K],
+  ): this;
+  public override off<K extends keyof CronusEvents>(
+    event: K,
+    callback?: CronusEvents[K][],
+  ): this;
+  public override off(
+    event: string,
+    callback?: EventCallback | EventCallback[],
+  ): this {
+    if (callback === undefined) return super.off(event as never);
+    if (Array.isArray(callback)) {
+      for (const cb of callback) this.off(event as never, cb as never);
+      return this;
+    }
+    return super.off(
+      event as never,
+      (this.__wrapped.get(callback) ?? callback) as never,
+    );
+  }
+
+  /**
+   * Register a one-shot listener (isolated like {@link Cronus.on});
+   * removable via `off(event, originalCallback)` before it fires.
+   */
+  public override once<K extends keyof CronusEvents>(
+    event: K,
+    callback: CronusEvents[K],
+  ): this;
+  public override once<K extends keyof CronusEvents>(
+    event: K,
+    callback: CronusEvents[K][],
+  ): this;
+  public override once(
+    event: string,
+    callback: EventCallback | EventCallback[],
+  ): this {
+    if (Array.isArray(callback)) {
+      for (const cb of callback) this.once(event as never, cb as never);
+      return this;
+    }
+    const isolated = this.__isolate(callback);
+    const wrapper: EventCallback = (...args: unknown[]) => {
+      super.off(event as never, wrapper as never);
+      return isolated(...args);
+    };
+    this.__wrapped.set(callback, wrapper);
+    return super.on(event as never, wrapper as never);
+  }
+
+  /** `true` while the ticker is running. */
+  public get active(): boolean {
+    return this.__active;
+  }
+
+  /** Number of registered jobs. */
+  public get size(): number {
+    return this.__jobs.size;
+  }
+
+  /**
+   * Register a job.
+   *
+   * @param name - Unique job name.
+   * @param schedule - A 5-field cron expression.
+   * @param action - Sync or async {@link CronusAction} to run on each
+   *   match. Actions must settle — a never-resolving action wedges its
+   *   job (overlap guard) until `remove()` + `add()`.
+   * @param options - See {@link CronusJobOptions}.
+   * @throws {DuplicateJobError} When `name` is already registered.
+   * @throws {InvalidScheduleError} When `schedule` is malformed.
+   * @throws {InvalidActionError} When `action` is not a function.
+   */
+  public add(
+    name: string,
+    schedule: string,
+    action: CronusAction,
+    options: CronusJobOptions = {},
+  ): this {
+    if (this.__jobs.has(name)) {
+      throw new DuplicateJobError(
+        `A job named '${name}' is already registered`,
+        { name },
+      );
+    }
+    if (typeof action !== 'function') {
+      throw new InvalidActionError(`Job '${name}' action must be a function`, {
+        name,
+      });
+    }
+    // Parse now — a bad schedule fails at registration, never silently.
+    this.__parsed.set(name, parseSchedule(schedule));
+    this.__jobs.set(name, {
+      name,
+      schedule,
+      action,
+      once: options.once ?? false,
+      enabled: options.enabled ?? true,
+      running: false,
+      runCount: 0,
+      lastRun: null,
+    });
+    return this;
+  }
+
+  /**
+   * Register a job that runs ONCE at its next matching minute, then
+   * auto-removes. Convenience for `add(..., { once: true })`.
+   *
+   * @throws {DuplicateJobError} When `name` is already registered.
+   * @throws {InvalidScheduleError} When `schedule` is malformed.
+   * @throws {InvalidActionError} When `action` is not a function.
+   */
+  public addOnce(name: string, schedule: string, action: CronusAction): this {
+    return this.add(name, schedule, action, { once: true });
+  }
+
+  /**
+   * Remove a job. A run already in flight is not interrupted — and its
+   * completion cannot touch a job registered later under the same name.
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  public remove(name: string): this {
+    if (!this.__jobs.has(name)) {
+      throw new JobNotFoundError(`No job registered under '${name}'`, {
+        name,
+      });
+    }
+    this.__jobs.delete(name);
+    this.__parsed.delete(name);
+    return this;
+  }
+
+  /** Whether a job is registered. */
+  public has(name: string): boolean {
+    return this.__jobs.has(name);
+  }
+
+  /**
+   * Read a job's public state as a {@link CronusJobInfo} snapshot
+   * (mutating the snapshot never affects the scheduler).
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  public get(name: string): CronusJobInfo {
+    return this.__info(this.__mustGet(name));
+  }
+
+  /** All jobs' public state (snapshots — see {@link Cronus.get}). */
+  public list(): CronusJobInfo[] {
+    return [...this.__jobs.values()].map((job) => this.__info(job));
+  }
+
+  /**
+   * Enable a disabled job.
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  public enable(name: string): this {
+    this.__mustGet(name).enabled = true;
+    return this;
+  }
+
+  /**
+   * Disable a job (skipped by the ticker; still runnable via
+   * {@link Cronus.trigger}).
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  public disable(name: string): this {
+    this.__mustGet(name).enabled = false;
+    return this;
+  }
+
+  /**
+   * Whether a job's action is currently running. (The flag stays `true`
+   * through that run's `success`/`error`/`finish` emissions.)
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  public isRunning(name: string): boolean {
+    return this.__mustGet(name).running;
+  }
+
+  /**
+   * Start the ticker. Aligns to the next minute boundary, then fires at
+   * each `:00`, self-correcting the phase against timer drift.
+   * Idempotent. A job is never fired for the minute in which `start()`
+   * is called, and minutes missed while stopped/blocked/suspended are
+   * not replayed — standard cron behaviour.
+   */
+  public start(): this {
+    if (this.__active) return this;
+    this.__active = true;
+    this.__generation += 1;
+    this.__scheduleTick(this.__generation);
+    return this;
+  }
+
+  /**
+   * Stop the ticker. Registrations survive; `start()` resumes. A run
+   * already in flight completes (it is not cancelled).
+   */
+  public stop(): this {
+    this.__active = false;
+    // Invalidate any timer chain that has already fired but not yet
+    // re-armed — otherwise a stop()+start() from inside a tick would
+    // leave two chains running.
+    this.__generation += 1;
+    if (this.__timer !== undefined) {
+      clearTimeout(this.__timer as number);
+      this.__timer = undefined;
+    }
+    return this;
+  }
+
+  /**
+   * Run a job NOW, bypassing its schedule. Respects the overlap guard:
+   * if the job is already running (including from inside that run's own
+   * event listeners), this is a no-op and resolves `false`. Otherwise
+   * it runs (awaited — a never-settling action hangs this await) and
+   * resolves `true`; the run itself never rejects — subscribe to
+   * `error` for failures. Works whether or not the ticker is started,
+   * and on disabled jobs.
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  public async trigger(name: string): Promise<boolean> {
+    const job = this.__mustGet(name);
+    if (job.running) return false;
+    await this.__run(job, new Date(), true);
+    return true;
+  }
+
+  /** Validate a cron expression without throwing (syntactic only). */
+  public static isValid(schedule: string): boolean {
+    return isValidSchedule(schedule);
+  }
+
+  /**
+   * Would `schedule` fire at `at` (default: now)?
+   *
+   * @throws {InvalidScheduleError} When `schedule` is malformed.
+   */
+  public static matches(schedule: string, at: Date = new Date()): boolean {
+    return matches(parseSchedule(schedule), at);
+  }
+
+  /**
+   * Evaluate one tick at `at`: run every enabled, non-running job whose
+   * schedule matches that minute. Each epoch minute is evaluated at
+   * most once; a small wall-clock step backwards (≤ 2 minutes — timer
+   * jitter, NTP nudge) is deduplicated, while a larger one is treated
+   * as a clock CHANGE and resynchronises the watermark (nothing is
+   * replayed). Jobs registered while a tick is being evaluated are not
+   * fired by that same tick.
+   *
+   * The built-in ticker calls this at each minute boundary; subclasses
+   * driving ticks from an external clock may call it directly.
+   */
+  protected _tick(at: Date): void {
+    const minute = Math.floor(at.getTime() / MINUTE_MS);
+    if (minute === this.__lastTickMinute) return;
+    if (
+      minute < this.__lastTickMinute &&
+      this.__lastTickMinute - minute <= CLOCK_JITTER_MINUTES
+    ) {
+      return;
+    }
+    this.__lastTickMinute = minute;
+    // Snapshot: registrations made DURING this tick wait for the next
+    // minute (a live Map iteration would run them immediately — and a
+    // self-re-registering job could loop forever inside one tick).
+    for (const job of [...this.__jobs.values()]) {
+      if (this.__jobs.get(job.name) !== job) continue; // removed mid-tick
+      if (!job.enabled) continue;
+      const parsed = this.__parsed.get(job.name);
+      if (parsed === undefined || !matches(parsed, at)) continue;
+      if (job.running) {
+        // Overlap prevented — the previous run has not finished.
+        this.__emit('skip', job.name, new Date(at.getTime()));
+        continue;
+      }
+      // Every job gets its OWN Date — an action or listener mutating
+      // its scheduledAt cannot corrupt sibling matching or timestamps.
+      void this.__run(job, new Date(at.getTime()), false);
+    }
+  }
+
+  /**
+   * Wrap a listener so a sync throw or async rejection is caught and
+   * reported, never propagated. Cached per original callback so
+   * registration dedupe and `off(original)` keep working.
+   */
+  private __isolate(callback: EventCallback): EventCallback {
+    let wrapped = this.__wrapped.get(callback);
+    if (wrapped === undefined) {
+      wrapped = (...args: unknown[]) => {
+        try {
+          const out = callback(...args) as unknown;
+          if (out instanceof Promise) {
+            out.catch((error) =>
+              console.error('[cronus] async listener rejected:', error)
+            );
+          }
+        } catch (error) {
+          console.error('[cronus] listener threw:', error);
+        }
+      };
+      this.__wrapped.set(callback, wrapped);
+    }
+    return wrapped;
+  }
+
+  /**
+   * Emit defensively. Listeners registered through {@link Cronus.on}/
+   * {@link Cronus.once} are individually isolated already; this is the
+   * outer belt for anything that reached the base class directly.
+   */
+  private __emit<K extends keyof CronusEvents>(
+    event: K,
+    ...args: Parameters<CronusEvents[K]>
+  ): void {
+    try {
+      this.emit(event, ...args);
+    } catch (error) {
+      console.error(`[cronus] '${String(event)}' listener threw:`, error);
+    }
+  }
+
+  /** Snapshot a {@link CronusJob} onto its public read-only view. */
+  private __info(job: CronusJob): CronusJobInfo {
+    return {
+      name: job.name,
+      schedule: job.schedule,
+      once: job.once,
+      enabled: job.enabled,
+      running: job.running,
+      runCount: job.runCount,
+      lastRun: job.lastRun === null ? null : new Date(job.lastRun.getTime()),
+    };
+  }
+
+  /**
+   * Fetch a job or throw.
+   *
+   * @throws {JobNotFoundError} When `name` is not registered.
+   */
+  private __mustGet(name: string): CronusJob {
+    const job = this.__jobs.get(name);
+    if (job === undefined) {
+      throw new JobNotFoundError(`No job registered under '${name}'`, {
+        name,
+      });
+    }
+    return job;
+  }
+
+  /**
+   * Self-correcting: arm the next tick at the next minute boundary.
+   * The `generation` token kills stale chains — a chain only re-arms
+   * while its generation is current.
+   */
+  private __scheduleTick(generation: number): void {
+    if (!this.__active || generation !== this.__generation) return;
+    const msToNextMinute = MINUTE_MS - (Date.now() % MINUTE_MS);
+    const timer = setTimeout(() => {
+      if (generation !== this.__generation) return; // stale chain — die
+      this._tick(new Date());
+      this.__scheduleTick(generation);
+    }, msToNextMinute);
+    if (this.__unref) unrefTimer(timer);
+    this.__timer = timer;
+  }
+
+  /**
+   * Run a job's action once with the full event lifecycle. Nothing in
+   * here can throw or reject: action errors are normalised and routed
+   * to the `error` event, listener errors are isolated. The overlap
+   * guard (`running`) is held through the emissions and once-cleanup
+   * happens last, so a listener re-triggering the job re-enters the
+   * guard instead of recursing.
+   */
+  private async __run(
+    job: CronusJob,
+    scheduledAt: Date,
+    triggered: boolean,
+  ): Promise<void> {
+    job.running = true;
+    job.runCount += 1;
+    job.lastRun = new Date();
+    const runId = crypto.randomUUID();
+    const started = Date.now();
+    this.__emit('run', runId, job.name, scheduledAt);
+    let result: unknown;
+    let failure: CronusError | undefined;
+    try {
+      result = await job.action({
+        runId,
+        name: job.name,
+        // The action's own copy — mutating it cannot skew event
+        // timestamps.
+        scheduledAt: new Date(scheduledAt.getTime()),
+        runCount: job.runCount,
+        triggered,
+      });
+    } catch (cause) {
+      // Errors NEVER escape a run — routed to the `error` event. A job
+      // that throws every time can never stop the ticker.
+      failure = cause instanceof CronusError ? cause : new CronusError(
+        cause instanceof Error ? cause.message : String(cause),
+        { job: job.name },
+        cause instanceof Error ? cause : undefined,
+      );
+    }
+    const elapsed = Date.now() - started;
+    if (failure === undefined) {
+      this.__emit('success', runId, job.name, scheduledAt, elapsed, result);
+    } else {
+      this.__emit('error', runId, job.name, scheduledAt, elapsed, failure);
+    }
+    this.__emit('finish', runId, job.name, scheduledAt, elapsed);
+    // Release the guard LAST: a listener above that re-triggered this
+    // job saw running=true and backed off (resolves false).
+    job.running = false;
+    // One-shot cleanup is identity-checked: a stale run can never
+    // delete a job registered later under the same name.
+    if (job.once && this.__jobs.get(job.name) === job) {
+      this.__jobs.delete(job.name);
+      this.__parsed.delete(job.name);
+    }
+  }
+}

--- a/packages/cronus/README.md
+++ b/packages/cronus/README.md
@@ -1,0 +1,113 @@
+# Cronus
+
+A cross-runtime, minute-resolution cron scheduler for Deno, Bun, and
+Node.js.
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## Overview
+
+Cronus runs jobs on standard 5-field cron expressions using a
+**tick-and-match** architecture: a self-correcting timer fires at each
+minute boundary and runs every job whose schedule matches the current
+time. It never computes a "next run", which has three practical
+consequences:
+
+- An impossible expression (`0 0 30 2 *` — Feb 30) simply never fires
+  instead of crashing the scheduler.
+- There is no far-future timer to overflow — a "fires in 40 days"
+  schedule is just a match that eventually comes true.
+- Drift self-corrects every tick (the next tick targets the next `:00`
+  boundary, not `now + 60s`).
+
+Jobs never overlap themselves: while a job's action is running, matching
+ticks are skipped — a job scheduled every minute that takes five minutes
+to run resumes on the sixth minute. The package is dependency-light: it
+imports only `@tundralibs/utils` (base error and event classes);
+`@tundralibs/compat` is used for cross-runtime tests only.
+
+## Modules
+
+| Module     | Description                                             | Documentation                                            |
+| ---------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| `Cronus`   | The scheduler — jobs, ticker, events, run-now           | This page                                                |
+| Schedules  | Cron expression syntax and matching semantics           | [Cronus-Schedule-Syntax](docs/Cronus-Schedule-Syntax.md) |
+| Jobs       | Job lifecycle, overlap prevention, events               | [Cronus-Jobs](docs/Cronus-Jobs.md)                       |
+| `./errors` | `CronusError` plus `InvalidScheduleError` etc.          | [Cronus-Errors](errors/Cronus-Errors.md)                 |
+| `./types`  | `CronusJobInfo`, `CronusRunContext`, `ParsedSchedule` … | —                                                        |
+
+## Installation
+
+**Deno:**
+
+```bash
+deno add @tundralibs/cronus
+```
+
+**Bun:**
+
+```bash
+bunx jsr add @tundralibs/cronus
+```
+
+**Node.js:**
+
+```bash
+npx jsr add @tundralibs/cronus
+```
+
+## Quick Start
+
+```typescript
+import { Cronus } from '@tundralibs/cronus';
+
+const cron = new Cronus();
+
+// Observability — actions and listeners can throw without harm:
+cron.on(
+  'error',
+  (_runId, name, _at, _ms, err) =>
+    console.error(`job ${name} failed:`, err.message),
+);
+cron.on('skip', (name) => console.warn(`${name} still running — tick skipped`));
+
+// Recurring: every hour on the hour.
+cron.add('hourly-cleanup', '0 * * * *', async () => {
+  await purgeExpired();
+});
+
+// Once: next 03:00, then auto-removes.
+cron.addOnce('migrate', '0 3 * * *', runMigration);
+
+cron.start();
+
+// Run-now, bypassing the schedule (false if already running):
+await cron.trigger('hourly-cleanup');
+```
+
+## Embedding
+
+By default the ticker holds the event loop (standalone-daemon
+friendly). When embedding inside a host that owns the lifecycle (an
+HTTP server), pass `{ unref: true }` so a pending tick never blocks
+shutdown — and call `stop()` on teardown. Caveat: with nothing else
+holding the loop, the process can exit mid-run of an async job; the
+host is responsible for draining in-flight work before exit:
+
+```typescript
+const cron = new Cronus({ unref: true });
+```
+
+## Related Documentation
+
+- [Cronus-Schedule-Syntax](docs/Cronus-Schedule-Syntax.md) - Cron
+  expression fields, names, steps, and POSIX matching semantics
+- [Cronus-Jobs](docs/Cronus-Jobs.md) - Job lifecycle, overlap
+  prevention, run-once/run-now, and the event surface
+- [Cronus-Errors](errors/Cronus-Errors.md) - The typed error hierarchy
+
+## License
+
+MIT

--- a/packages/cronus/deno.json
+++ b/packages/cronus/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@tundralibs/cronus",
+  "version": "0.0.0",
+  "description": "Cross-runtime minute-resolution cron scheduler \u2014 tick-and-match (impossible expressions never crash), per-job overlap prevention, cron/run-once/run-now triggers.",
+  "license": "MIT",
+  "exports": {
+    ".": "./mod.ts",
+    "./errors": "./errors/mod.ts",
+    "./types": "./types/mod.ts"
+  },
+  "imports": {}
+}

--- a/packages/cronus/docs/Cronus-Jobs.md
+++ b/packages/cronus/docs/Cronus-Jobs.md
@@ -1,0 +1,196 @@
+# Jobs
+
+Job lifecycle, overlap prevention, run-once/run-now, and the event
+surface.
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## Table of Contents
+
+- [Registering jobs](#registering-jobs)
+- [Overlap prevention](#overlap-prevention)
+- [Run-once and run-now](#run-once-and-run-now)
+- [The run context](#the-run-context)
+- [Events](#events)
+- [Error isolation](#error-isolation)
+- [API Reference](#api-reference)
+- [Related Documentation](#related-documentation)
+
+## Registering jobs
+
+```typescript
+import { Cronus } from '@tundralibs/cronus';
+
+const cron = new Cronus();
+
+cron.add('report', '0 6 * * *', async (ctx) => {
+  await buildReport();
+});
+
+// Registered disabled — the ticker skips it until enable():
+cron.add('beta', '*/5 * * * *', betaSync, { enabled: false });
+
+cron.start();
+```
+
+Registration is loud: a duplicate name, a malformed schedule, or a
+non-function action throw immediately (see
+[Cronus-Errors](../errors/Cronus-Errors.md)) — never a silent
+never-fires. Jobs can be added and removed while the ticker runs.
+
+## Overlap prevention
+
+A job never overlaps itself. While its action is running, matching
+ticks are **skipped** (a `skip` event fires per skipped tick). A job
+scheduled `* * * * *` whose run takes five minutes resumes on the
+sixth minute — there is no queue and no pile-up:
+
+```
+minute  1     2     3     4     5     6
+        run──────────────────────┐   run
+              skip  skip  skip  skip
+```
+
+Different jobs run independently — a slow job never delays others.
+The guard is **per registration**: removing a job and re-adding the
+same name while the old run is still in flight starts a fresh guard,
+so the old and new registrations can briefly run concurrently.
+
+## Run-once and run-now
+
+```typescript
+// Run ONCE at the next matching minute, then auto-remove:
+cron.addOnce('migrate', '0 3 * * *', runMigration);
+
+// Run NOW, bypassing the schedule:
+const fired = await cron.trigger('report');
+```
+
+`trigger()` respects the overlap guard — it resolves `false` (without
+running) when the job is already mid-run, `true` after the run
+settles. It works whether or not the ticker is started, and on
+disabled jobs. A one-shot job auto-removes after its single run —
+scheduled or triggered, success or error.
+
+Actions must **settle**: an action that never resolves wedges its job
+(the overlap guard skips every subsequent tick) and hangs any
+`trigger()` awaiting it — recovery is `remove()` + `add()`. Jobs
+registered while a tick is being evaluated wait for the next minute.
+
+## The run context
+
+Every run receives a `CronusRunContext`:
+
+| Field         | Meaning                                                          |
+| ------------- | ---------------------------------------------------------------- |
+| `runId`       | Unique id for THIS run — a fresh UUID per firing                 |
+| `name`        | The job's registered name                                        |
+| `scheduledAt` | The minute boundary the run fired for (call time on trigger)     |
+| `runCount`    | Runs STARTED since registration (failed runs and triggers count) |
+| `triggered`   | `true` when started via `trigger()`                              |
+
+## Events
+
+Metadata only — never the action's arguments. Listeners are
+**isolated**: each callback is wrapped at registration, so a sync
+throw or an async rejection is caught and reported via
+`console.error` — it never affects the run, the job's state, other
+listeners, the ticker, or the process. A listener that re-triggers
+its own job during `success`/`error`/`finish` hits the overlap guard
+(resolves `false`) — the guard releases only after the emissions.
+
+| Event     | Fires when                        | Arguments                                            |
+| --------- | --------------------------------- | ---------------------------------------------------- |
+| `run`     | a run starts                      | `(runId, name, scheduledAt)`                         |
+| `success` | a run returns                     | `(runId, name, scheduledAt, elapsedMs, result)`      |
+| `error`   | a run throws (never escapes)      | `(runId, name, scheduledAt, elapsedMs, CronusError)` |
+| `finish`  | a run settles (success or error)  | `(runId, name, scheduledAt, elapsedMs)`              |
+| `skip`    | a matching tick hit a running job | `(name, scheduledAt)`                                |
+
+## Error isolation
+
+An action that throws is routed to the `error` event as a
+`CronusError` (foreign errors are wrapped, the original preserved as
+`cause`) and then `finish` fires. The throw never escapes the run: a
+job that fails every single tick cannot stop the ticker or affect
+other jobs. `trigger()` follows the same rule — it resolves normally
+even when the action threw; subscribe to `error` for the failure.
+
+## API Reference
+
+### `add()`
+
+```typescript
+add(name: string, schedule: string, action: CronusAction, options?: CronusJobOptions): this
+```
+
+**Parameters:**
+
+- `name` - Unique job name.
+- `schedule` - A 5-field cron expression
+  ([syntax](Cronus-Schedule-Syntax.md)).
+- `action` - Sync or async function; receives a `CronusRunContext`.
+- `options` - `{ once?: boolean; enabled?: boolean }` (defaults:
+  `false`, `true`).
+
+**Throws:**
+
+- `DuplicateJobError` - When `name` is already registered.
+- `InvalidScheduleError` - When `schedule` is malformed.
+- `InvalidActionError` - When `action` is not a function.
+
+### `addOnce()`
+
+`add(..., { once: true })` — runs once at the next matching minute,
+then auto-removes. Same throws as `add()`.
+
+### `remove()` / `has()` / `get()` / `list()`
+
+Manage and inspect registrations. `get()`/`list()` return snapshots
+(`CronusJobInfo`) — mutating one never affects the scheduler.
+`lastRun` is when the most recent run **started** (not completed);
+`runCount` counts runs started, including failures and triggers.
+`remove()`/`get()` throw `JobNotFoundError` for unknown names. A
+removed job's in-flight run is not interrupted, and its completion
+cannot touch a job registered later under the same name.
+
+### `enable()` / `disable()` / `isRunning()`
+
+Toggle or inspect a job by name. Disabled jobs are skipped by the
+ticker but remain runnable via `trigger()`. All throw
+`JobNotFoundError` for unknown names.
+
+### `start()` / `stop()` / `active`
+
+Start aligns to the next minute boundary and is idempotent; a job is
+never fired for the minute in which `start()` was called. Minutes
+missed while stopped, blocked, or suspended are not replayed (classic
+cron behaviour — no catch-up). Stop clears the pending tick but does
+not cancel a run already in flight; registrations survive and
+`start()` resumes.
+
+### `trigger()`
+
+```typescript
+trigger(name: string): Promise<boolean>
+```
+
+Run now, bypassing the schedule. Resolves `false` when the job is
+already running (overlap guard), `true` after the run settles.
+
+**Throws:**
+
+- `JobNotFoundError` - When `name` is not registered.
+
+## Related Documentation
+
+- [Cronus-Schedule-Syntax](Cronus-Schedule-Syntax.md) - Expression
+  syntax and matching semantics
+- [Cronus-Errors](../errors/Cronus-Errors.md) - The typed error
+  hierarchy
+
+---
+
+[← Back to Cronus](../README.md)

--- a/packages/cronus/docs/Cronus-Schedule-Syntax.md
+++ b/packages/cronus/docs/Cronus-Schedule-Syntax.md
@@ -1,0 +1,165 @@
+# Schedule Syntax
+
+Cron expression fields, extensions, and matching semantics.
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## Table of Contents
+
+- [Fields](#fields)
+- [Field syntax](#field-syntax)
+- [Day-of-month vs day-of-week (POSIX OR)](#day-of-month-vs-day-of-week-posix-or)
+- [Matching semantics](#matching-semantics)
+- [Examples](#examples)
+- [API Reference](#api-reference)
+- [Related Documentation](#related-documentation)
+
+## Fields
+
+Standard 5-field cron, minute resolution — seconds and years are
+deliberately out of scope:
+
+```
+┌───────────── minute        (0-59)
+│ ┌─────────── hour          (0-23)
+│ │ ┌───────── day of month  (1-31)
+│ │ │ ┌─────── month         (1-12 or JAN-DEC)
+│ │ │ │ ┌───── day of week   (0-7 or SUN-SAT; 0 and 7 = Sunday)
+│ │ │ │ │
+* * * * *
+```
+
+## Field syntax
+
+| Form    | Meaning                           | Example                         |
+| ------- | --------------------------------- | ------------------------------- |
+| `*`     | every value                       | `* * * * *` — every minute      |
+| `n`     | exact value                       | `30 6 * * *` — 06:30 daily      |
+| `a-b`   | inclusive range                   | `0 9-17 * * *` — hourly 9→17    |
+| `a,b,c` | list (mixes with ranges/steps)    | `0,30 * * * *` — on :00 & :30   |
+| `*/n`   | every `n` from the field minimum  | `*/15 * * * *` — every 15 min   |
+| `a/n`   | every `n` starting at `a`         | `5/10 * * * *` — :05,:15,:25…   |
+| `a-b/n` | every `n` within the range        | `10-20/5 * * * *` — :10,:15,:20 |
+| names   | month/day names, case-insensitive | `0 0 * JAN mon-fri`             |
+
+Malformed fields throw
+[InvalidScheduleError](../errors/Cronus-Errors.md) at parse time —
+out-of-range values, zero steps (`*/0`), steps wider than their span
+(`*/60` in minutes), reversed (`5-1`) or half-open (`-5`, `5-`)
+ranges, and unknown names are all rejected loudly rather than
+silently mis-read. Names must be complete tokens: `JAN1` is an error,
+never a silent misparse. Ranges do not wrap — use a list (`SAT,SUN`)
+instead of `SAT-SUN`.
+
+## Day-of-month vs day-of-week (POSIX OR)
+
+When **both** day fields are restricted, a date matches if it
+satisfies **either** — the standard cron rule. As in Vixie cron, a
+field **beginning with `*`** (`*` or `*/n`) counts as UNrestricted:
+`0 0 */2 * 1` means "every 2nd day AND Monday", while `0 0 13 * 5`
+means "the 13th OR Friday":
+
+```
+0 0 13 * 5   →  midnight on the 13th OR any Friday
+```
+
+When only one is restricted, only that one applies (`0 0 15 * *` is
+strictly the 15th).
+
+## Matching semantics
+
+- **Local time.** Matching reads the host's local wall clock
+  (`getMinutes()`/`getHours()`/…). Note the usual cron caveat: a DST
+  spring-forward skips wall-clock times that never occur.
+- **Minute boundary.** The ticker fires at each `:00` second boundary
+  and evaluates every job against that minute; there is no
+  sub-minute scheduling.
+- **No next-run computation.** An expression that can never match
+  (e.g. `0 0 30 2 *`) parses fine and simply never fires — validity
+  is syntactic, fireability is not checked.
+- **Sunday.** Day-of-week accepts `0` and `7`; both fold to Sunday.
+
+## Examples
+
+| Expression         | Meaning                           |
+| ------------------ | --------------------------------- |
+| `* * * * *`        | every minute                      |
+| `*/5 * * * *`      | every 5 minutes                   |
+| `0 * * * *`        | hourly, on the hour               |
+| `30 6 * * *`       | daily at 06:30                    |
+| `0 3 * * MON`      | Mondays at 03:00                  |
+| `0 9-17/2 * * 1-5` | weekdays at 09,11,13,15,17:00     |
+| `0 0 1 JAN,JUL *`  | Jan 1 and Jul 1 at midnight       |
+| `0 0 13 * 5`       | the 13th OR any Friday (POSIX OR) |
+
+## API Reference
+
+### `parseSchedule()`
+
+Parse an expression into a `ParsedSchedule` (per-field value sets plus
+restriction flags).
+
+```typescript
+parseSchedule(expression: string): ParsedSchedule
+```
+
+**Parameters:**
+
+- `expression` - A 5-field cron expression.
+
+**Returns:** The compiled `ParsedSchedule`.
+
+**Throws:**
+
+- `InvalidScheduleError` - On the wrong field count or any malformed
+  field.
+
+**Example:**
+
+```typescript
+import { parseSchedule } from '@tundralibs/cronus';
+
+const schedule = parseSchedule('*/15 9-17 * * MON-FRI');
+```
+
+### `matches()`
+
+Does a `Date` (local time, minute resolution) satisfy a parsed
+schedule?
+
+```typescript
+matches(schedule: ParsedSchedule, date: Date): boolean
+```
+
+**Example:**
+
+```typescript
+import { matches, parseSchedule } from '@tundralibs/cronus';
+
+matches(parseSchedule('30 6 * * *'), new Date(2026, 0, 1, 6, 30)); // true
+```
+
+### `isValidSchedule()`
+
+Validate without throwing.
+
+```typescript
+isValidSchedule(expression: string): boolean
+```
+
+### Static conveniences
+
+`Cronus.isValid(schedule)` and `Cronus.matches(schedule, at?)` wrap the
+above for one-off checks without importing the engine functions.
+
+## Related Documentation
+
+- [Cronus-Jobs](Cronus-Jobs.md) - How schedules drive job runs
+- [Cronus-Errors](../errors/Cronus-Errors.md) - `InvalidScheduleError`
+  context shape
+
+---
+
+[← Back to Cronus](../README.md)

--- a/packages/cronus/errors/Base.ts
+++ b/packages/cronus/errors/Base.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview {@link CronusError} — the package base error.
+ *
+ * @module
+ */
+
+import { BaseError } from '@tundralibs/utils';
+
+/**
+ * Base class for every error thrown by `@tundralibs/cronus`. Extends
+ * `BaseError` so all package errors share the project-wide contract
+ * (typed `context`, `${var}` substitution, cause chains, JSON
+ * serialisation).
+ */
+export class CronusError<
+  M extends Record<string, unknown> = Record<string, unknown>,
+> extends BaseError<M> {
+  // `name` is set automatically by BaseError via this.constructor.name.
+}

--- a/packages/cronus/errors/Cronus-Errors.md
+++ b/packages/cronus/errors/Cronus-Errors.md
@@ -1,0 +1,83 @@
+# Errors
+
+The typed error hierarchy for `@tundralibs/cronus`.
+
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+
+## Table of Contents
+
+- [Hierarchy](#hierarchy)
+- [Classes](#classes)
+- [Catching](#catching)
+- [Related Documentation](#related-documentation)
+
+## Hierarchy
+
+All package errors extend `CronusError`, which extends `BaseError`
+from [Utils](../../utils/README.md) — so every error carries the
+project-wide contract: typed `context`, cause chains, and JSON
+serialisation.
+
+```
+BaseError (@tundralibs/utils)
+└── CronusError
+    ├── DuplicateJobError
+    ├── JobNotFoundError
+    ├── InvalidScheduleError
+    └── InvalidActionError
+```
+
+`CronusError` is also used directly to wrap foreign errors thrown by
+job actions before they surface on the `error` event (the original
+error is preserved as `cause`).
+
+## Classes
+
+| Class                  | Thrown by                                                              | Context                          |
+| ---------------------- | ---------------------------------------------------------------------- | -------------------------------- |
+| `DuplicateJobError`    | `add`/`addOnce` — name already registered                              | `{ name }`                       |
+| `JobNotFoundError`     | `get`/`remove`/`enable`/`disable`/`isRunning`/`trigger` — unknown name | `{ name }`                       |
+| `InvalidScheduleError` | `parseSchedule` (and therefore `add`) — malformed expression           | `{ expression, field?, reason }` |
+| `InvalidActionError`   | `add` — action is not a function                                       | `{ name }`                       |
+
+All registration errors are thrown synchronously at the call site —
+never deferred to tick time — so a mis-configured job fails the
+deploy, not the 03:00 run.
+
+## Catching
+
+Branch with `instanceof`; read structured data from `context`:
+
+```typescript
+import {
+  Cronus,
+  DuplicateJobError,
+  InvalidScheduleError,
+} from '@tundralibs/cronus';
+
+try {
+  cron.add(name, schedule, action);
+} catch (e) {
+  if (e instanceof InvalidScheduleError) {
+    console.error(
+      `bad schedule '${e.context.expression}': ${e.context.reason}`,
+    );
+  } else if (e instanceof DuplicateJobError) {
+    // idempotent re-registration — ignore
+  } else {
+    throw e;
+  }
+}
+```
+
+## Related Documentation
+
+- [Cronus-Jobs](../docs/Cronus-Jobs.md) - Where these errors surface
+- [Cronus-Schedule-Syntax](../docs/Cronus-Schedule-Syntax.md) - What
+  makes a schedule invalid
+
+---
+
+[← Back to Cronus](../README.md)

--- a/packages/cronus/errors/DuplicateJobError.ts
+++ b/packages/cronus/errors/DuplicateJobError.ts
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Error thrown when registering a job under a name that is
+ * already in use.
+ *
+ * @module
+ */
+
+import { CronusError } from './Base.ts';
+
+/**
+ * Structured context for {@link DuplicateJobError}.
+ *
+ * `name` is the already-registered job name.
+ */
+export type DuplicateJobContext = {
+  name: string;
+};
+
+/**
+ * Thrown by `Cronus.add`/`Cronus.addOnce` when a job is already
+ * registered under the same name. Catch this to deduplicate;
+ * otherwise let it surface — duplicate registration is almost always
+ * a setup bug.
+ */
+export class DuplicateJobError extends CronusError<DuplicateJobContext> {}

--- a/packages/cronus/errors/InvalidActionError.ts
+++ b/packages/cronus/errors/InvalidActionError.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Error thrown when a job's action is not callable.
+ *
+ * @module
+ */
+
+import { CronusError } from './Base.ts';
+
+/**
+ * Structured context for {@link InvalidActionError}.
+ *
+ * `name` is the job whose action failed validation.
+ */
+export type InvalidActionContext = {
+  name: string;
+};
+
+/** Thrown by `Cronus.add` when the supplied action is not a function. */
+export class InvalidActionError extends CronusError<InvalidActionContext> {}

--- a/packages/cronus/errors/InvalidScheduleError.ts
+++ b/packages/cronus/errors/InvalidScheduleError.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Error thrown when a cron expression cannot be parsed.
+ *
+ * @module
+ */
+
+import { CronusError } from './Base.ts';
+
+/**
+ * Structured context for {@link InvalidScheduleError}.
+ *
+ * `expression` is the offending schedule, `field` the cron field that
+ * failed (when the failure is field-specific), and `reason` the
+ * human-readable cause.
+ */
+export type InvalidScheduleContext = {
+  expression: string;
+  field?: string;
+  reason: string;
+};
+
+/**
+ * Thrown by `parseSchedule` (and therefore `Cronus.add`) when a cron
+ * expression is malformed — wrong field count, a value outside its
+ * range, a malformed range/step, or an unknown month/day name.
+ */
+export class InvalidScheduleError extends CronusError<InvalidScheduleContext> {}

--- a/packages/cronus/errors/JobNotFoundError.ts
+++ b/packages/cronus/errors/JobNotFoundError.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Error thrown when a lookup or mutation targets a job
+ * name that is not registered.
+ *
+ * @module
+ */
+
+import { CronusError } from './Base.ts';
+
+/**
+ * Structured context for {@link JobNotFoundError}.
+ *
+ * `name` is the name that resolved to nothing.
+ */
+export type JobNotFoundContext = {
+  name: string;
+};
+
+/**
+ * Thrown by `Cronus.get`/`remove`/`enable`/`disable`/`isRunning`/
+ * `trigger` when no job is registered under the given name.
+ */
+export class JobNotFoundError extends CronusError<JobNotFoundContext> {}

--- a/packages/cronus/errors/mod.ts
+++ b/packages/cronus/errors/mod.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Barrel re-exporting the public cronus error classes.
+ *
+ * @module
+ */
+
+export { CronusError } from './Base.ts';
+export {
+  type DuplicateJobContext,
+  DuplicateJobError,
+} from './DuplicateJobError.ts';
+export {
+  type InvalidActionContext,
+  InvalidActionError,
+} from './InvalidActionError.ts';
+export {
+  type InvalidScheduleContext,
+  InvalidScheduleError,
+} from './InvalidScheduleError.ts';
+export {
+  type JobNotFoundContext,
+  JobNotFoundError,
+} from './JobNotFoundError.ts';

--- a/packages/cronus/mod.ts
+++ b/packages/cronus/mod.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview `@tundralibs/cronus` — a cross-runtime, minute-resolution
+ * cron scheduler (Deno, Bun, Node). Tick-and-match: never computes a
+ * next-run, so impossible expressions never fire rather than crashing;
+ * per-job overlap prevention; cron, run-once, and run-now triggers.
+ *
+ * @module
+ */
+
+export { Cronus } from './Cronus.ts';
+export { isValidSchedule, matches, parseSchedule } from './schedule.ts';
+export {
+  CronusError,
+  type DuplicateJobContext,
+  DuplicateJobError,
+  type InvalidActionContext,
+  InvalidActionError,
+  type InvalidScheduleContext,
+  InvalidScheduleError,
+  type JobNotFoundContext,
+  JobNotFoundError,
+} from './errors/mod.ts';
+export type {
+  CronusAction,
+  CronusEvents,
+  CronusJobInfo,
+  CronusJobOptions,
+  CronusOptions,
+  CronusRunContext,
+  ParsedSchedule,
+} from './types/mod.ts';

--- a/packages/cronus/package.json
+++ b/packages/cronus/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tundralibs/cronus",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Cross-runtime minute-resolution cron scheduler — tick-and-match (impossible expressions never crash), per-job overlap prevention, cron/run-once/run-now triggers.",
+  "exports": {
+    ".": "./mod.ts",
+    "./errors": "./errors/mod.ts",
+    "./types": "./types/mod.ts"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@tundralibs/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@tundralibs/compat": "workspace:*"
+  }
+}

--- a/packages/cronus/schedule.test.ts
+++ b/packages/cronus/schedule.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @fileoverview The cron engine — field parsing (wildcards, ranges,
+ * steps, lists, names), the fixes over the naive predecessor (month
+ * off-by-one, dow=7, `-5` rejection), and POSIX dom/dow OR matching.
+ * @module
+ */
+
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { isValidSchedule, matches, parseSchedule } from './mod.ts';
+import { InvalidScheduleError } from './errors/mod.ts';
+
+/** A local Date at the given wall-clock parts (matcher reads local time). */
+const at = (
+  y: number,
+  mo: number,
+  d: number,
+  h: number,
+  mi: number,
+) => new Date(y, mo - 1, d, h, mi);
+
+describe('cronus.schedule', () => {
+  describe('parsing', () => {
+    it('expands * to the full field range', () => {
+      const s = parseSchedule('* * * * *');
+      asserts.assertEquals(s.minute.size, 60);
+      asserts.assertEquals(s.hour.size, 24);
+      asserts.assertEquals(s.dayOfMonth.size, 31);
+      asserts.assertEquals(s.month.size, 12);
+      asserts.assertEquals(s.dayOfWeek.size, 7);
+    });
+
+    it('handles ranges, lists, and steps', () => {
+      asserts.assertEquals([...parseSchedule('1-5 * * * *').minute], [
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]);
+      asserts.assertEquals([...parseSchedule('0,15,30,45 * * * *').minute], [
+        0,
+        15,
+        30,
+        45,
+      ]);
+      asserts.assertEquals([...parseSchedule('*/15 * * * *').minute], [
+        0,
+        15,
+        30,
+        45,
+      ]);
+      asserts.assertEquals([...parseSchedule('10-20/5 * * * *').minute], [
+        10,
+        15,
+        20,
+      ]);
+      // bare-number-with-step: 5/10 = 5,15,25,... to max
+      asserts.assertEquals([...parseSchedule('5/10 * * * *').minute], [
+        5,
+        15,
+        25,
+        35,
+        45,
+        55,
+      ]);
+    });
+
+    it('expands month and day NAMES (case-insensitive)', () => {
+      asserts.assertEquals([...parseSchedule('0 0 * jan,dec *').month], [
+        1,
+        12,
+      ]);
+      asserts.assertEquals([...parseSchedule('0 0 * * MON-FRI').dayOfWeek], [
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]);
+    });
+
+    it('accepts BOTH 0 and 7 for Sunday, folding 7 → 0', () => {
+      asserts.assertEquals([...parseSchedule('0 0 * * 7').dayOfWeek], [0]);
+      asserts.assertEquals([...parseSchedule('0 0 * * 0').dayOfWeek], [0]);
+      asserts.assertEquals([...parseSchedule('0 0 * * 0-7').dayOfWeek], [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+      ]);
+    });
+
+    it('rejects malformed fields loudly', () => {
+      const bad = [
+        '* * * *', // 4 fields
+        '60 * * * *', // minute out of range
+        '* 24 * * *', // hour out of range
+        '*/0 * * * *', // zero step
+        '-5 * * * *', // the naive predecessor silently read this as 0-5
+        '5- * * * *', // half range
+        '5-1 * * * *', // reversed range
+        '1/2/3 * * * *', // double step
+        '* * * FOO *', // unknown name
+        '', // empty
+        '0 0 * JAN1 *', // name glued to a digit — NOT November
+        '0 0 * 1JAN *', // digit glued to a name
+        '0 0 * * SUN1', // day name glued to a digit
+        '*/60 * * * *', // step exceeds the field span
+        '*/ * * * *', // missing step
+        '/5 * * * *', // missing value before step
+        '0 0 * * SAT-SUN', // wrapping name range (6-0)
+        '0 0 * MAY-JAN *', // wrapping month range
+      ];
+      for (const expr of bad) {
+        asserts.assertThrows(
+          () => parseSchedule(expr),
+          InvalidScheduleError,
+          undefined,
+          `expected '${expr}' to throw`,
+        );
+        asserts.assertEquals(isValidSchedule(expr), false);
+      }
+    });
+
+    it('step-span boundary: real spans reject, degenerate spans accept', () => {
+      // Accepting side of the cut — one typo away from regressing.
+      asserts.assertEquals([...parseSchedule('*/59 * * * *').minute], [0, 59]);
+      asserts.assertEquals([...parseSchedule('0/59 * * * *').minute], [0, 59]);
+      asserts.assertEquals([...parseSchedule('0 0 * */11 *').month], [1, 12]);
+      asserts.assertEquals([...parseSchedule('0 0 * * */7').dayOfWeek], [0]);
+      // Degenerate single-value spans: a step is a no-op, not an error.
+      asserts.assertEquals([...parseSchedule('59/1 * * * *').minute], [59]);
+      asserts.assertEquals([...parseSchedule('0-0/1 * * * *').minute], [0]);
+      asserts.assertEquals([...parseSchedule('59/60 * * * *').minute], [59]);
+      // Real spans one past the edge still reject.
+      asserts.assertEquals(isValidSchedule('*/60 * * * *'), false);
+      asserts.assertEquals(isValidSchedule('0 0 * */12 *'), false);
+    });
+
+    it('out-of-range bare atom with a step blames the ATOM, not the step', () => {
+      try {
+        parseSchedule('99/2 * * * *');
+        asserts.fail('should have thrown');
+      } catch (e) {
+        const err = e as InvalidScheduleError;
+        asserts.assert(
+          String(err.context.reason).includes("'99' outside 0-59"),
+        );
+      }
+    });
+
+    it('names in name-less fields get the whole-number error', () => {
+      try {
+        parseSchedule('MON * * * *');
+        asserts.fail('should have thrown');
+      } catch (e) {
+        const err = e as InvalidScheduleError;
+        asserts.assert(String(err.context.reason).includes('whole number'));
+        asserts.assertEquals(err.context.field, 'minute');
+      }
+    });
+
+    it('mixed name/number atoms parse Vixie-style', () => {
+      asserts.assertEquals([...parseSchedule('0 0 * * SUN-1').dayOfWeek], [
+        0,
+        1,
+      ]);
+      asserts.assertEquals([...parseSchedule('0 0 * * 0-SAT/2').dayOfWeek], [
+        0,
+        2,
+        4,
+        6,
+      ]);
+    });
+
+    it('carries expression/field/reason in the error context', () => {
+      try {
+        parseSchedule('0 0 * * SAT-SUN');
+        asserts.fail('should have thrown');
+      } catch (e) {
+        const err = e as InvalidScheduleError;
+        asserts.assertEquals(err.context.expression, '0 0 * * SAT-SUN');
+        asserts.assertEquals(err.context.field, 'day-of-week');
+        // The reason names the ORIGINAL token and explains the rule.
+        asserts.assert(String(err.context.reason).includes('SAT-SUN'));
+        asserts.assert(String(err.context.reason).includes('do not wrap'));
+      }
+    });
+
+    it('isValidSchedule true-branch; validity is syntactic only', () => {
+      asserts.assertEquals(isValidSchedule('59 23 31 12 7'), true);
+      // Impossible dates parse as valid — they just never match.
+      asserts.assertEquals(isValidSchedule('0 0 30 2 *'), true);
+      asserts.assertEquals(isValidSchedule('* * 31 4 *'), true);
+    });
+  });
+
+  describe('matching', () => {
+    it('matches minute/hour/day/month correctly (month is 1-based)', () => {
+      const s = parseSchedule('30 6 15 1 *'); // 06:30 on Jan 15
+      asserts.assert(matches(s, at(2026, 1, 15, 6, 30)));
+      asserts.assert(!matches(s, at(2026, 1, 15, 6, 31)));
+      // January, NOT December — the off-by-one the predecessor had.
+      asserts.assert(!matches(s, at(2026, 12, 15, 6, 30)));
+    });
+
+    it('day-of-week matches the right day', () => {
+      const s = parseSchedule('0 0 * * 1'); // Monday
+      asserts.assert(matches(s, at(2026, 8, 17, 0, 0))); // 2026-08-17 is Monday
+      asserts.assert(!matches(s, at(2026, 8, 18, 0, 0))); // Tuesday
+    });
+
+    it('POSIX: both dom AND dow restricted → OR', () => {
+      const s = parseSchedule('0 0 13 * 5'); // 13th OR any Friday
+      asserts.assert(matches(s, at(2026, 8, 13, 0, 0))); // the 13th (a Thu)
+      asserts.assert(matches(s, at(2026, 8, 14, 0, 0))); // a Friday (not 13th)
+      asserts.assert(!matches(s, at(2026, 8, 12, 0, 0))); // neither
+    });
+
+    it('one restricted, one * → AND (only the restricted one counts)', () => {
+      const dom = parseSchedule('0 0 15 * *'); // 15th, any weekday
+      asserts.assert(matches(dom, at(2026, 8, 15, 0, 0)));
+      asserts.assert(!matches(dom, at(2026, 8, 16, 0, 0)));
+    });
+
+    it('star-flag list cliff: *,5 unrestricted vs 5,* restricted', () => {
+      // Identical SETS, different flags — Vixie's first-char rule.
+      const starFirst = parseSchedule('0 0 *,5 * 1');
+      const starLater = parseSchedule('0 0 5,* * 1');
+      asserts.assertEquals(starFirst.domRestricted, false);
+      asserts.assertEquals(starLater.domRestricted, true);
+      const tue = at(2026, 8, 18, 0, 0); // Tuesday, not the 5th
+      asserts.assert(!matches(starFirst, tue)); // AND → Mondays only
+      asserts.assert(matches(starLater, tue)); // OR → every day
+    });
+
+    it('minute resolution: seconds/millis are ignored', () => {
+      const s = parseSchedule('30 6 * * *');
+      const withSeconds = new Date(2026, 0, 1, 6, 30, 59, 999);
+      const justBefore = new Date(2026, 0, 1, 6, 29, 59, 999);
+      asserts.assert(matches(s, withSeconds));
+      asserts.assert(!matches(s, justBefore));
+    });
+
+    it('Vixie star-flag: */n counts as UNrestricted → AND, not OR', () => {
+      // "every day-of-month step" + Monday = Mondays only (Vixie),
+      // NOT every day (which the naive not-'*' flag would produce).
+      const s = parseSchedule('0 0 */1 * 1');
+      asserts.assertEquals(s.domRestricted, false);
+      asserts.assertEquals(s.dowRestricted, true);
+      asserts.assert(matches(s, at(2026, 8, 17, 0, 0))); // Monday
+      asserts.assert(!matches(s, at(2026, 8, 18, 0, 0))); // Tuesday — must NOT fire
+    });
+
+    it('dow 7 matches a real Sunday date', () => {
+      const s = parseSchedule('0 0 * * 7');
+      asserts.assert(matches(s, at(2026, 8, 16, 0, 0))); // 2026-08-16 is Sunday
+      asserts.assert(!matches(s, at(2026, 8, 17, 0, 0)));
+    });
+
+    it('full-coverage restricted dow still ORs (POSIX footgun, pinned)', () => {
+      // '0-6' is "restricted" though it covers every day → the OR arm
+      // always matches → fires daily. Standard cron behaves the same.
+      const s = parseSchedule('0 0 13 * 0-6');
+      asserts.assert(matches(s, at(2026, 8, 14, 0, 0))); // not the 13th
+    });
+
+    it('impossible dates never match anything', () => {
+      const s = parseSchedule('* * 31 4 *'); // April 31
+      for (let d = 1; d <= 30; d++) {
+        asserts.assert(!matches(s, at(2026, 4, d, 12, 0)));
+      }
+    });
+  });
+});

--- a/packages/cronus/schedule.ts
+++ b/packages/cronus/schedule.ts
@@ -4,15 +4,16 @@
  * against it. Minute resolution (`minute hour day-of-month month
  * day-of-week`); seconds and years are deliberately out of scope.
  *
- * Field support: `*`, ranges `a-b`, steps `a/n` and `*​/n` and `a-b/n`,
- * lists `a,b,c`, plus month/day NAMES (`JAN`, `MON`). Day-of-week
+ * Field support: `*`, ranges `a-b`, steps (`a/n`, `a-b/n`, and steps on
+ * the `*` wildcard), lists `a,b,c`, plus month/day NAMES (`JAN`,
+ * `MON`). Day-of-week
  * accepts both `0` and `7` for Sunday. Names must be complete tokens —
  * `JAN1` is rejected, never silently misread.
  *
  * Semantics follow POSIX/Vixie cron: when BOTH day-of-month and
  * day-of-week are restricted, a date matches if it satisfies EITHER
  * (the standard OR rule) — and, as in Vixie cron, a field beginning
- * with `*` (including `*​/n`) counts as UNrestricted for this rule.
+ * with `*` (wildcard steps included) counts as UNrestricted for this rule.
  *
  * Validity is syntactic: an expression that can never match a real
  * date (`0 0 30 2 *` — Feb 30) parses fine and simply never fires.

--- a/packages/cronus/schedule.ts
+++ b/packages/cronus/schedule.ts
@@ -1,0 +1,278 @@
+/**
+ * @fileoverview The cron engine — pure, testable functions that parse a
+ * 5-field expression into a {@link ParsedSchedule} and match a `Date`
+ * against it. Minute resolution (`minute hour day-of-month month
+ * day-of-week`); seconds and years are deliberately out of scope.
+ *
+ * Field support: `*`, ranges `a-b`, steps `a/n` and `*​/n` and `a-b/n`,
+ * lists `a,b,c`, plus month/day NAMES (`JAN`, `MON`). Day-of-week
+ * accepts both `0` and `7` for Sunday. Names must be complete tokens —
+ * `JAN1` is rejected, never silently misread.
+ *
+ * Semantics follow POSIX/Vixie cron: when BOTH day-of-month and
+ * day-of-week are restricted, a date matches if it satisfies EITHER
+ * (the standard OR rule) — and, as in Vixie cron, a field beginning
+ * with `*` (including `*​/n`) counts as UNrestricted for this rule.
+ *
+ * Validity is syntactic: an expression that can never match a real
+ * date (`0 0 30 2 *` — Feb 30) parses fine and simply never fires.
+ *
+ * @module
+ */
+
+import { InvalidScheduleError } from './errors/mod.ts';
+import type { ParsedSchedule } from './types/mod.ts';
+
+/** Month names → 1-12 (JAN = 1). Case-insensitive on lookup. */
+const MONTH_NAMES: Readonly<Record<string, number>> = Object.freeze({
+  JAN: 1,
+  FEB: 2,
+  MAR: 3,
+  APR: 4,
+  MAY: 5,
+  JUN: 6,
+  JUL: 7,
+  AUG: 8,
+  SEP: 9,
+  OCT: 10,
+  NOV: 11,
+  DEC: 12,
+});
+
+/**
+ * Day names → 0-6 (SUN = 0). Cron also allows `7` for Sunday; the
+ * parser folds 7 → 0.
+ */
+const DAY_NAMES: Readonly<Record<string, number>> = Object.freeze({
+  SUN: 0,
+  MON: 1,
+  TUE: 2,
+  WED: 3,
+  THU: 4,
+  FRI: 5,
+  SAT: 6,
+});
+
+type FieldName = 'minute' | 'hour' | 'day-of-month' | 'month' | 'day-of-week';
+
+const FIELDS: ReadonlyArray<{ name: FieldName; min: number; max: number }> = [
+  { name: 'minute', min: 0, max: 59 },
+  { name: 'hour', min: 0, max: 23 },
+  { name: 'day-of-month', min: 1, max: 31 },
+  { name: 'month', min: 1, max: 12 },
+  { name: 'day-of-week', min: 0, max: 7 }, // 7 accepted, folded to 0
+];
+
+/** Compose and throw the package's schedule error in one place. */
+function fail(
+  expression: string,
+  field: FieldName | undefined,
+  reason: string,
+): never {
+  throw new InvalidScheduleError(`Invalid cron schedule: ${reason}`, {
+    expression,
+    field,
+    reason,
+  });
+}
+
+/**
+ * Reject anything that is not a base-10 non-negative integer string.
+ * @throws {InvalidScheduleError} When `token` is not a whole number.
+ */
+function toInt(token: string, field: FieldName, expression: string): number {
+  if (!/^\d+$/.test(token)) {
+    fail(expression, field, `'${token}' is not a whole number`);
+  }
+  return Number(token);
+}
+
+/**
+ * Resolve one atom — a complete token that is either a number or a
+ * month/day NAME. Names must match the whole token: `JAN1` fails here
+ * instead of silently splicing into `11`.
+ *
+ * @throws {InvalidScheduleError} When the token is neither.
+ */
+function atomValue(
+  token: string,
+  field: FieldName,
+  expression: string,
+): number {
+  if (/^\d+$/.test(token)) return Number(token);
+  const map = field === 'month'
+    ? MONTH_NAMES
+    : field === 'day-of-week'
+    ? DAY_NAMES
+    : undefined;
+  if (map === undefined) {
+    fail(expression, field, `'${token}' is not a whole number`);
+  }
+  const value = map[token.toUpperCase()];
+  if (value === undefined) {
+    fail(expression, field, `'${token}' is not a number or a valid name`);
+  }
+  return value;
+}
+
+/**
+ * Parse a single field into its set of matching values.
+ * @throws {InvalidScheduleError} On any malformed part.
+ */
+function parseField(
+  raw: string,
+  field: FieldName,
+  min: number,
+  max: number,
+  expression: string,
+): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of raw.split(',')) {
+    if (part === '') {
+      fail(expression, field, 'empty list item');
+    }
+    // Split step first: `<range>/<step>`.
+    const slash = part.split('/');
+    if (slash.length > 2) {
+      fail(expression, field, `too many '/' in '${part}'`);
+    }
+    const [rangePart, stepPart] = slash;
+    if (stepPart === '') {
+      fail(expression, field, `missing step after '/' in '${part}'`);
+    }
+    if (rangePart === '') {
+      fail(expression, field, `missing value before '/' in '${part}'`);
+    }
+    let step = 1;
+    if (stepPart !== undefined) {
+      step = toInt(stepPart, field, expression);
+      if (step < 1) {
+        fail(expression, field, `step must be >= 1 (got '${stepPart}')`);
+      }
+    }
+
+    let from: number;
+    let to: number;
+    if (rangePart === '*') {
+      from = min;
+      to = max;
+    } else if (rangePart!.includes('-')) {
+      const bounds = rangePart!.split('-');
+      if (bounds.length !== 2 || bounds[0] === '' || bounds[1] === '') {
+        fail(expression, field, `malformed range '${rangePart}'`);
+      }
+      from = atomValue(bounds[0]!, field, expression);
+      to = atomValue(bounds[1]!, field, expression);
+      if (from > to) {
+        fail(
+          expression,
+          field,
+          `'${rangePart}' is reversed — ranges do not wrap; use a list ` +
+            `(e.g. 'SAT,SUN' instead of 'SAT-SUN')`,
+        );
+      }
+    } else {
+      // A bare atom: a single value, or the start of an open step
+      // (`5/10` = 5,15,25,… up to max).
+      from = atomValue(rangePart!, field, expression);
+      to = stepPart !== undefined ? max : from;
+    }
+
+    if (from < min || from > max || to > max) {
+      fail(expression, field, `'${rangePart}' outside ${min}-${max}`);
+    }
+    // Reject a step wider than a REAL span (the '*/60' typo class). A
+    // degenerate single-value span ('59/1', '0-0/1') is an explicit
+    // single firing — any step is a no-op there, as in Vixie cron.
+    if (stepPart !== undefined && to > from && step > to - from) {
+      fail(
+        expression,
+        field,
+        `step ${step} exceeds the span of '${part}' — it would fire ` +
+          `only at ${from}`,
+      );
+    }
+    for (let v = from; v <= to; v += step) {
+      // Fold day-of-week 7 → 0 (both are Sunday).
+      values.add(field === 'day-of-week' && v === 7 ? 0 : v);
+    }
+  }
+  return values;
+}
+
+/**
+ * Parse a 5-field cron expression into a {@link ParsedSchedule}.
+ *
+ * Validity is syntactic only — an expression naming an impossible date
+ * (`0 0 30 2 *`) parses successfully and simply never matches.
+ *
+ * @throws {InvalidScheduleError} On the wrong field count or any
+ *   malformed field (out-of-range value, malformed/reversed range,
+ *   step of 0 or wider than its span, unknown or digit-glued name).
+ */
+export function parseSchedule(expression: string): ParsedSchedule {
+  if (typeof expression !== 'string' || expression.trim() === '') {
+    fail(String(expression), undefined, 'schedule must be a non-blank string');
+  }
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    fail(
+      expression,
+      undefined,
+      `expected 5 fields (minute hour day-of-month month day-of-week), got ${fields.length}`,
+    );
+  }
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = FIELDS.map((
+    spec,
+    i,
+  ) => parseField(fields[i]!, spec.name, spec.min, spec.max, expression));
+  return {
+    minute: minute!,
+    hour: hour!,
+    dayOfMonth: dayOfMonth!,
+    month: month!,
+    dayOfWeek: dayOfWeek!,
+    // Vixie star-flag rule: a field BEGINNING with '*' (so '*' and
+    // '*/n') is unrestricted for the dom/dow OR — '0 0 */2 * 1' means
+    // "every 2nd day AND Monday", not "OR Monday".
+    domRestricted: !fields[2]!.startsWith('*'),
+    dowRestricted: !fields[4]!.startsWith('*'),
+  };
+}
+
+/**
+ * Does `date` (local time, minute resolution) satisfy the
+ * {@link ParsedSchedule}?
+ *
+ * POSIX dom/dow rule: if both are restricted, EITHER matching is enough;
+ * otherwise both must match (a field beginning with `*` always counts
+ * as unrestricted — the Vixie star-flag rule).
+ */
+export function matches(schedule: ParsedSchedule, date: Date): boolean {
+  if (!schedule.minute.has(date.getMinutes())) return false;
+  if (!schedule.hour.has(date.getHours())) return false;
+  // getMonth() is 0-11; the month field is 1-12.
+  if (!schedule.month.has(date.getMonth() + 1)) return false;
+
+  const domOk = schedule.dayOfMonth.has(date.getDate());
+  const dowOk = schedule.dayOfWeek.has(date.getDay());
+  if (schedule.domRestricted && schedule.dowRestricted) {
+    return domOk || dowOk; // POSIX OR
+  }
+  return domOk && dowOk;
+}
+
+/**
+ * Validate an expression without throwing. `true` means syntactically
+ * valid — NOT that the schedule will ever fire (see
+ * {@link parseSchedule}).
+ */
+export function isValidSchedule(expression: string): boolean {
+  try {
+    parseSchedule(expression);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cronus/types/CronusAction.ts
+++ b/packages/cronus/types/CronusAction.ts
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview {@link CronusAction} — the callable a job runs.
+ *
+ * @module
+ */
+
+import type { CronusRunContext } from './CronusRunContext.ts';
+
+/**
+ * A job's action — sync or async; receives a {@link CronusRunContext}
+ * and its return value is surfaced on the `success` event.
+ */
+export type CronusAction = (
+  context: CronusRunContext,
+) => unknown | Promise<unknown>;

--- a/packages/cronus/types/CronusEvents.ts
+++ b/packages/cronus/types/CronusEvents.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview The event surface — metadata only, never the action's
+ * arguments or return payloads beyond what a monitor needs.
+ *
+ * @module
+ */
+
+import type { CronusError } from '../errors/mod.ts';
+
+/**
+ * Cronus lifecycle events.
+ *
+ * Listeners are ISOLATED per listener: each callback is wrapped at
+ * registration, so a sync throw OR an async rejection is caught and
+ * reported via `console.error` — it never affects the run, the job's
+ * state, other listeners, the ticker, or the process.
+ */
+export type CronusEvents = {
+  /** A run started. */
+  run: (runId: string, name: string, scheduledAt: Date) => void;
+  /** A run completed without throwing; `result` is the action's return. */
+  success: (
+    runId: string,
+    name: string,
+    scheduledAt: Date,
+    elapsed: number,
+    result: unknown,
+  ) => void;
+  /** A run threw; `error` is normalised to a {@link CronusError}. */
+  error: (
+    runId: string,
+    name: string,
+    scheduledAt: Date,
+    elapsed: number,
+    error: CronusError,
+  ) => void;
+  /** A run settled (success OR error) — the place for always-run teardown. */
+  finish: (
+    runId: string,
+    name: string,
+    scheduledAt: Date,
+    elapsed: number,
+  ) => void;
+  /** A scheduled tick matched but the job was already running (skipped). */
+  skip: (name: string, scheduledAt: Date) => void;
+};

--- a/packages/cronus/types/CronusJobInfo.ts
+++ b/packages/cronus/types/CronusJobInfo.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview {@link CronusJobInfo} — the public, read-only view of a
+ * job.
+ *
+ * @module
+ */
+
+/**
+ * Public snapshot of a job (returned by `get`/`list`). Mutating a
+ * snapshot never affects the scheduler.
+ */
+export type CronusJobInfo = {
+  name: string;
+  schedule: string;
+  once: boolean;
+  enabled: boolean;
+  /** `true` while the job's action is currently executing. */
+  running: boolean;
+  /**
+   * Runs STARTED since registration — includes runs that failed and
+   * manual `trigger()` runs.
+   */
+  runCount: number;
+  /**
+   * When the most recent run STARTED (not completed); `null` before
+   * the first run.
+   */
+  lastRun: Date | null;
+};

--- a/packages/cronus/types/CronusJobOptions.ts
+++ b/packages/cronus/types/CronusJobOptions.ts
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview {@link CronusJobOptions} — per-job registration options.
+ *
+ * @module
+ */
+
+/** Options accepted when registering a job. */
+export type CronusJobOptions = {
+  /**
+   * Run exactly ONCE — at the next matching minute — then auto-remove.
+   * @default false
+   */
+  once?: boolean;
+  /**
+   * Start enabled. A disabled job is skipped by the ticker but still
+   * runnable via `trigger()`.
+   * @default true
+   */
+  enabled?: boolean;
+};

--- a/packages/cronus/types/CronusOptions.ts
+++ b/packages/cronus/types/CronusOptions.ts
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview {@link CronusOptions} — scheduler configuration.
+ *
+ * @module
+ */
+
+export type CronusOptions = {
+  /**
+   * `unref` the internal timer so a running scheduler does NOT keep the
+   * process alive on its own. Leave `false` for a standalone cron
+   * daemon (the ticker holds the loop); set `true` when embedding
+   * inside a host that owns the lifecycle (e.g. an HTTP server) so
+   * shutdown is not blocked by a pending tick. Caveat: with nothing
+   * else holding the loop, the process can exit MID-RUN of an async
+   * job — the host, not cronus, is responsible for draining work
+   * before exit.
+   * @default false
+   */
+  unref?: boolean;
+};

--- a/packages/cronus/types/CronusRunContext.ts
+++ b/packages/cronus/types/CronusRunContext.ts
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview {@link CronusRunContext} — per-run metadata handed to a
+ * job action.
+ *
+ * @module
+ */
+
+/**
+ * The context handed to a job action on each run — enough to log,
+ * correlate, and measure without reaching back into the scheduler.
+ */
+export type CronusRunContext = {
+  /** Unique id for THIS run (not the job) — a fresh UUID per firing. */
+  runId: string;
+  /** The job's registered name. */
+  name: string;
+  /**
+   * The minute boundary this run fired for (a scheduled tick), or the
+   * call time for a run started via `trigger()`.
+   */
+  scheduledAt: Date;
+  /** Nth run of this job since registration (1-based; a manual trigger counts). */
+  runCount: number;
+  /** `true` when this run came from `trigger()` rather than the schedule. */
+  triggered: boolean;
+};

--- a/packages/cronus/types/ParsedSchedule.ts
+++ b/packages/cronus/types/ParsedSchedule.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview {@link ParsedSchedule} — the compiled form of a cron
+ * expression.
+ *
+ * @module
+ */
+
+/**
+ * One parsed schedule — a value set per field, plus restriction flags.
+ * Produced by `parseSchedule`, consumed by `matches`.
+ */
+export type ParsedSchedule = {
+  minute: Set<number>;
+  hour: Set<number>;
+  dayOfMonth: Set<number>;
+  month: Set<number>;
+  dayOfWeek: Set<number>;
+  /** `true` when the field was not `*` (drives the POSIX dom/dow OR). */
+  domRestricted: boolean;
+  dowRestricted: boolean;
+};

--- a/packages/cronus/types/mod.ts
+++ b/packages/cronus/types/mod.ts
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview Barrel re-exporting the public cronus type definitions.
+ *
+ * @module
+ */
+
+export type { CronusAction } from './CronusAction.ts';
+export type { CronusEvents } from './CronusEvents.ts';
+export type { CronusJobInfo } from './CronusJobInfo.ts';
+export type { CronusJobOptions } from './CronusJobOptions.ts';
+export type { CronusOptions } from './CronusOptions.ts';
+export type { CronusRunContext } from './CronusRunContext.ts';
+export type { ParsedSchedule } from './ParsedSchedule.ts';

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -76,6 +76,18 @@
         }
       ]
     },
+    "packages/cronus": {
+      "release-type": "node",
+      "component": "cronus",
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
     "packages/crypt": {
       "release-type": "node",
       "component": "crypt",


### PR DESCRIPTION
## @tundralibs/cronus — new package

Cross-runtime (Deno / Bun / Node 22+) **cron scheduler** built on the tick-and-match architecture: a self-correcting minute-boundary timer runs every job whose schedule matches the current time — no next-run computation, so impossible expressions (`0 0 30 2 *`) never fire instead of crashing, and there is no far-future timer to overflow.

### Features
- 5-field cron with ranges/steps/lists + `JAN`/`MON` names (whole-token — `JAN1` rejects, never misparses); dow accepts 0 and 7 for Sunday; POSIX/Vixie dom-dow OR semantics incl. the star-flag rule for `*/n`
- **Per-job overlap prevention**: a matching tick on a still-running job is skipped — a 5-minute job on a per-minute schedule resumes on the 6th minute
- Run-once (`addOnce` → auto-remove) and run-now (`trigger()` — bypasses schedule, respects the overlap guard)
- **Per-listener isolation**: sync throws AND async rejections in listeners are contained and reported — they can never wedge a job, kill the ticker, or crash the process
- Generation-tokened ticker (stop/start can never double-arm), epoch-minute dedupe with clock-change resync, typed errors over utils `BaseError`, `run`/`success`/`error`/`finish`/`skip` events

### Hardening
Two full adversarial review rounds (2 independent reviewers each + empirical attack scripts); every finding fixed and pinned as a regression test. 56 tests green on all three runtimes.

### Release notes
- Includes the workspace-tooling registration (release-please seed 0.0.0, labeler, codecov, issue templates, wiki mapping) generated via `workspace:sync`
- ⚠️ **Before merging**: create `@tundralibs/cronus` on JSR and link the repo (new-package first-publish requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)