### PR TITLE
fix(utils): harden Events and Options; adopt across the suite

### DIFF
--- a/packages/cacher/AbstractEngine.test.ts
+++ b/packages/cacher/AbstractEngine.test.ts
@@ -4,6 +4,21 @@ import { AbstractEngine } from './AbstractEngine.ts';
 import { CacherEngineError } from './errors/mod.ts';
 import type { CacherOptions, CacheValue } from './types/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 /**
  * Test implementation of AbstractEngine for comprehensive testing
  */
@@ -123,7 +138,7 @@ describe('cacher.AbstractEngine', () => {
 
         asserts.assertEquals(engine.name, 'test-cache');
         asserts.assertEquals(engine.Engine, 'TEST');
-        asserts.assertEquals(engine.getOption('defaultExpiry'), 600);
+        asserts.assertEquals(readOption(engine, 'defaultExpiry'), 600);
       },
     );
 
@@ -155,7 +170,7 @@ describe('cacher.AbstractEngine', () => {
 
     it('should use default options when not provided', () => {
       const engine = new TestEngine('test', {});
-      asserts.assertEquals(engine.getOption('defaultExpiry'), 300);
+      asserts.assertEquals(readOption(engine, 'defaultExpiry'), 300);
     });
 
     it('should validate defaultExpiry option', () => {
@@ -180,7 +195,7 @@ describe('cacher.AbstractEngine', () => {
 
     it('should accept zero as valid defaultExpiry', () => {
       const engine = new TestEngine('test', { defaultExpiry: 0 });
-      asserts.assertEquals(engine.getOption('defaultExpiry'), 0);
+      asserts.assertEquals(readOption(engine, 'defaultExpiry'), 0);
     });
   });
 
@@ -558,11 +573,11 @@ describe('cacher.AbstractEngine', () => {
       'should process defaultExpiry option correctly in _processOption',
       () => {
         const engine = new TestEngine('test', { defaultExpiry: 600 });
-        asserts.assertEquals(engine.getOption('defaultExpiry'), 600);
+        asserts.assertEquals(readOption(engine, 'defaultExpiry'), 600);
 
         // Test with undefined (should get default)
         const engine2 = new TestEngine('test2', {});
-        asserts.assertEquals(engine2.getOption('defaultExpiry'), 300);
+        asserts.assertEquals(readOption(engine2, 'defaultExpiry'), 300);
       },
     );
   });

--- a/packages/cacher/AbstractEngine.ts
+++ b/packages/cacher/AbstractEngine.ts
@@ -119,7 +119,7 @@ export abstract class AbstractEngine<
     opt: CacheValueOptions = {},
   ): Promise<void> {
     await this.init();
-    const expiry = opt.expiry ?? this.getOption('defaultExpiry')!;
+    const expiry = opt.expiry ?? this._getOption('defaultExpiry')!;
     if (this._validateExpiry(expiry) === false) {
       throw new CacherEngineError('OPERATION_INVALID_PARAMS', {
         name: this.name,

--- a/packages/cacher/Cacher.test.ts
+++ b/packages/cacher/Cacher.test.ts
@@ -6,6 +6,21 @@ import { CacherError } from './errors/mod.ts';
 import type { CacherOptions } from './types/mod.ts';
 import type { CacheValue } from './types/CacheValue.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 /**
  * Mock engine for testing purposes
  */
@@ -215,7 +230,7 @@ describe({
 
         asserts.assert(cache instanceof MockEngine);
         asserts.assertEquals(cache.name, 'test-cache');
-        asserts.assertEquals(cache.getOption('defaultExpiry'), 300);
+        asserts.assertEquals(readOption(cache, 'defaultExpiry'), 300);
       });
 
       it('should return existing instance for same name', () => {
@@ -229,7 +244,7 @@ describe({
         // Should be the same instance
         asserts.assertStrictEquals(cache1, cache2);
         // Should keep original options
-        asserts.assertEquals(cache1.getOption('defaultExpiry'), 300);
+        asserts.assertEquals(readOption(cache1, 'defaultExpiry'), 300);
       });
 
       it('should normalize and trim instance names', () => {
@@ -772,7 +787,7 @@ describe({
           asserts.assertStrictEquals(cache2, cache3);
 
           // Should maintain original configuration
-          asserts.assertEquals(cache1.getOption('defaultExpiry'), 300);
+          asserts.assertEquals(readOption(cache1, 'defaultExpiry'), 300);
 
           // Should only have one instance
           asserts.assertEquals(Cacher.getActiveInstances().length, 1);

--- a/packages/cacher/engines/memcached/MemCacher.test.ts
+++ b/packages/cacher/engines/memcached/MemCacher.test.ts
@@ -5,6 +5,21 @@ import { MemCacher, type MemCacherOptions } from './mod.ts';
 import { CacherEngineError } from '../../errors/mod.ts';
 import { envArgs } from '@tundralibs/utils';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/cacher/engines/');
 
 /** Resolve the configured Memcached port, falling back to the default. */
@@ -78,7 +93,7 @@ describe({
         asserts.assert(cacher instanceof MemCacher);
         asserts.assertEquals(cacher.name, 'memory-test');
         asserts.assertEquals(cacher.Engine, 'MEMCACHED');
-        asserts.assertEquals(cacher.getOption('defaultExpiry'), 300);
+        asserts.assertEquals(readOption(cacher, 'defaultExpiry'), 300);
       });
 
       it('set port and maxBufferSize', () => {
@@ -88,8 +103,8 @@ describe({
           maxBufferSize: undefined,
         });
 
-        asserts.assertEquals(cacher.getOption('port'), 11211);
-        asserts.assertEquals(cacher.getOption('maxBufferSize'), 10);
+        asserts.assertEquals(readOption(cacher, 'port'), 11211);
+        asserts.assertEquals(readOption(cacher, 'maxBufferSize'), 10);
       });
 
       it('Should throw on invalid config', () => {
@@ -168,7 +183,7 @@ describe({
           defaultExpiry: 600,
         });
 
-        asserts.assertEquals(cacher.getOption('defaultExpiry'), 600);
+        asserts.assertEquals(readOption(cacher, 'defaultExpiry'), 600);
       });
 
       it('should validate port range', () => {

--- a/packages/cacher/engines/memcached/MemCacher.ts
+++ b/packages/cacher/engines/memcached/MemCacher.ts
@@ -182,8 +182,8 @@ export class MemCacher extends AbstractEngine<MemCacherOptions> {
         throw new CacherEngineError('CONNECTION_FAILED', {
           name: this.name,
           engine: this.Engine,
-          host: this.getOption('host'),
-          port: this.getOption('port'),
+          host: this._getOption('host'),
+          port: this._getOption('port'),
           reason: (e as Error).message,
         }, e as Error);
       }
@@ -199,11 +199,11 @@ export class MemCacher extends AbstractEngine<MemCacherOptions> {
    * @protected
    */
   protected _createClient(): MemcachedEngine {
-    const ssl = this.getOption('ssl');
+    const ssl = this._getOption('ssl');
     return new MemcachedEngine(this.name, {
-      host: this.getOption('host'),
-      port: this.getOption('port'),
-      maxBufferSize: this.getOption('maxBufferSize')! * 1024 * 1024,
+      host: this._getOption('host'),
+      port: this._getOption('port'),
+      maxBufferSize: this._getOption('maxBufferSize')! * 1024 * 1024,
       ...(ssl === undefined ? {} : { ssl }),
     });
   }

--- a/packages/cacher/engines/memory/MemoryCacher.test.ts
+++ b/packages/cacher/engines/memory/MemoryCacher.test.ts
@@ -3,6 +3,21 @@ import { describe, it } from '@tundralibs/compat';
 import { MemoryCacher } from './mod.ts';
 import { CacherEngineError } from '../../errors/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 describe('cacher.engines.memory', () => {
   describe('initialization', () => {
     it('should reject a ":" in the instance name on direct construction', () => {
@@ -23,7 +38,7 @@ describe('cacher.engines.memory', () => {
         asserts.assert(cacher instanceof MemoryCacher);
         asserts.assertEquals(cacher.name, 'memory-test');
         asserts.assertEquals(cacher.Engine, 'MEMORY');
-        asserts.assertEquals(cacher.getOption('defaultExpiry'), 300);
+        asserts.assertEquals(readOption(cacher, 'defaultExpiry'), 300);
       } finally {
         cacher.finalize();
       }
@@ -35,7 +50,7 @@ describe('cacher.engines.memory', () => {
       });
 
       try {
-        asserts.assertEquals(cacher.getOption('defaultExpiry'), 600);
+        asserts.assertEquals(readOption(cacher, 'defaultExpiry'), 600);
       } finally {
         cacher.finalize();
       }

--- a/packages/cacher/engines/redis/RedisCacher.test.ts
+++ b/packages/cacher/engines/redis/RedisCacher.test.ts
@@ -4,6 +4,21 @@ import { RedisCacher, type RedisCacherOptions } from './mod.ts';
 import { CacherEngineError } from '../../errors/mod.ts';
 import { envArgs } from '@tundralibs/utils';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/cacher/engines/');
 
 /**
@@ -73,7 +88,7 @@ describe('cacher.engines.redis', () => {
       asserts.assert(cacher instanceof RedisCacher);
       asserts.assertEquals(cacher.name, 'redis-test');
       asserts.assertEquals(cacher.Engine, 'REDIS');
-      asserts.assertEquals(cacher.getOption('defaultExpiry'), 300);
+      asserts.assertEquals(readOption(cacher, 'defaultExpiry'), 300);
     });
 
     it('set defaults when undefined', () => {
@@ -82,7 +97,7 @@ describe('cacher.engines.redis', () => {
         port: undefined,
       } as unknown as RedisCacherOptions);
 
-      asserts.assertEquals(cacher.getOption('port'), 6379);
+      asserts.assertEquals(readOption(cacher, 'port'), 6379);
     });
 
     it('Should throw on invalid config', () => {
@@ -220,7 +235,7 @@ describe('cacher.engines.redis', () => {
         defaultExpiry: 600,
       });
 
-      asserts.assertEquals(cacher.getOption('defaultExpiry'), 600);
+      asserts.assertEquals(readOption(cacher, 'defaultExpiry'), 600);
     });
 
     it('should validate port range', () => {
@@ -464,8 +479,8 @@ describe('cacher.engines.redis', () => {
         password: 'testpass',
       });
 
-      asserts.assertEquals(cache.getOption('username'), 'testuser');
-      asserts.assertEquals(cache.getOption('password'), 'testpass');
+      asserts.assertEquals(readOption(cache, 'username'), 'testuser');
+      asserts.assertEquals(readOption(cache, 'password'), 'testpass');
     });
 
     it('should validate database number', () => {
@@ -475,7 +490,7 @@ describe('cacher.engines.redis', () => {
         port: 6379,
         db: 1,
       });
-      asserts.assertEquals(cache1.getOption('db'), 1);
+      asserts.assertEquals(readOption(cache1, 'db'), 1);
     });
 
     it('should validate and trim username/password', () => {
@@ -487,8 +502,8 @@ describe('cacher.engines.redis', () => {
         password: '  testpass  ',
       });
 
-      asserts.assertEquals(cache.getOption('username'), 'testuser');
-      asserts.assertEquals(cache.getOption('password'), 'testpass');
+      asserts.assertEquals(readOption(cache, 'username'), 'testuser');
+      asserts.assertEquals(readOption(cache, 'password'), 'testpass');
 
       // Empty string credentials should become undefined
       const cache2 = new RedisCacher('empty-cache', {
@@ -498,8 +513,8 @@ describe('cacher.engines.redis', () => {
         password: '   ',
       });
 
-      asserts.assertEquals(cache2.getOption('username'), undefined);
-      asserts.assertEquals(cache2.getOption('password'), undefined);
+      asserts.assertEquals(readOption(cache2, 'username'), undefined);
+      asserts.assertEquals(readOption(cache2, 'password'), undefined);
     });
 
     it('should handle certificate path option', async () => {

--- a/packages/cacher/engines/redis/RedisCacher.ts
+++ b/packages/cacher/engines/redis/RedisCacher.ts
@@ -78,13 +78,13 @@ export class RedisCacher extends AbstractEngine<RedisCacherOptions> {
   public override async init(): Promise<void> {
     if (this._client !== undefined) return;
     try {
-      const ssl = this.getOption('ssl');
+      const ssl = this._getOption('ssl');
       this._client = new RedisEngine(this.name, {
-        host: this.getOption('host'),
-        port: this.getOption('port'),
-        username: this.getOption('username'),
-        password: this.getOption('password'),
-        database: this.getOption('db'),
+        host: this._getOption('host'),
+        port: this._getOption('port'),
+        username: this._getOption('username'),
+        password: this._getOption('password'),
+        database: this._getOption('db'),
         ...(ssl === undefined ? {} : { ssl }),
       });
       await this._client.connect();
@@ -93,10 +93,10 @@ export class RedisCacher extends AbstractEngine<RedisCacherOptions> {
       throw new CacherEngineError('CONNECTION_FAILED', {
         name: this.name,
         engine: this.Engine,
-        host: this.getOption('host'),
-        port: this.getOption('port'),
-        username: this.getOption('username'),
-        db: this.getOption('db'),
+        host: this._getOption('host'),
+        port: this._getOption('port'),
+        username: this._getOption('username'),
+        db: this._getOption('db'),
         reason: (e as Error).message,
       }, e as Error);
     }

--- a/packages/compat/CHANGELOG.md
+++ b/packages/compat/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.1.0](https://github.com/TundraSoft/TundraLibs/compare/compat-v1.0.0...compat-v1.1.0) (2026-08-09)
+
+
+### Features
+
+* **compat:** report the actual bound port on WebServer ([3507c3d](https://github.com/TundraSoft/TundraLibs/commit/3507c3d9391ac8ec4e379ebad69e011ee880ce7f))
+* **compat:** report the actual bound port on WebServer ([1cc2c88](https://github.com/TundraSoft/TundraLibs/commit/1cc2c8838ccea6c935e712951678a084c81882fa))
+
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/compat-v1.0.0-dev10...compat-v1.0.0) (2026-08-01)
 
 

--- a/packages/compat/deno.json
+++ b/packages/compat/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@tundralibs/compat",
   "description": "Compatibility layer smoothing API differences across Deno, Bun, and Node.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tundralibs/compat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     ".": "./mod.ts",

--- a/packages/cronus/Cronus.test.ts
+++ b/packages/cronus/Cronus.test.ts
@@ -479,6 +479,26 @@ describe('cronus.Cronus', () => {
       }
     }
     const minute = (n: number) => new Date(n * 60_000);
+    /**
+     * A Date whose EPOCH is offset but whose wall-clock reading is
+     * cloned from `src` — how a DST fall-back looks to the matcher.
+     */
+    const wallClone = (src: Date, epochOffsetMs: number): Date => {
+      const d = new Date(src.getTime() + epochOffsetMs);
+      const methods = [
+        'getFullYear',
+        'getMonth',
+        'getDate',
+        'getDay',
+        'getHours',
+        'getMinutes',
+      ] as const;
+      for (const m of methods) {
+        // deno-lint-ignore no-explicit-any
+        (d as any)[m] = () => (src as any)[m]();
+      }
+      return d;
+    };
 
     it('fires matching jobs and honours enabled', () => {
       const manual = new ManualCronus();
@@ -564,6 +584,45 @@ describe('cronus.Cronus', () => {
       } finally {
         console.error = original;
       }
+    });
+
+    it('DST fall-back: a fixed-time job fires ONCE in the repeated hour', async () => {
+      const manual = new ManualCronus();
+      let runs = 0;
+      manual.add('nightly', '30 1 * * *', () => {
+        runs++;
+      });
+      const firstPass = new Date(2026, 10, 1, 1, 30); // 01:30, first time
+      manual.tick(firstPass);
+      await defer(1);
+      asserts.assertEquals(runs, 1);
+      // One physical hour later the wall clock reads 01:30 AGAIN.
+      manual.tick(wallClone(firstPass, 3_600_000));
+      await defer(1);
+      asserts.assertEquals(runs, 1); // no double-fire
+      // Next day's 01:30 is a different local key — fires normally.
+      manual.tick(new Date(2026, 10, 2, 1, 30));
+      await defer(1);
+      asserts.assertEquals(runs, 2);
+    });
+
+    it('DST fall-back: wildcard jobs keep firing every physical minute', async () => {
+      const manual = new ManualCronus();
+      let every = 0;
+      let hourly = 0;
+      manual.add('heartbeat', '* * * * *', () => {
+        every++;
+      });
+      manual.add('on-the-half', '30 * * * *', () => {
+        hourly++; // minute fixed, hour WILDCARD → not a fixed-time job
+      });
+      const firstPass = new Date(2026, 10, 1, 1, 30);
+      manual.tick(firstPass);
+      await defer(1);
+      manual.tick(wallClone(firstPass, 3_600_000)); // repeated 01:30
+      await defer(1);
+      asserts.assertEquals(every, 2); // Vixie parity: wildcards run through
+      asserts.assertEquals(hourly, 2);
     });
 
     it('a stale timer chain dies after stop()/start() (no double ticker)', () => {

--- a/packages/cronus/Cronus.ts
+++ b/packages/cronus/Cronus.ts
@@ -29,7 +29,7 @@
  * ```
  */
 
-import { type EventCallback, Events } from '@tundralibs/utils';
+import { Events } from '@tundralibs/utils';
 import {
   CronusError,
   DuplicateJobError,
@@ -72,6 +72,12 @@ type CronusJob = {
   running: boolean;
   runCount: number;
   lastRun: Date | null;
+  /**
+   * Local wall-clock key of the last SCHEDULED fire — fixed-time jobs
+   * only. A DST fall-back replays a wall hour on new epoch minutes;
+   * this key (which includes the date) blocks the replay.
+   */
+  lastLocalFire: string | null;
 };
 
 /** `unref` a timer where the runtime supports it (no-op elsewhere). */
@@ -94,17 +100,14 @@ function unrefTimer(handle: TimerHandle): void {
  * guard. It also assumes actions SETTLE — an action that never resolves
  * wedges its job until `remove()` + `add()`.)
  *
- * Listeners are isolated: each listener is wrapped at registration, so
- * one that throws synchronously OR rejects asynchronously is caught and
+ * Listeners are isolated (inherited from `Events`): one that throws
+ * synchronously or rejects asynchronously is caught per listener and
  * reported via `console.error` — it never affects the run, other
  * listeners, the ticker, or the process.
  */
 export class Cronus extends Events<CronusEvents> {
   private readonly __jobs: Map<string, CronusJob> = new Map();
   private readonly __parsed: Map<string, ParsedSchedule> = new Map();
-  /** Original listener → isolation wrapper (lets `off(original)` work). */
-  private readonly __wrapped: WeakMap<EventCallback, EventCallback> =
-    new WeakMap();
   private readonly __unref: boolean;
   private __timer: TimerHandle | undefined;
   private __active = false;
@@ -116,86 +119,6 @@ export class Cronus extends Events<CronusEvents> {
   constructor(options: CronusOptions = {}) {
     super();
     this.__unref = options.unref ?? false;
-  }
-
-  /**
-   * Register a listener. The callback is wrapped for isolation: a sync
-   * throw or async rejection is caught and reported via
-   * `console.error`, never propagated.
-   */
-  public override on<K extends keyof CronusEvents>(
-    event: K,
-    callback: CronusEvents[K],
-  ): this;
-  public override on<K extends keyof CronusEvents>(
-    event: K,
-    callback: CronusEvents[K][],
-  ): this;
-  public override on(
-    event: string,
-    callback: EventCallback | EventCallback[],
-  ): this {
-    if (Array.isArray(callback)) {
-      for (const cb of callback) this.on(event as never, cb as never);
-      return this;
-    }
-    return super.on(event as never, this.__isolate(callback) as never);
-  }
-
-  /**
-   * Remove listener(s). Accepts the ORIGINAL callback passed to
-   * `on`/`once` (the isolation wrapper is resolved internally).
-   */
-  public override off<K extends keyof CronusEvents>(
-    event: K,
-    callback?: CronusEvents[K],
-  ): this;
-  public override off<K extends keyof CronusEvents>(
-    event: K,
-    callback?: CronusEvents[K][],
-  ): this;
-  public override off(
-    event: string,
-    callback?: EventCallback | EventCallback[],
-  ): this {
-    if (callback === undefined) return super.off(event as never);
-    if (Array.isArray(callback)) {
-      for (const cb of callback) this.off(event as never, cb as never);
-      return this;
-    }
-    return super.off(
-      event as never,
-      (this.__wrapped.get(callback) ?? callback) as never,
-    );
-  }
-
-  /**
-   * Register a one-shot listener (isolated like {@link Cronus.on});
-   * removable via `off(event, originalCallback)` before it fires.
-   */
-  public override once<K extends keyof CronusEvents>(
-    event: K,
-    callback: CronusEvents[K],
-  ): this;
-  public override once<K extends keyof CronusEvents>(
-    event: K,
-    callback: CronusEvents[K][],
-  ): this;
-  public override once(
-    event: string,
-    callback: EventCallback | EventCallback[],
-  ): this {
-    if (Array.isArray(callback)) {
-      for (const cb of callback) this.once(event as never, cb as never);
-      return this;
-    }
-    const isolated = this.__isolate(callback);
-    const wrapper: EventCallback = (...args: unknown[]) => {
-      super.off(event as never, wrapper as never);
-      return isolated(...args);
-    };
-    this.__wrapped.set(callback, wrapper);
-    return super.on(event as never, wrapper as never);
   }
 
   /** `true` while the ticker is running. */
@@ -249,6 +172,7 @@ export class Cronus extends Events<CronusEvents> {
       running: false,
       runCount: 0,
       lastRun: null,
+      lastLocalFire: null,
     });
     return this;
   }
@@ -427,11 +351,24 @@ export class Cronus extends Events<CronusEvents> {
       if (!job.enabled) continue;
       const parsed = this.__parsed.get(job.name);
       if (parsed === undefined || !matches(parsed, at)) continue;
+      // DST fall-back guard (Vixie parity): a FIXED-TIME job fires at
+      // most once per wall-clock minute — when the fall-back replays
+      // an hour, the second pass reads the same local key and is
+      // skipped. Wildcard jobs run every physical minute regardless.
+      let localKey: string | undefined;
+      if (parsed.fixedTime) {
+        localKey = `${at.getFullYear()}-${at.getMonth()}-${at.getDate()}T` +
+          `${at.getHours()}:${at.getMinutes()}`;
+        if (job.lastLocalFire === localKey) continue;
+      }
       if (job.running) {
-        // Overlap prevented — the previous run has not finished.
-        this.__emit('skip', job.name, new Date(at.getTime()));
+        // Overlap prevented — the previous run has not finished. The
+        // local key is NOT stamped, so if the repeated DST hour comes
+        // around the job still gets its once-per-wall-time chance.
+        this._emit('skip', job.name, new Date(at.getTime()));
         continue;
       }
+      if (localKey !== undefined) job.lastLocalFire = localKey;
       // Every job gets its OWN Date — an action or listener mutating
       // its scheduledAt cannot corrupt sibling matching or timestamps.
       void this.__run(job, new Date(at.getTime()), false);
@@ -439,44 +376,14 @@ export class Cronus extends Events<CronusEvents> {
   }
 
   /**
-   * Wrap a listener so a sync throw or async rejection is caught and
-   * reported, never propagated. Cached per original callback so
-   * registration dedupe and `off(original)` keep working.
+   * Listener faults (sync throws and async rejections — isolation is
+   * inherited from `Events`) are reported with the package brand.
    */
-  private __isolate(callback: EventCallback): EventCallback {
-    let wrapped = this.__wrapped.get(callback);
-    if (wrapped === undefined) {
-      wrapped = (...args: unknown[]) => {
-        try {
-          const out = callback(...args) as unknown;
-          if (out instanceof Promise) {
-            out.catch((error) =>
-              console.error('[cronus] async listener rejected:', error)
-            );
-          }
-        } catch (error) {
-          console.error('[cronus] listener threw:', error);
-        }
-      };
-      this.__wrapped.set(callback, wrapped);
-    }
-    return wrapped;
-  }
-
-  /**
-   * Emit defensively. Listeners registered through {@link Cronus.on}/
-   * {@link Cronus.once} are individually isolated already; this is the
-   * outer belt for anything that reached the base class directly.
-   */
-  private __emit<K extends keyof CronusEvents>(
-    event: K,
-    ...args: Parameters<CronusEvents[K]>
+  protected override _onListenerError(
+    event: PropertyKey,
+    error: unknown,
   ): void {
-    try {
-      this.emit(event, ...args);
-    } catch (error) {
-      console.error(`[cronus] '${String(event)}' listener threw:`, error);
-    }
+    console.error(`[cronus] '${String(event)}' listener error:`, error);
   }
 
   /** Snapshot a {@link CronusJob} onto its public read-only view. */
@@ -542,7 +449,7 @@ export class Cronus extends Events<CronusEvents> {
     job.lastRun = new Date();
     const runId = crypto.randomUUID();
     const started = Date.now();
-    this.__emit('run', runId, job.name, scheduledAt);
+    this._emit('run', runId, job.name, scheduledAt);
     let result: unknown;
     let failure: CronusError | undefined;
     try {
@@ -566,11 +473,11 @@ export class Cronus extends Events<CronusEvents> {
     }
     const elapsed = Date.now() - started;
     if (failure === undefined) {
-      this.__emit('success', runId, job.name, scheduledAt, elapsed, result);
+      this._emit('success', runId, job.name, scheduledAt, elapsed, result);
     } else {
-      this.__emit('error', runId, job.name, scheduledAt, elapsed, failure);
+      this._emit('error', runId, job.name, scheduledAt, elapsed, failure);
     }
-    this.__emit('finish', runId, job.name, scheduledAt, elapsed);
+    this._emit('finish', runId, job.name, scheduledAt, elapsed);
     // Release the guard LAST: a listener above that re-triggered this
     // job saw running=true and backed off (resolves false).
     job.running = false;

--- a/packages/cronus/docs/Cronus-Jobs.md
+++ b/packages/cronus/docs/Cronus-Jobs.md
@@ -94,12 +94,14 @@ Every run receives a `CronusRunContext`:
 ## Events
 
 Metadata only — never the action's arguments. Listeners are
-**isolated**: each callback is wrapped at registration, so a sync
-throw or an async rejection is caught and reported via
+**isolated** (inherited from `@tundralibs/utils` Events): a sync throw
+or an async rejection is caught per listener and reported via
 `console.error` — it never affects the run, the job's state, other
-listeners, the ticker, or the process. A listener that re-triggers
-its own job during `success`/`error`/`finish` hits the overlap guard
-(resolves `false`) — the guard releases only after the emissions.
+listeners, the ticker, or the process. `off(event, callback)` also
+removes `once` listeners by their original callback. A listener that
+re-triggers its own job during `success`/`error`/`finish` hits the
+overlap guard (resolves `false`) — the guard releases only after the
+emissions.
 
 | Event     | Fires when                        | Arguments                                            |
 | --------- | --------------------------------- | ---------------------------------------------------- |

--- a/packages/cronus/docs/Cronus-Schedule-Syntax.md
+++ b/packages/cronus/docs/Cronus-Schedule-Syntax.md
@@ -71,8 +71,13 @@ strictly the 15th).
 ## Matching semantics
 
 - **Local time.** Matching reads the host's local wall clock
-  (`getMinutes()`/`getHours()`/…). Note the usual cron caveat: a DST
-  spring-forward skips wall-clock times that never occur.
+  (`getMinutes()`/`getHours()`/…), with Vixie cron's DST semantics:
+  - **Fall-back** (an hour repeats): a _fixed-time_ job — minute AND
+    hour both concrete, e.g. `30 1 * * *` — fires **once**, not twice;
+    wildcard jobs (`* * * * *`, `*/5 …`, `30 * * * *`) keep firing
+    every physical minute through the repeated hour.
+  - **Spring-forward** (an hour never occurs): jobs scheduled in the
+    skipped hour do not run that day (no catch-up).
 - **Minute boundary.** The ticker fires at each `:00` second boundary
   and evaluates every job against that minute; there is no
   sub-minute scheduling.

--- a/packages/cronus/mod.ts
+++ b/packages/cronus/mod.ts
@@ -1,10 +1,40 @@
 /**
  * @fileoverview `@tundralibs/cronus` — a cross-runtime, minute-resolution
- * cron scheduler (Deno, Bun, Node). Tick-and-match: never computes a
- * next-run, so impossible expressions never fire rather than crashing;
- * per-job overlap prevention; cron, run-once, and run-now triggers.
+ * cron scheduler for Deno, Bun, and Node.
+ *
+ * Built on a **tick-and-match** architecture: a self-correcting timer
+ * fires at each minute boundary and runs every job whose 5-field cron
+ * expression matches the current time. It never computes a "next run",
+ * so an impossible expression (`0 0 30 2 *`) simply never fires instead
+ * of crashing, and there is no far-future timer to overflow.
+ *
+ * - Standard cron syntax with ranges, steps, lists, and `JAN`/`MON`
+ *   names; day-of-week accepts 0 and 7 for Sunday; POSIX/Vixie
+ *   day-of-month/day-of-week OR semantics
+ * - **Per-job overlap prevention** — a matching tick on a still-running
+ *   job is skipped, so a 5-minute job on a per-minute schedule resumes
+ *   on the 6th minute, never overlapping itself
+ * - Run-once (`addOnce` — auto-removes after its single run) and
+ *   run-now (`trigger()` — bypasses the schedule, respects the guard)
+ * - Isolated `run`/`success`/`error`/`finish`/`skip` events — a
+ *   throwing or rejecting listener can never wedge a job or the ticker
  *
  * @module
+ *
+ * @example
+ * ```typescript
+ * import { Cronus } from '@tundralibs/cronus';
+ *
+ * const cron = new Cronus();
+ * cron.on('error', (_id, name, _at, _ms, err) =>
+ *   console.error(`job ${name} failed:`, err.message));
+ *
+ * cron.add('hourly-cleanup', '0 * * * *', async () => {
+ *   await purgeExpired();
+ * });
+ * cron.addOnce('migrate', '0 3 * * *', runMigration);
+ * cron.start();
+ * ```
  */
 
 export { Cronus } from './Cronus.ts';

--- a/packages/cronus/schedule.test.ts
+++ b/packages/cronus/schedule.test.ts
@@ -256,6 +256,14 @@ describe('cronus.schedule', () => {
       asserts.assert(!matches(s, at(2026, 8, 18, 0, 0))); // Tuesday — must NOT fire
     });
 
+    it('fixedTime: concrete minute AND hour, star-prefix rules', () => {
+      asserts.assertEquals(parseSchedule('30 1 * * *').fixedTime, true);
+      asserts.assertEquals(parseSchedule('30 1-2 * * *').fixedTime, true);
+      asserts.assertEquals(parseSchedule('* * * * *').fixedTime, false);
+      asserts.assertEquals(parseSchedule('*/5 1 * * *').fixedTime, false);
+      asserts.assertEquals(parseSchedule('30 * * * *').fixedTime, false);
+    });
+
     it('dow 7 matches a real Sunday date', () => {
       const s = parseSchedule('0 0 * * 7');
       asserts.assert(matches(s, at(2026, 8, 16, 0, 0))); // 2026-08-16 is Sunday

--- a/packages/cronus/schedule.ts
+++ b/packages/cronus/schedule.ts
@@ -4,15 +4,16 @@
  * against it. Minute resolution (`minute hour day-of-month month
  * day-of-week`); seconds and years are deliberately out of scope.
  *
- * Field support: `*`, ranges `a-b`, steps `a/n` and `*​/n` and `a-b/n`,
- * lists `a,b,c`, plus month/day NAMES (`JAN`, `MON`). Day-of-week
+ * Field support: `*`, ranges `a-b`, steps (`a/n`, `a-b/n`, and steps on
+ * the `*` wildcard), lists `a,b,c`, plus month/day NAMES (`JAN`,
+ * `MON`). Day-of-week
  * accepts both `0` and `7` for Sunday. Names must be complete tokens —
  * `JAN1` is rejected, never silently misread.
  *
  * Semantics follow POSIX/Vixie cron: when BOTH day-of-month and
  * day-of-week are restricted, a date matches if it satisfies EITHER
  * (the standard OR rule) — and, as in Vixie cron, a field beginning
- * with `*` (including `*​/n`) counts as UNrestricted for this rule.
+ * with `*` (wildcard steps included) counts as UNrestricted for this rule.
  *
  * Validity is syntactic: an expression that can never match a real
  * date (`0 0 30 2 *` — Feb 30) parses fine and simply never fires.
@@ -238,6 +239,10 @@ export function parseSchedule(expression: string): ParsedSchedule {
     // "every 2nd day AND Monday", not "OR Monday".
     domRestricted: !fields[2]!.startsWith('*'),
     dowRestricted: !fields[4]!.startsWith('*'),
+    // Vixie's fixed-time rule: minute AND hour both concrete means
+    // "once per day at this wall time" — the DST fall-back guard
+    // applies only to these (see Cronus._tick).
+    fixedTime: !fields[0]!.startsWith('*') && !fields[1]!.startsWith('*'),
   };
 }
 

--- a/packages/cronus/types/CronusEvents.ts
+++ b/packages/cronus/types/CronusEvents.ts
@@ -10,10 +10,11 @@ import type { CronusError } from '../errors/mod.ts';
 /**
  * Cronus lifecycle events.
  *
- * Listeners are ISOLATED per listener: each callback is wrapped at
- * registration, so a sync throw OR an async rejection is caught and
- * reported via `console.error` — it never affects the run, the job's
- * state, other listeners, the ticker, or the process.
+ * Listeners are ISOLATED per listener (inherited from `Events`): a
+ * sync throw or an async rejection is caught and reported via
+ * `console.error` — it never affects the run, the job's state, other
+ * listeners, the ticker, or the process. `off(event, callback)` also
+ * removes `once` listeners by their original callback.
  */
 export type CronusEvents = {
   /** A run started. */

--- a/packages/cronus/types/ParsedSchedule.ts
+++ b/packages/cronus/types/ParsedSchedule.ts
@@ -18,4 +18,13 @@ export type ParsedSchedule = {
   /** `true` when the field was not `*` (drives the POSIX dom/dow OR). */
   domRestricted: boolean;
   dowRestricted: boolean;
+  /**
+   * `true` when the minute AND hour fields are both concrete (neither
+   * starts with `*`) — a "fixed-time" job in Vixie cron's sense:
+   * "once per day at this wall time". Fixed-time jobs are fired at
+   * most once per wall-clock minute, so a DST fall-back's repeated
+   * hour cannot double-fire them; wildcard jobs (`* * * * *` and
+   * step-on-wildcard forms) keep firing every physical minute.
+   */
+  fixedTime: boolean;
 };

--- a/packages/doctor/mod.ts
+++ b/packages/doctor/mod.ts
@@ -1,6 +1,8 @@
 /**
- * @fileoverview Public entry point — re-exports every class, type,
- * decorator, and error the package exposes.
+ * @fileoverview `@tundralibs/doctor` — dependency-health checks for
+ * services: declare named checks (decorator or registration API), run
+ * them with timeouts and consecutive-failure tracking, and expose the
+ * aggregate as readiness/liveness results.
  *
  * @module
  */

--- a/packages/drivers/BaseEngine.test.ts
+++ b/packages/drivers/BaseEngine.test.ts
@@ -4,6 +4,21 @@ import { BaseEngine } from './BaseEngine.ts';
 import type { EngineCapabilities, EngineOptions } from './types/mod.ts';
 import { EngineError } from './errors/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 /**
  * A minimal in-memory engine used to exercise `BaseEngine` end-to-end without
  * requiring a real network service.
@@ -34,8 +49,8 @@ class FakeEngine extends BaseEngine<FakeResource, FakeOptions> {
   public destroyed = 0;
 
   protected _createResource(): FakeResource | Promise<FakeResource> {
-    if (this.getOption('createError')) {
-      throw new Error(this.getOption('createError'));
+    if (this._getOption('createError')) {
+      throw new Error(this._getOption('createError'));
     }
     this.created++;
     return { id: this.created, closed: false };
@@ -52,12 +67,12 @@ class FakeEngine extends BaseEngine<FakeResource, FakeOptions> {
   protected override _validateResource(
     r: FakeResource,
   ): boolean | Promise<boolean> {
-    if (this.getOption('invalidate')) return false;
+    if (this._getOption('invalidate')) return false;
     return !r.closed;
   }
 
   protected _ping(_r: FakeResource): boolean {
-    const mode = this.getOption('pingFailure') ?? 'ok';
+    const mode = this._getOption('pingFailure') ?? 'ok';
     if (mode === 'throw') throw new Error('ping failed');
     if (mode === 'false') return false;
     return true;
@@ -441,8 +456,8 @@ describe('drivers.BaseEngine', () => {
       const e = new FakeEngine('o7', {
         pool: { min: 1, max: 5, idleTimeoutSeconds: 60 },
       });
-      asserts.assertEquals(e.getOption('pool')?.min, 1);
-      asserts.assertEquals(e.getOption('pool')?.max, 5);
+      asserts.assertEquals(readOption(e, 'pool')?.min, 1);
+      asserts.assertEquals(readOption(e, 'pool')?.max, 5);
     });
 
     it('should reject non-function idGenerator', () => {
@@ -458,7 +473,7 @@ describe('drivers.BaseEngine', () => {
 
     it('should accept ssl=true', () => {
       const e = new FakeEngine('o9', { ssl: true });
-      asserts.assertEquals(e.getOption('ssl'), true);
+      asserts.assertEquals(readOption(e, 'ssl'), true);
     });
 
     it('should accept ssl object with PEM string array for ca', () => {
@@ -467,7 +482,7 @@ describe('drivers.BaseEngine', () => {
           ca: ['-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----'],
         },
       });
-      asserts.assertEquals(typeof e.getOption('ssl'), 'object');
+      asserts.assertEquals(typeof readOption(e, 'ssl'), 'object');
     });
 
     it('should reject ssl object with non-array ca', () => {
@@ -782,12 +797,12 @@ describe('drivers.BaseEngine', () => {
   describe('database option validation', () => {
     it('should accept valid database string', () => {
       const e = new FakeEngine('db1', { database: 'mydb' });
-      asserts.assertEquals(e.getOption('database'), 'mydb');
+      asserts.assertEquals(readOption(e, 'database'), 'mydb');
     });
 
     it('should accept database as number (for Redis index)', () => {
       const e = new FakeEngine('db2', { database: 0 });
-      asserts.assertEquals(e.getOption('database'), 0);
+      asserts.assertEquals(readOption(e, 'database'), 0);
     });
 
     it('should reject empty database string', () => {
@@ -932,7 +947,7 @@ describe('drivers.BaseEngine', () => {
           enforce: false,
         },
       });
-      asserts.assertEquals(typeof e.getOption('ssl'), 'object');
+      asserts.assertEquals(typeof readOption(e, 'ssl'), 'object');
     });
 
     it('should reject SSL with non-boolean rejectUnauthorized', () => {

--- a/packages/drivers/ConnectionEngine.ts
+++ b/packages/drivers/ConnectionEngine.ts
@@ -146,7 +146,7 @@ export abstract class ConnectionEngine<
       ...defaults,
       ...options,
     } as EventOptionKeys<O, E>);
-    this._idGenerator = this.getOption('idGenerator')!;
+    this._idGenerator = this._getOption('idGenerator')!;
   }
 
   //#region Public API
@@ -181,7 +181,7 @@ export abstract class ConnectionEngine<
       this._status = 'CONNECTING';
       await this._open();
       this._status = 'READY';
-      this._emit('connect', this.instanceId);
+      this._emitRaw('connect', this.instanceId);
     } catch (e) {
       this._status = 'CLOSED';
       const error = e instanceof EngineError ? e : new EngineError(
@@ -189,7 +189,7 @@ export abstract class ConnectionEngine<
         { instanceId: this.instanceId },
         e as Error,
       );
-      this._emit('connectionFailed', this.instanceId, error);
+      this._emitRaw('connectionFailed', this.instanceId, error);
       throw error;
     }
   }
@@ -208,14 +208,14 @@ export abstract class ConnectionEngine<
     try {
       await this._close();
       this._status = 'CLOSED';
-      this._emit('disconnect', this.instanceId);
+      this._emitRaw('disconnect', this.instanceId);
     } catch (e) {
       const error = e instanceof EngineError ? e : new EngineError(
         'DISCONNECTION_FAILED',
         { instanceId: this.instanceId },
         e as Error,
       );
-      this._emit('error', this.instanceId, error);
+      this._emitRaw('error', this.instanceId, error);
       throw error;
     }
   }
@@ -368,8 +368,8 @@ export abstract class ConnectionEngine<
     // `query` / `slowQuery` are declared on the query-executing subclasses'
     // event maps (SQL/Mongo), not on the base `EngineEvents` this class is
     // generic over — cast the key so the shared helper can emit them.
-    this._emit('query' as keyof E, this.instanceId, result);
-    if (isSlow) this._emit('slowQuery' as keyof E, this.instanceId, result);
+    this._emitRaw('query' as keyof E, this.instanceId, result);
+    if (isSlow) this._emitRaw('slowQuery' as keyof E, this.instanceId, result);
     return result;
   }
 
@@ -534,7 +534,7 @@ export abstract class PooledConnectionEngine<
     defaults?: Partial<O>,
   ) {
     super(name, options, defaults);
-    this._pool = createEnginePool<T>(this.getOption('pool'), {
+    this._pool = createEnginePool<T>(this._getOption('pool'), {
       // `instanceId` is read lazily: the subclass's `Engine` field is only
       // initialized after this `super()` returns, so it can't be captured here.
       instanceId: () => this.instanceId,
@@ -542,7 +542,7 @@ export abstract class PooledConnectionEngine<
       destroy: (resource) => this._destroyResource(resource),
       validate: (resource) => this._validateResource(resource),
       ping: (resource) => this._ping(resource),
-      onWarn: (message) => this._emit('warn', this.instanceId, message),
+      onWarn: (message) => this._emitRaw('warn', this.instanceId, message),
     });
   }
 

--- a/packages/drivers/SQLConnectionEngine.test.ts
+++ b/packages/drivers/SQLConnectionEngine.test.ts
@@ -34,6 +34,21 @@ import type {
   SQLEngineOptions,
 } from './types/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 /**
  * Stand-in translator: these tests never touch the OQL surface, so every
  * emit hook throws to fail loudly if a future test accidentally strays into
@@ -164,7 +179,7 @@ class FakePoolFreeSQLEngine extends SQLConnectionEngine<FakeConn, FakeOptions> {
     _client: FakeConn,
   ): Promise<{ data: R[]; count: number }> {
     this.executeCount++;
-    const delay = this.getOption('executeDelay') ?? 0;
+    const delay = this._getOption('executeDelay') ?? 0;
     if (delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
@@ -212,10 +227,10 @@ describe('SQLConnectionEngine (pool-free)', () => {
       asserts.assertStrictEquals(engine.Engine, 'FAKE_POOLFREE_SQL');
       asserts.assertStrictEquals(engine.status, 'CLOSED');
       // SQL defaults still apply through the pool-free base.
-      asserts.assertStrictEquals(engine.getOption('slowQueryThreshold'), 0.5);
-      asserts.assertStrictEquals(engine.getOption('transactionTimeout'), 120);
+      asserts.assertStrictEquals(readOption(engine, 'slowQueryThreshold'), 0.5);
+      asserts.assertStrictEquals(readOption(engine, 'transactionTimeout'), 120);
       // Never configured a pool.
-      asserts.assertStrictEquals(engine.getOption('pool'), undefined);
+      asserts.assertStrictEquals(readOption(engine, 'pool'), undefined);
       asserts.assertEquals(engine.poolStats, EMPTY_POOL_STATS);
     });
   });

--- a/packages/drivers/SQLEngine.test.ts
+++ b/packages/drivers/SQLEngine.test.ts
@@ -25,6 +25,21 @@ import type {
   TransactionScope,
 } from './types/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 /**
  * Stand-in translator for SQLEngine unit tests. SQLEngine declares an
  * abstract `_translator` field but these tests never exercise the OQL
@@ -170,13 +185,13 @@ class FakeSQLEngine extends SQLEngine<FakeClient, FakeOptions> {
     query: EngineQuery,
     client: FakeClient,
   ): Promise<{ data: R[]; count: number }> {
-    if (this.getOption('failExecute')) {
+    if (this._getOption('failExecute')) {
       throw new Error('Simulated execute failure');
     }
 
     this.executeCount++;
 
-    const delay = this.getOption('executeDelay') ?? 0;
+    const delay = this._getOption('executeDelay') ?? 0;
     if (delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
@@ -190,7 +205,7 @@ class FakeSQLEngine extends SQLEngine<FakeClient, FakeOptions> {
     client: FakeClient,
     _transactionId: string,
   ): void {
-    if (this.getOption('failBegin')) {
+    if (this._getOption('failBegin')) {
       throw new Error('Simulated begin failure');
     }
     client.inTransaction = true;
@@ -201,7 +216,7 @@ class FakeSQLEngine extends SQLEngine<FakeClient, FakeOptions> {
     client: FakeClient,
     _transactionId: string,
   ): void {
-    if (this.getOption('failCommit')) {
+    if (this._getOption('failCommit')) {
       throw new Error('Simulated commit failure');
     }
     client.inTransaction = false;
@@ -212,7 +227,7 @@ class FakeSQLEngine extends SQLEngine<FakeClient, FakeOptions> {
     client: FakeClient,
     _transactionId: string,
   ): void {
-    if (this.getOption('failRollback')) {
+    if (this._getOption('failRollback')) {
       throw new Error('Simulated rollback failure');
     }
     client.inTransaction = false;
@@ -300,10 +315,10 @@ describe('SQLEngine', () => {
     it('should apply SQL-specific defaults', async () => {
       const engine = new FakeSQLEngine('test');
 
-      asserts.assertStrictEquals(engine.getOption('slowQueryThreshold'), 0.5);
-      asserts.assertStrictEquals(engine.getOption('transactionTimeout'), 120);
+      asserts.assertStrictEquals(readOption(engine, 'slowQueryThreshold'), 0.5);
+      asserts.assertStrictEquals(readOption(engine, 'transactionTimeout'), 120);
       asserts.assertStrictEquals(
-        engine.getOption('autoRollbackOnFailure'),
+        readOption(engine, 'autoRollbackOnFailure'),
         true,
       );
     });
@@ -315,10 +330,10 @@ describe('SQLEngine', () => {
         autoRollbackOnFailure: false,
       });
 
-      asserts.assertStrictEquals(engine.getOption('slowQueryThreshold'), 1.0);
-      asserts.assertStrictEquals(engine.getOption('transactionTimeout'), 60);
+      asserts.assertStrictEquals(readOption(engine, 'slowQueryThreshold'), 1.0);
+      asserts.assertStrictEquals(readOption(engine, 'transactionTimeout'), 60);
       asserts.assertStrictEquals(
-        engine.getOption('autoRollbackOnFailure'),
+        readOption(engine, 'autoRollbackOnFailure'),
         false,
       );
     });

--- a/packages/drivers/SQLEngine.ts
+++ b/packages/drivers/SQLEngine.ts
@@ -168,9 +168,9 @@ export abstract class SQLConnectionEngine<
     defaults?: Partial<O>,
   ) {
     super(name, options, { ...SQL_DEFAULTS, ...defaults } as Partial<O>);
-    this._slowThresholdMs = (this.getOption('slowQueryThreshold') ?? 0.5) *
+    this._slowThresholdMs = (this._getOption('slowQueryThreshold') ?? 0.5) *
       1000;
-    this._autoRollback = this.getOption('autoRollbackOnFailure') !== false;
+    this._autoRollback = this._getOption('autoRollbackOnFailure') !== false;
   }
 
   //#region Public API
@@ -399,7 +399,7 @@ export abstract class SQLConnectionEngine<
     };
     this._transactions.set(id, record);
     this.__armTransactionTimeout(id, record, options?.timeout);
-    this._emit('transactionBegin', this.instanceId, id);
+    this._emitRaw('transactionBegin', this.instanceId, id);
     return id;
   }
 
@@ -430,7 +430,7 @@ export abstract class SQLConnectionEngine<
     try {
       await this._commitTransaction(tx.client, transactionId);
       tx.state = 'COMMITTED';
-      this._emit('transactionCommit', this.instanceId, transactionId);
+      this._emitRaw('transactionCommit', this.instanceId, transactionId);
     } catch (e) {
       throw e instanceof EngineError ? e : new EngineError(
         'TRANSACTION_OPERATION_ERROR',
@@ -477,7 +477,7 @@ export abstract class SQLConnectionEngine<
     try {
       await this._rollbackTransaction(tx.client, transactionId);
       tx.state = 'ROLLBACK';
-      this._emit('transactionRollback', this.instanceId, transactionId);
+      this._emitRaw('transactionRollback', this.instanceId, transactionId);
     } catch (e) {
       rollbackFailed = true;
       throw e instanceof EngineError ? e : new EngineError(
@@ -1360,7 +1360,7 @@ export abstract class SQLConnectionEngine<
     record: TxRecord<T>,
     override?: number,
   ): void {
-    const seconds = override ?? this.getOption('transactionTimeout') ?? 120;
+    const seconds = override ?? this._getOption('transactionTimeout') ?? 120;
     if (seconds <= 0) return;
     record.timer = setTimeout(async () => {
       const tx = this._transactions.get(id);
@@ -1383,7 +1383,7 @@ export abstract class SQLConnectionEngine<
       // on the torn-down socket.
       if (tx.busy) {
         this.__releaseTransactionClient(id, true);
-        this._emit('transactionTimeout', this.instanceId, id);
+        this._emitRaw('transactionTimeout', this.instanceId, id);
         return;
       }
       let rollbackFailed = false;
@@ -1397,7 +1397,7 @@ export abstract class SQLConnectionEngine<
         }
       } finally {
         this.__releaseTransactionClient(id, rollbackFailed);
-        this._emit('transactionTimeout', this.instanceId, id);
+        this._emitRaw('transactionTimeout', this.instanceId, id);
       }
     }, seconds * 1000);
   }
@@ -1500,7 +1500,7 @@ export abstract class SQLEngine<
     defaults?: Partial<O>,
   ) {
     super(name, options, defaults);
-    this._pool = createEnginePool<T>(this.getOption('pool'), {
+    this._pool = createEnginePool<T>(this._getOption('pool'), {
       // `instanceId` is read lazily: the subclass's `Engine` field is only
       // initialized after this `super()` returns, so it can't be captured here.
       instanceId: () => this.instanceId,
@@ -1508,7 +1508,7 @@ export abstract class SQLEngine<
       destroy: (resource) => this._destroyResource(resource),
       validate: (resource) => this._validateResource(resource),
       ping: (resource) => this._ping(resource),
-      onWarn: (message) => this._emit('warn', this.instanceId, message),
+      onWarn: (message) => this._emitRaw('warn', this.instanceId, message),
     });
   }
 

--- a/packages/drivers/engines/d1/Engine.ts
+++ b/packages/drivers/engines/d1/Engine.ts
@@ -151,13 +151,13 @@ export class D1Engine extends SQLConnectionEngine<
    */
   protected override _open(): void {
     this._resource = new D1HttpClient({
-      accountId: this.getOption('accountId'),
-      databaseId: this.getOption('databaseId'),
-      apiToken: this.getOption('apiToken'),
+      accountId: this._getOption('accountId'),
+      databaseId: this._getOption('databaseId'),
+      apiToken: this._getOption('apiToken'),
       // A Cloudflare-compatible gateway / local test proxy, when set; otherwise
       // the client dials Cloudflare's cloud endpoint.
-      endpoint: this.getOption('endpoint'),
-      timeout: this.getOption('timeout'),
+      endpoint: this._getOption('endpoint'),
+      timeout: this._getOption('timeout'),
     });
   }
 

--- a/packages/drivers/engines/maria/Engine.test.ts
+++ b/packages/drivers/engines/maria/Engine.test.ts
@@ -5,6 +5,21 @@ import { MariaEngine } from './Engine.ts';
 import { EngineError } from '../../errors/mod.ts';
 import type { EngineQuery } from '../../types/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/drivers/');
 
 const TEST_CONFIG = {
@@ -58,7 +73,7 @@ describe('drivers.MariaEngine', () => {
     it('should default port to 3306', () => {
       const { port: _p, ...rest } = TEST_CONFIG;
       const engine = new MariaEngine('cfg-2', rest);
-      asserts.assertEquals(engine.getOption('port'), 3306);
+      asserts.assertEquals(readOption(engine, 'port'), 3306);
     });
 
     it('should require host / database / username', () => {

--- a/packages/drivers/engines/maria/Engine.ts
+++ b/packages/drivers/engines/maria/Engine.ts
@@ -98,11 +98,11 @@ export class MariaEngine extends SQLEngine<Connection, MariaEngineOptions> {
     // declare (e.g. `supportBigInt`, `decimalAsNumber`). Pass through as a
     // typed-loose record.
     const config: Record<string, unknown> = {
-      host: this.getOption('host'),
-      port: this.getOption('port'),
-      database: String(this.getOption('database')),
-      user: this.getOption('username'),
-      password: this.getOption('password'),
+      host: this._getOption('host'),
+      port: this._getOption('port'),
+      database: String(this._getOption('database')),
+      user: this._getOption('username'),
+      password: this._getOption('password'),
       ssl: this.__buildMariaSsl(),
       namedPlaceholders: true,
       supportBigInt: true,
@@ -166,7 +166,7 @@ export class MariaEngine extends SQLEngine<Connection, MariaEngineOptions> {
       key?: string;
       ca?: string[];
     } {
-    const ssl = this.getOption('ssl');
+    const ssl = this._getOption('ssl');
     if (!ssl) return undefined;
     if (ssl === true) return true;
 

--- a/packages/drivers/engines/memcached/Engine.test.ts
+++ b/packages/drivers/engines/memcached/Engine.test.ts
@@ -5,6 +5,21 @@ import { envArgs } from '@tundralibs/utils';
 import { MemcachedEngine } from './Engine.ts';
 import { EngineError } from '../../errors/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/drivers/');
 
 const TEST_CONFIG = {
@@ -66,12 +81,12 @@ describe({
           ...withoutPort,
           host: TEST_CONFIG.host,
         });
-        asserts.assertEquals(engine.getOption('port'), 11211);
+        asserts.assertEquals(readOption(engine, 'port'), 11211);
       });
 
       it('should default maxBufferSize to 2 (MB)', () => {
         const engine = new MemcachedEngine('cfg-3', TEST_CONFIG);
-        asserts.assertEquals(engine.getOption('maxBufferSize'), 2);
+        asserts.assertEquals(readOption(engine, 'maxBufferSize'), 2);
       });
 
       it('should require host', () => {

--- a/packages/drivers/engines/memcached/Engine.ts
+++ b/packages/drivers/engines/memcached/Engine.ts
@@ -148,7 +148,7 @@ export class MemcachedEngine extends BaseEngine<
     options: EventOptionKeys<MemcachedEngineOptions, MemcachedEngineEvents>,
   ) {
     super(name, options, MEMCACHED_DEFAULTS);
-    this.__slowThresholdMs = (this.getOption('slowQueryThreshold') ?? 0.5) *
+    this.__slowThresholdMs = (this._getOption('slowQueryThreshold') ?? 0.5) *
       1000;
     this._requireOptions(['host']);
   }
@@ -174,13 +174,13 @@ export class MemcachedEngine extends BaseEngine<
    * ElastiCache for Memcached).
    */
   protected async _createResource(): Promise<Connection> {
-    const host = this.getOption('host')!;
+    const host = this._getOption('host')!;
     if (host.endsWith('.sock')) {
       return await connect({ path: host });
     }
 
-    const port = this.getOption('port')!;
-    const ssl = this.getOption('ssl');
+    const port = this._getOption('port')!;
+    const ssl = this._getOption('ssl');
     const enforceTls = _resolveEnforceTls(ssl);
 
     let conn: Connection;
@@ -193,7 +193,7 @@ export class MemcachedEngine extends BaseEngine<
     } catch (e) {
       if (!ssl || enforceTls) throw e;
       const reason = e instanceof Error ? e.message : String(e);
-      this.emit(
+      this._emit(
         'notice',
         this.instanceId,
         `WARNING: TLS connect failed (${reason}); falling back to plaintext per ssl.enforce=false`,
@@ -214,7 +214,7 @@ export class MemcachedEngine extends BaseEngine<
         }
         if (!enforceTls && looksLikeTlsRuntimeError(e)) {
           const reason = e instanceof Error ? e.message : String(e);
-          this.emit(
+          this._emit(
             'notice',
             this.instanceId,
             `WARNING: TLS handshake failed during probe (${reason}); falling back to plaintext per ssl.enforce=false`,
@@ -839,7 +839,7 @@ export class MemcachedEngine extends BaseEngine<
   ): Promise<string> {
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
-    const maxBytes = this.getOption('maxBufferSize')! * 1024 * 1024;
+    const maxBytes = this._getOption('maxBufferSize')! * 1024 * 1024;
     const isCounter = command.startsWith('incr ') ||
       command.startsWith('decr ');
 
@@ -911,8 +911,8 @@ export class MemcachedEngine extends BaseEngine<
       time: timeMs,
       isSlow,
     };
-    this._emit('query', this.instanceId, result);
-    if (isSlow) this._emit('slowQuery', this.instanceId, result);
+    this._emitRaw('query', this.instanceId, result);
+    if (isSlow) this._emitRaw('slowQuery', this.instanceId, result);
   }
 
   /**
@@ -939,7 +939,7 @@ export class MemcachedEngine extends BaseEngine<
   ): Promise<{ value: string; cas?: string } | null> {
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
-    const maxBytes = this.getOption('maxBufferSize')! * 1024 * 1024;
+    const maxBytes = this._getOption('maxBufferSize')! * 1024 * 1024;
     const op = command.split(' ')[0]!;
 
     const start = performance.now();

--- a/packages/drivers/engines/mongo/Engine.test.ts
+++ b/packages/drivers/engines/mongo/Engine.test.ts
@@ -4,6 +4,21 @@ import { envArgs } from '@tundralibs/utils';
 import { MongoEngine } from './Engine.ts';
 import { EngineError } from '../../errors/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/drivers/');
 
 const TEST_CONFIG = {
@@ -59,7 +74,7 @@ describe({
       it('should default port to 27017', () => {
         const { port: _port, ...rest } = TEST_CONFIG;
         const engine = new MongoEngine('cfg-2', rest);
-        asserts.assertEquals(engine.getOption('port'), 27017);
+        asserts.assertEquals(readOption(engine, 'port'), 27017);
       });
 
       it('should require host or uri', () => {

--- a/packages/drivers/engines/mongo/Engine.ts
+++ b/packages/drivers/engines/mongo/Engine.ts
@@ -132,7 +132,7 @@ export class MongoEngine
     options: EventOptionKeys<MongoEngineOptions, MongoEngineEvents>,
   ) {
     super(name, options, MONGO_DEFAULTS);
-    this.__slowThresholdMs = (this.getOption('slowQueryThreshold') ?? 0.5) *
+    this.__slowThresholdMs = (this._getOption('slowQueryThreshold') ?? 0.5) *
       1000;
     if (
       this.hasOption('uri') === false &&
@@ -172,11 +172,11 @@ export class MongoEngine
       try {
         this.__client = await this._connectClient();
         this._status = 'READY';
-        this.emit('connect', this.instanceId);
+        this._emit('connect', this.instanceId);
       } catch (e) {
         this._status = 'CLOSED';
         const error = this.__wrapMongoError(e, 'connect');
-        this.emit('connectionFailed', this.instanceId, error);
+        this._emit('connectionFailed', this.instanceId, error);
         throw error;
       }
     })();
@@ -196,7 +196,7 @@ export class MongoEngine
    */
   protected _connectClient(): Promise<MongoClient> {
     return MongoClient.connect(this.__buildUri(), {
-      ...(this.getOption('driverOptions') ?? {}),
+      ...(this._getOption('driverOptions') ?? {}),
     });
   }
 
@@ -223,10 +223,10 @@ export class MongoEngine
         this.__client = null;
       }
       this._status = 'CLOSED';
-      this.emit('disconnect', this.instanceId);
+      this._emit('disconnect', this.instanceId);
     } catch (e) {
       const error = this.__wrapMongoError(e, 'disconnect');
-      this.emit('error', this.instanceId, error);
+      this._emit('error', this.instanceId, error);
       throw error;
     }
   }
@@ -866,7 +866,7 @@ export class MongoEngine
   }
 
   private __defaultDb(): string {
-    const db = this.getOption('database');
+    const db = this._getOption('database');
     if (!db) {
       throw new EngineError('MISSING_CONFIG_VALUE', {
         instanceId: this.instanceId,
@@ -883,16 +883,16 @@ export class MongoEngine
    *   hostname / IPv4 / bracketed IPv6 (guards against URI injection).
    */
   private __buildUri(): string {
-    const explicit = this.getOption('uri');
+    const explicit = this._getOption('uri');
     if (explicit) return explicit;
 
-    const host = this.getOption('host')!;
-    const port = this.getOption('port') ?? 27017;
-    const username = this.getOption('username');
-    const password = this.getOption('password');
-    const database = this.getOption('database');
-    const replicaSet = this.getOption('replicaSet');
-    const authSource = this.getOption('authSource') ??
+    const host = this._getOption('host')!;
+    const port = this._getOption('port') ?? 27017;
+    const username = this._getOption('username');
+    const password = this._getOption('password');
+    const database = this._getOption('database');
+    const replicaSet = this._getOption('replicaSet');
+    const authSource = this._getOption('authSource') ??
       (username ? 'admin' : undefined);
 
     // `host` is interpolated raw into the URI authority (username,

--- a/packages/drivers/engines/neon/Engine.ts
+++ b/packages/drivers/engines/neon/Engine.ts
@@ -115,17 +115,17 @@ export class NeonHttpEngine extends SQLConnectionEngine<
    * makes it edge/serverless-safe.
    */
   protected override _open(): void {
-    const database = this.getOption('database');
+    const database = this._getOption('database');
     this._resource = new NeonHttpClient({
-      host: this.getOption('host')!,
-      endpoint: this.getOption('endpoint'),
-      connectionString: this.getOption('connectionString'),
-      username: this.getOption('username'),
-      password: this.getOption('password'),
+      host: this._getOption('host')!,
+      endpoint: this._getOption('endpoint'),
+      connectionString: this._getOption('connectionString'),
+      username: this._getOption('username'),
+      password: this._getOption('password'),
       // Base allows `string | number` for `database`; Neon uses string names.
       database: database === undefined ? undefined : String(database),
-      token: this.getOption('token'),
-      timeout: this.getOption('timeout'),
+      token: this._getOption('token'),
+      timeout: this._getOption('timeout'),
     });
   }
 
@@ -393,7 +393,7 @@ export class NeonHttpEngine extends SQLConnectionEngine<
 
   /** Whether an option is set to a meaningful (non-empty for strings) value. */
   private __present(key: keyof NeonHttpEngineOptions): boolean {
-    const v = this.getOption(key);
+    const v = this._getOption(key);
     if (v === undefined) return false;
     if (typeof v === 'string') return v.trim().length > 0;
     return true;

--- a/packages/drivers/engines/neon/NeonHttpClient.ts
+++ b/packages/drivers/engines/neon/NeonHttpClient.ts
@@ -188,7 +188,7 @@ export class NeonHttpClient extends RESTler<NeonRESTlerOptions> {
     endpoint: RESTlerEndpoint,
   ): Promise<void> {
     await super._authInjector(endpoint);
-    const connectionString = this.getOption('connectionString');
+    const connectionString = this._getOption('connectionString');
     if (connectionString) {
       endpoint.headers = endpoint.headers || {};
       endpoint.headers['Neon-Connection-String'] = connectionString;

--- a/packages/drivers/engines/postgres/Engine.test.ts
+++ b/packages/drivers/engines/postgres/Engine.test.ts
@@ -6,6 +6,21 @@ import { PgServerError } from './PgServerError.ts';
 import { EngineError } from '../../errors/mod.ts';
 import type { EngineQuery } from '../../types/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/drivers/');
 
 const TEST_CONFIG = {
@@ -60,7 +75,7 @@ describe('drivers.PostgresEngine', () => {
     it('should default port to 5432', () => {
       const { port: _p, ...rest } = TEST_CONFIG;
       const engine = new PostgresEngine('cfg-2', rest);
-      asserts.assertEquals(engine.getOption('port'), 5432);
+      asserts.assertEquals(readOption(engine, 'port'), 5432);
     });
 
     it('should require host / database / username', () => {

--- a/packages/drivers/engines/postgres/Engine.ts
+++ b/packages/drivers/engines/postgres/Engine.ts
@@ -122,9 +122,9 @@ export class PostgresEngine
   protected async _createResource(): Promise<PgConnection> {
     // Constructor enforces host / username / database are present, so
     // the non-null assertions below are safe.
-    const hostname = this.getOption('host')!;
-    const port = this.getOption('port')!;
-    const ssl = this.getOption('ssl');
+    const hostname = this._getOption('host')!;
+    const port = this._getOption('port')!;
+    const ssl = this._getOption('ssl');
     const enforceTls = ssl
       ? (typeof ssl === 'object' ? ssl.enforce !== false : true)
       : false;
@@ -133,7 +133,7 @@ export class PostgresEngine
     // `notice` emitted on every cleartext-over-plaintext handshake. Only an
     // explicit `allowCleartextPassword: false` turns that into a refusal.
     const allowCleartextPassword =
-      this.getOption('allowCleartextPassword') !== false;
+      this._getOption('allowCleartextPassword') !== false;
 
     // First attempt: plain TCP, then SSL upgrade if configured. `tlsActive`
     // tracks whether the socket ended up encrypted — used to gate
@@ -152,7 +152,7 @@ export class PostgresEngine
       // ssl is configured but `enforce: false` — surrender encryption
       // and reconnect plain. Loud emit so this isn't silently invisible.
       const reason = e instanceof Error ? e.message : String(e);
-      this.emit(
+      this._emit(
         'notice',
         this.instanceId,
         `WARNING: TLS failed (${reason}); falling back to plaintext per ssl.enforce=false`,
@@ -162,15 +162,15 @@ export class PostgresEngine
     }
 
     const pg = new PgConnection(conn, (msg) => {
-      this.emit('notice', this.instanceId, msg);
+      this._emit('notice', this.instanceId, msg);
     }, this.instanceId);
     try {
       await pg.connect({
-        user: this.getOption('username')!,
-        database: String(this.getOption('database')),
-        password: this.getOption('password'),
-        applicationName: this.getOption('applicationName') ?? this.Name,
-        statementTimeoutMs: this.getOption('statementTimeoutMs'),
+        user: this._getOption('username')!,
+        database: String(this._getOption('database')),
+        password: this._getOption('password'),
+        applicationName: this._getOption('applicationName') ?? this.Name,
+        statementTimeoutMs: this._getOption('statementTimeoutMs'),
         tlsActive,
         allowCleartextPassword,
       });
@@ -191,22 +191,22 @@ export class PostgresEngine
         looksLikeTlsRuntimeError(e);
       if (ssl && !enforceTls && isTlsErr) {
         const reason = e instanceof Error ? e.message : String(e);
-        this.emit(
+        this._emit(
           'notice',
           this.instanceId,
           `WARNING: TLS handshake failed during startup (${reason}); falling back to plaintext per ssl.enforce=false`,
         );
         const plain = await connect({ hostname, port });
         const pgPlain = new PgConnection(plain, (msg) => {
-          this.emit('notice', this.instanceId, msg);
+          this._emit('notice', this.instanceId, msg);
         }, this.instanceId);
         try {
           await pgPlain.connect({
-            user: this.getOption('username')!,
-            database: String(this.getOption('database')),
-            password: this.getOption('password'),
-            applicationName: this.getOption('applicationName') ?? this.Name,
-            statementTimeoutMs: this.getOption('statementTimeoutMs'),
+            user: this._getOption('username')!,
+            database: String(this._getOption('database')),
+            password: this._getOption('password'),
+            applicationName: this._getOption('applicationName') ?? this.Name,
+            statementTimeoutMs: this._getOption('statementTimeoutMs'),
             // Plaintext fallback — the socket is unencrypted.
             tlsActive: false,
             allowCleartextPassword,
@@ -240,7 +240,7 @@ export class PostgresEngine
     port: number,
   ): Promise<Connection> {
     const tcp = await connect({ hostname, port });
-    const ssl = this.getOption('ssl');
+    const ssl = this._getOption('ssl');
     if (!ssl) return tcp;
 
     try {

--- a/packages/drivers/engines/redis/Engine.test.ts
+++ b/packages/drivers/engines/redis/Engine.test.ts
@@ -7,6 +7,21 @@ import { RedisConnection } from './RedisConnection.ts';
 import { EngineError } from '../../errors/mod.ts';
 import type { Connection } from '@tundralibs/compat';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+
 const env = envArgs('./packages/drivers/');
 
 const TEST_CONFIG = {
@@ -51,12 +66,12 @@ describe({
 
       it('should default port to 6379', () => {
         const engine = new RedisEngine('cfg-2', { host: TEST_CONFIG.host });
-        asserts.assertEquals(engine.getOption('port'), 6379);
+        asserts.assertEquals(readOption(engine, 'port'), 6379);
       });
 
       it('should default database to 0', () => {
         const engine = new RedisEngine('cfg-3', TEST_CONFIG);
-        asserts.assertEquals(engine.getOption('database'), 0);
+        asserts.assertEquals(readOption(engine, 'database'), 0);
       });
 
       it('should require host', () => {

--- a/packages/drivers/engines/redis/Engine.ts
+++ b/packages/drivers/engines/redis/Engine.ts
@@ -99,9 +99,9 @@ export class RedisEngine
     options: EventOptionKeys<RedisEngineOptions, RedisEngineEvents>,
   ) {
     super(name, options, REDIS_DEFAULTS);
-    this.__slowThresholdMs = (this.getOption('slowQueryThreshold') ?? 0.5) *
+    this.__slowThresholdMs = (this._getOption('slowQueryThreshold') ?? 0.5) *
       1000;
-    this.__targetDb = (this.getOption('database') as number | undefined) ?? 0;
+    this.__targetDb = (this._getOption('database') as number | undefined) ?? 0;
     this._requireOptions(['host']);
   }
 
@@ -123,11 +123,11 @@ export class RedisEngine
    *   a `notice` so it isn't silently invisible.
    */
   protected async _createResource(): Promise<RedisConnection> {
-    const hostname = this.getOption('host');
-    const port = this.getOption('port')!;
-    const ssl = this.getOption('ssl');
+    const hostname = this._getOption('host');
+    const port = this._getOption('port')!;
+    const ssl = this._getOption('ssl');
     const enforceTls = _resolveEnforceTls(ssl);
-    const bufferBytes = this.getOption('maxBufferSize')! * 1024 * 1024;
+    const bufferBytes = this._getOption('maxBufferSize')! * 1024 * 1024;
 
     let conn: RedisConnection;
     try {
@@ -140,7 +140,7 @@ export class RedisEngine
     } catch (e) {
       if (!ssl || enforceTls) throw e;
       const reason = e instanceof Error ? e.message : String(e);
-      this.emit(
+      this._emit(
         'notice',
         this.instanceId,
         `WARNING: TLS connect failed (${reason}); falling back to plaintext per ssl.enforce=false`,
@@ -164,7 +164,7 @@ export class RedisEngine
       // were on a TLS connection with `enforce: false`.
       if (ssl && !enforceTls && looksLikeTlsRuntimeError(e)) {
         const reason = e instanceof Error ? e.message : String(e);
-        this.emit(
+        this._emit(
           'notice',
           this.instanceId,
           `WARNING: TLS handshake failed during auth (${reason}); falling back to plaintext per ssl.enforce=false`,
@@ -227,8 +227,8 @@ export class RedisEngine
    * support `HELLO`. Selects the configured logical database afterwards.
    */
   private async __handshake(conn: RedisConnection): Promise<void> {
-    const username = this.getOption('username');
-    const password = this.getOption('password');
+    const username = this._getOption('username');
+    const password = this._getOption('password');
     // A new (or reconnected) connection must adopt the engine's *current*
     // target database, which may have moved past the configured one via
     // `select()` — otherwise a pool refill would silently revert to the old
@@ -979,8 +979,8 @@ export class RedisEngine
       time: timeMs,
       isSlow,
     };
-    this._emit('query', this.instanceId, result);
-    if (isSlow) this._emit('slowQuery', this.instanceId, result);
+    this._emitRaw('query', this.instanceId, result);
+    if (isSlow) this._emitRaw('slowQuery', this.instanceId, result);
   }
 
   /**

--- a/packages/drivers/engines/sqlite/Engine.ts
+++ b/packages/drivers/engines/sqlite/Engine.ts
@@ -170,26 +170,26 @@ export class SQLiteEngine extends SQLEngine<SqliteDb, SQLiteEngineOptions> {
   }
 
   protected async _createResource(): Promise<SqliteDb> {
-    const path = this.getOption('path')!;
+    const path = this._getOption('path')!;
 
     if (path === ':memory:') {
       return await this._openDatabase(':memory:', {
-        readonly: this.getOption('readonly'),
-        create: this.getOption('create'),
+        readonly: this._getOption('readonly'),
+        create: this._getOption('create'),
       });
     }
 
     // Directory mode. Resolve `<path>/<name-lowercased>/` and ensure the
     // directory + `main.db` exist (when `create` is true).
     const dir = resolvePath(join(path, this.Name.toLowerCase()));
-    if (this.getOption('create') !== false) {
+    if (this._getOption('create') !== false) {
       await makeDir(dir, { recursive: true });
     }
     this.#schemaDir = dir;
     const mainDb = join(dir, 'main.db');
     const db = await this._openDatabase(mainDb, {
-      readonly: this.getOption('readonly'),
-      create: this.getOption('create'),
+      readonly: this._getOption('readonly'),
+      create: this._getOption('create'),
     });
 
     // Auto-attach every other `.db` file in the directory under its

--- a/packages/drivers/engines/turso/Engine.ts
+++ b/packages/drivers/engines/turso/Engine.ts
@@ -120,9 +120,9 @@ export class TursoEngine extends SQLConnectionEngine<
    */
   protected override _open(): void {
     this._resource = new TursoHttpClient({
-      url: this.getOption('url'),
-      authToken: this.getOption('authToken') ?? '',
-      timeout: this.getOption('timeout'),
+      url: this._getOption('url'),
+      authToken: this._getOption('authToken') ?? '',
+      timeout: this._getOption('timeout'),
     });
   }
 

--- a/packages/id/mod.ts
+++ b/packages/id/mod.ts
@@ -1,7 +1,8 @@
 /**
- * @fileoverview Main entry point for the ID package.
- *
- * Re-exports all ID generators and character set constants.
+ * @fileoverview `@tundralibs/id` — cross-runtime unique-id generation:
+ * ULID (lexicographically sortable), nanoID (compact, alphabet-tunable),
+ * ObjectID (MongoDB-compatible), sequential ids, and OTP generation,
+ * plus the character-set constants they build on.
  *
  * @module
  */

--- a/packages/metro-man/mod.ts
+++ b/packages/metro-man/mod.ts
@@ -1,6 +1,9 @@
 /**
- * @fileoverview Public entry point — re-exports every class, type,
- * and error the package exposes.
+ * @fileoverview `@tundralibs/metro-man` — Prometheus-compatible
+ * in-process metrics for Deno, Bun, and Node: the four standard metric
+ * types (`Counter`, `Gauge`, `Histogram`, `Summary`) and a registry
+ * (`MetroMan`) with bulk collection in JSON, debug-string, or the
+ * Prometheus text exposition format via one `dump(mode)` call.
  *
  * @module
  */

--- a/packages/norm/Norm.ts
+++ b/packages/norm/Norm.ts
@@ -216,28 +216,29 @@ export class Norm extends Options<NormConfig, NormEvents> {
         cb: (id: string, r: EngineQueryResult) => void,
       ): unknown;
     };
-    on('connect', (id) => void this.emit('connect', id));
-    on('disconnect', (id) => void this.emit('disconnect', id));
+    on('connect', (id) => void this._emit('connect', id));
+    on('disconnect', (id) => void this._emit('disconnect', id));
     on(
       'connectionFailed',
-      (id, err) => void this.emit('connectionFailed', id, err),
+      (id, err) => void this._emit('connectionFailed', id, err),
     );
-    on('error', (id, err) => void this.emit('error', id, err));
+    on('error', (id, err) => void this._emit('error', id, err));
     on(
       'query',
       (id, r) =>
-        void this.emit('query', id, r.id, r.time, r.isSlow, r.transactionId),
+        void this._emit('query', id, r.id, r.time, r.isSlow, r.transactionId),
     );
     on(
       'slowQuery',
-      (id, r) => void this.emit('slowQuery', id, r.id, r.time, r.transactionId),
+      (id, r) =>
+        void this._emit('slowQuery', id, r.id, r.time, r.transactionId),
     );
     // transactionTimeout is a SQL-only engine event (Mongo has no tx).
     if (!(engine instanceof MongoEngine)) {
       engine.on(
         'transactionTimeout',
         (_id: string, txId: string) =>
-          void this.emit('transactionTimeout', txId),
+          void this._emit('transactionTimeout', txId),
       );
     }
   }
@@ -258,7 +259,7 @@ export class Norm extends Options<NormConfig, NormEvents> {
       registry,
       this.__compileCfg,
       this.__executor,
-      (event, ...args) => void this.emit(event, ...args),
+      (event, ...args) => void this._emit(event, ...args),
       this.__witness,
     );
     // NOT intersected with Record<string, AnyDefinition> — that would

--- a/packages/pact/PACT.test.ts
+++ b/packages/pact/PACT.test.ts
@@ -14,6 +14,30 @@ import {
 } from './errors/mod.ts';
 import type { PACTEvents, PACTGrants } from './types/mod.ts';
 
+// Wave-note: emission/option accessors are protected now — tests reach
+// them through deliberate casts.
+// deno-lint-ignore no-explicit-any
+const readOption = (t: unknown, k: string): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOption(k);
+// deno-lint-ignore no-explicit-any
+const readOptions = (t: unknown): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._getOptions();
+// deno-lint-ignore no-explicit-any
+const fireEvent = (t: unknown, e: string, ...a: unknown[]): any =>
+  // deno-lint-ignore no-explicit-any
+  (t as any)._emitRaw(e, ...a);
+const fireEventSync = (
+  t: unknown,
+  e: string,
+  ...a: unknown[]
+): Promise<unknown> =>
+  (t as { _emitSync(e: string, ...a: unknown[]): Promise<unknown> })._emitSync(
+    e,
+    ...a,
+  );
+
 /** Minimal cross-runtime fetch stub with call recording. */
 type SeenInit = {
   method?: string;
@@ -52,7 +76,7 @@ const SECRET =
 describe('pact.PACT', () => {
   it('constructs via Options; config is readable through getOption', () => {
     const pact = new PACT({ bits: BITS, modules: { Post: ['READ', 'EDIT'] } });
-    asserts.assertEquals(pact.getOption('bits').READ, 1n);
+    asserts.assertEquals(readOption(pact, 'bits').READ, 1n);
     asserts.assertEquals(pact.permissions.modules, ['Post']);
   });
 
@@ -956,16 +980,16 @@ describe('pact.PACT review fixes', () => {
   it('M2: the secret never surfaces via getOption/getOptions', () => {
     const pact = new PACT({ bits: BITS, secret: SECRET, issuer: 'x' });
     asserts.assertEquals(
-      (pact as unknown as { getOption(k: string): unknown }).getOption(
+      (pact as unknown as { _getOption(k: string): unknown })._getOption(
         'secret',
       ),
       undefined,
     );
     asserts.assertEquals(
-      (pact.getOptions() as { secret?: unknown }).secret,
+      (readOptions(pact) as { secret?: unknown }).secret,
       undefined,
     );
-    asserts.assertEquals(pact.getOption('issuer'), 'x'); // non-secret opts fine
+    asserts.assertEquals(readOption(pact, 'issuer'), 'x'); // non-secret opts fine
   });
 
   it('L3: HS* enforces the RFC 7518 §3.2 per-algorithm secret minimum', () => {
@@ -1855,7 +1879,7 @@ describe('pact.PACT round-4 review findings', () => {
       await new Promise((r) => setTimeout(r, 1));
       order.push('B-end');
     });
-    await pact.emitSync('verify', { sub: 'u' }, 'tok');
+    await fireEventSync(pact, 'verify', { sub: 'u' }, 'tok');
     // emitSync's contract: the next listener does not start until the
     // previous one resolves, and it returns only once all are done.
     asserts.assertEquals(order, ['A-start', 'A-end', 'B-start', 'B-end']);
@@ -1865,7 +1889,7 @@ describe('pact.PACT round-4 review findings', () => {
     const pact = new PACT({ bits: BITS, secret: SECRET });
     pact.on('verify', () => Promise.reject(new Error('audit write failed')));
     const err = await asserts.assertRejects(
-      () => pact.emitSync('verify', { sub: 'u' }, 'tok'),
+      () => fireEventSync(pact, 'verify', { sub: 'u' }, 'tok'),
       Error,
     );
     asserts.assertEquals((err as Error).message, 'audit write failed');

--- a/packages/pact/PACT.ts
+++ b/packages/pact/PACT.ts
@@ -124,14 +124,14 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
       algorithm: 'HS256',
       expiry: 3600,
     } as Partial<PACTOptions<P>>);
-    const bits = this.getOption('bits');
+    const bits = this._getOption('bits');
     if (bits === undefined) {
       throw new PactDefinitionError(
         'PACT requires a `bits` permission registry',
         { code: 'MISSING_OPTION', option: 'bits' },
       );
     }
-    this.__permissions = new Permissions<P>(bits, this.getOption('modules'));
+    this.__permissions = new Permissions<P>(bits, this._getOption('modules'));
 
     // Validate key material against the algorithm family: HS* takes one
     // shared secret string; RS* takes a PEM { privateKey, publicKey } pair.
@@ -166,15 +166,15 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     }
 
     // Group resolution (consumer-owned data; PACT caches + syncs).
-    const resolver = this.getOption('groupResolver');
+    const resolver = this._getOption('groupResolver');
     if (resolver !== undefined) {
       this.__groups = new Groups(resolver);
-      const interval = this.getOption('syncInterval') ?? 0;
+      const interval = this._getOption('syncInterval') ?? 0;
       if (interval > 0) this.__startSync(interval);
     }
 
     // OAuth provider instances (each doubles as a login strategy).
-    const oauth = this.getOption('oauth');
+    const oauth = this._getOption('oauth');
     if (oauth !== undefined) {
       for (const [name, config] of Object.entries(oauth)) {
         this.__oauth.set(
@@ -440,7 +440,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
    */
   async syncGroups(groupIds?: string[]): Promise<string[]> {
     const ids = await this.__requireGroups().sync(groupIds);
-    if (ids.length > 0) this.emit('sync', ids);
+    if (ids.length > 0) this._emit('sync', ids);
     return ids;
   }
 
@@ -500,9 +500,9 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
   async generateJWT(claims: JWTPayload): Promise<string> {
     const key = this.__signKey();
     const now = Math.floor(Date.now() / 1000);
-    const expiry = this.getOption('expiry') ?? 3600;
-    const issuer = this.getOption('issuer');
-    const audience = this.getOption('audience');
+    const expiry = this._getOption('expiry') ?? 3600;
+    const issuer = this._getOption('issuer');
+    const audience = this._getOption('audience');
     const payload: JWTPayload = {
       iat: now,
       exp: now + expiry,
@@ -514,9 +514,9 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
       this.__algorithm(),
       payload,
       key,
-      this.getOption('keyId'),
+      this._getOption('keyId'),
     );
-    this.emit('issue', token, payload);
+    this._emit('issue', token, payload);
     return token;
   }
 
@@ -539,8 +539,8 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     token: string,
   ): Promise<T> {
     const key = this.__verifyKey();
-    const issuer = this.getOption('issuer');
-    const audience = this.getOption('audience');
+    const issuer = this._getOption('issuer');
+    const audience = this._getOption('audience');
     let claims: T;
     try {
       claims = await cryptVerifyJWT<T>(token, key, {
@@ -548,7 +548,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
         ...(issuer !== undefined ? { iss: issuer } : {}),
         ...(audience !== undefined ? { aud: audience } : {}),
       });
-      const isRevoked = this.getOption('isRevoked');
+      const isRevoked = this._getOption('isRevoked');
       if (isRevoked !== undefined && await isRevoked(claims)) {
         // The revocation decision is final. Isolate the audit emit so a
         // throwing `revoked` listener can't replace the PactTokenError the
@@ -591,8 +591,8 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     const fresh = await cryptRefreshJWT(
       token,
       this.__refreshKeys(),
-      this.getOption('expiry') ?? 3600,
-      this.getOption('keyId'),
+      this._getOption('expiry') ?? 3600,
+      this._getOption('keyId'),
     );
     // The fresh token is already minted — isolate listener errors like the
     // other success emits. [F1]
@@ -699,7 +699,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     name: string,
     credentials: unknown,
   ): Promise<PACTLoginResult | null> {
-    const strategy = this.getOption('strategies')?.[name];
+    const strategy = this._getOption('strategies')?.[name];
     const oauth = this.__oauth.get(name);
     if (strategy === undefined && oauth === undefined) {
       throw new PactDefinitionError(
@@ -714,7 +714,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
         outcome = await strategy(credentials);
       } else {
         const profile = await oauth!.callback(credentials as CallbackParams);
-        const map = this.getOption('oauth')![name]!.map;
+        const map = this._getOption('oauth')![name]!.map;
         outcome = map !== undefined
           ? await map(profile)
           : { id: `${name}:${profile.id}`, profile };
@@ -747,7 +747,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
       }
       result = { principal, isNew };
       // Inside the try so an autoIssue failure routes through loginFailed. [L6]
-      if (this.getOption('autoIssue') === true) {
+      if (this._getOption('autoIssue') === true) {
         result.token = await this.generateJWT({ sub: principal.id });
       }
     } catch (error) {
@@ -823,7 +823,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     ...args: Parameters<PACTEvents[K]>
   ): void {
     try {
-      this.emit(event, ...args);
+      this._emit(event, ...args);
     } catch {
       // Listener exceptions are isolated by contract — the operation's
       // outcome is already final and must be reported as such.
@@ -892,7 +892,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
 
   /** The configured algorithm (defaulted at construction). */
   private __algorithm(): JWTAlgorithm {
-    return this.getOption('algorithm') ?? 'HS256';
+    return this._getOption('algorithm') ?? 'HS256';
   }
 
   /** True for the symmetric (`HS*`) family. */
@@ -949,7 +949,7 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
         // Isolate a throwing consumer handler so it can't surface as an
         // unhandled rejection from the detached timer. [L4]
         try {
-          this.emit('syncFailed', error as Error);
+          this._emit('syncFailed', error as Error);
         } catch { /* swallow listener errors on the detached timer path */ }
       });
     }, interval);

--- a/packages/restler/CHANGELOG.md
+++ b/packages/restler/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.1.0](https://github.com/TundraSoft/TundraLibs/compare/restler-v1.0.1...restler-v1.1.0) (2026-08-09)
+
+
+### Features
+
+* **restler:** witness + headerProvider — the propagator hooks ([09e8968](https://github.com/TundraSoft/TundraLibs/commit/09e8968bcb20ad60a6eb017e602a3915be3be8c8))
+* **restler:** witness + headerProvider propagator hooks ([c4f8442](https://github.com/TundraSoft/TundraLibs/commit/c4f844235f555cba164c1a8a12283811c48bd055))
+
+
+### Documentation
+
+* **restler:** self-consistent Observability example + RESTlerHooks type ([fb08d01](https://github.com/TundraSoft/TundraLibs/commit/fb08d01bdf3f099ac2ba9efd3e22388da542c078))
+
 ## [1.0.1](https://github.com/TundraSoft/TundraLibs/compare/restler-v1.0.0...restler-v1.0.1) (2026-08-09)
 
 

--- a/packages/restler/RESTler.ts
+++ b/packages/restler/RESTler.ts
@@ -184,7 +184,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
         },
       );
     }
-    this._defaultHeaders = this.getOption('headers') || {};
+    this._defaultHeaders = this._getOption('headers') || {};
   }
 
   //#region Event registration (per-listener isolation)
@@ -357,7 +357,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
         },
       );
     }
-    const auth = endpoint.auth ?? this.getOption('auth');
+    const auth = endpoint.auth ?? this._getOption('auth');
     if (auth) {
       endpoint.headers = endpoint.headers || {};
       if (auth.type === 'BASIC') {
@@ -618,7 +618,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     ...args: Parameters<RESTlerEvents[K]>
   ): void {
     try {
-      this.emit(event, ...args);
+      this._emit(event, ...args);
     } catch {
       // Defensive backstop; per-listener isolation (see `on`) already contains
       // listener faults. The base client has no logger, so any error that
@@ -787,7 +787,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     endpoint: RESTlerEndpoint,
     responseHandler?: RESTlerResponseHandler,
   ): Promise<RESTlerResponse<B>> {
-    const witness = this.getOption('witness');
+    const witness = this._getOption('witness');
     if (witness === undefined) {
       return this.__request<B>(endpoint, responseHandler);
     }
@@ -854,9 +854,9 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
         signal: controller.signal,
       };
       if (body !== undefined) init.body = body;
-      const socketPath = this.getOption('socketPath');
+      const socketPath = this._getOption('socketPath');
       if (socketPath) init.unix = socketPath;
-      const tls = this.getOption('tls');
+      const tls = this._getOption('tls');
       if (tls) init.tls = tls;
 
       const resp = await this._fetch(request.url, init);
@@ -1146,9 +1146,9 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     // invalid content type shouldn't cost the caller a token refresh first.
     const contentType = 'contentType' in endpoint
       ? this.__resolveEndpointContentType(endpoint.contentType)
-      : this.getOption('contentType');
-    const baseURL = endpoint.baseURL ?? this.getOption('baseURL');
-    const port = endpoint.port ?? this.getOption('port');
+      : this._getOption('contentType');
+    const baseURL = endpoint.baseURL ?? this._getOption('baseURL');
+    const port = endpoint.port ?? this._getOption('port');
     if (endpoint.port && !this._validatePort(endpoint.port)) {
       // Validate port!!!
       throw new RESTlerConfigError(
@@ -1166,7 +1166,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     // explicit always beats ambient. Values are runtime-computed, so no
     // {version} replacement. A throwing provider is contained: observability
     // wiring must never break the request it decorates.
-    const headerProvider = this.getOption('headerProvider');
+    const headerProvider = this._getOption('headerProvider');
     if (headerProvider !== undefined) {
       try {
         for (const [key, value] of Object.entries(headerProvider() ?? {})) {
@@ -1221,7 +1221,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
         { vendor: this.vendor, key: 'timeout', value: timeout },
       );
     }
-    return timeout ?? this.getOption('timeout')!;
+    return timeout ?? this._getOption('timeout')!;
   }
 
   /**
@@ -1242,7 +1242,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
         { vendor: this.vendor, key: 'version', value: version },
       );
     }
-    return version ?? this.getOption('version') ?? '';
+    return version ?? this._getOption('version') ?? '';
   }
 
   /**

--- a/packages/restler/deno.json
+++ b/packages/restler/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tundralibs/restler",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Cross-runtime REST API client base class for building typed per-vendor SDKs on Deno, Bun, and Node.js",
   "license": "MIT",
   "exports": {

--- a/packages/restler/package.json
+++ b/packages/restler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tundralibs/restler",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Cross-runtime REST API client base class for building typed per-vendor SDKs on Deno, Bun, and Node.js",
   "type": "module",
   "main": "mod.ts",

--- a/packages/restler/tests/RESTler.test.ts
+++ b/packages/restler/tests/RESTler.test.ts
@@ -103,7 +103,7 @@ class TestRESTler extends RESTler {
 
   // Expose the resolved (post-_processOption) option value for assertions.
   public readOption<K extends keyof RESTlerOptions>(key: K) {
-    return this.getOption(key);
+    return this._getOption(key);
   }
 }
 

--- a/packages/slogger/mod.ts
+++ b/packages/slogger/mod.ts
@@ -1,6 +1,24 @@
 /**
- * Slogger - Structured logging library for Deno
+ * @fileoverview `@tundralibs/slogger` — cross-runtime structured
+ * logging (Deno, Bun, Node) that fans a single log record out to many
+ * destinations in-process: console, JSON, logfmt, syslog (RFC 5424),
+ * file, HTTP, and TCP handlers, each with its own format, level
+ * threshold, and masking. A `contextProvider` stamps every record with
+ * ambient correlation data (request ids, trace ids) without threading
+ * loggers through call stacks.
+ *
  * @module
+ *
+ * @example
+ * ```typescript
+ * import { ConsoleHandler, Slogger } from '@tundralibs/slogger';
+ *
+ * const log = new Slogger({
+ *   appName: 'api',
+ *   handlers: [new ConsoleHandler({ level: 'INFO' })],
+ * });
+ * log.info('server started', { port: 8080 });
+ * ```
  */
 
 export {

--- a/packages/tracer/CHANGELOG.md
+++ b/packages/tracer/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.5.0](https://github.com/TundraSoft/TundraLibs/compare/tracer-v0.4.1...tracer-v0.5.0) (2026-08-09)
+
+
+### Features
+
+* **tracer:** wrapClient + propagation — the outbound adapters ([2797c16](https://github.com/TundraSoft/TundraLibs/commit/2797c16b97bdca8ca4dc6d93f42e5a1490b41a71))
+* **tracer:** wrapClient + propagation outbound adapters ([0ff696c](https://github.com/TundraSoft/TundraLibs/commit/0ff696c11ce4ec7e87f9e47d048fd7835ace8904))
+
+
+### Documentation
+
+* **tracer:** revise the outbound-tracing decision record ([fc1049e](https://github.com/TundraSoft/TundraLibs/commit/fc1049e394c2aeff9af46a17e33e824ed80f44de))
+
 ## [0.4.1](https://github.com/TundraSoft/TundraLibs/compare/tracer-v0.4.0...tracer-v0.4.1) (2026-08-09)
 
 

--- a/packages/tracer/README.md
+++ b/packages/tracer/README.md
@@ -95,6 +95,17 @@ await tracer.startActiveSpan(
 );
 ```
 
+For clients built on `@tundralibs/restler` (≥ 1.1) the outbound side is two
+lines of wiring — a CLIENT span per request, `traceparent` carrying that
+request's own span id:
+
+```typescript
+const api = new PaymentsAPI(token, {
+  witness: tracer.wrapClient, // span per outbound request
+  headerProvider: tracer.propagation, // traceparent per request
+});
+```
+
 ### 3. Correlate logs with traces
 
 Slogger's `contextProvider` is called for every record, so trace ids land on

--- a/packages/tracer/ROADMAP.md
+++ b/packages/tracer/ROADMAP.md
@@ -22,6 +22,12 @@ shaped the package.
   keys that `otelLogFormatter` hoists — the names that once shipped wrong in
   our own docs now live in code). Both bound arrows, both structural, no new
   dependencies in either direction.
+- **Outbound propagation adapters** — `tracer.wrapClient` (the Witness
+  adapter at `SpanKind.CLIENT`, for restler's `witness` hook) and
+  `tracer.propagation` (restler's `headerProvider`: the active span as a
+  W3C `traceparent` header, `{}` outside a span, sampled flag clear on
+  unsampled spans). Completes the seam rule: leaf = events, container =
+  witness, propagator = pre-send headers.
 
 ### Encoder: Guardian, decided by measurement
 
@@ -109,13 +115,14 @@ inline.
 - **Sampling is head-based and parent-inherited.** Child spans never re-sample;
   a partially-sampled trace renders as a waterfall with holes. `ratioSampler`
   derives its verdict from the trace id so independent services agree.
-- **Outbound tracing (restler, drivers) stays a recipe, not code.** A
-  first-class `tracer/restler` or driver hook would make outbound calls and
-  queries traced by default rather than by discipline, and unlike Express these
-  are our own APIs — so the usual "we can't track their churn" argument does not
-  apply. It was still declined: it would couple tracer to those packages (or
-  those packages to tracer) for something a ~10-line wrapper already does, and
-  the wrappers are documented in
+- **Outbound tracing couples through generic seams, never imports.**
+  Originally "stays a recipe, not code"; **revised 2026-08 for restler** —
+  but the part worth not relitigating survived: no `tracer/restler` module,
+  no import in either direction. Restler grew two _generic_ hooks
+  (`witness`, `headerProvider`), tracer ships the matching bound adapters
+  (`wrapClient`, `propagation`), and the app connects them at the
+  composition root — same shape as norm's witness and slogger's
+  `contextProvider`. The raw-`fetch` wrapper remains a recipe in
   [Tracer-Recipes](docs/Tracer-Recipes.md#outbound-propagating-the-trace).
 
   `drivers` settles it further: its engines already emit `query`, `slowQuery`,

--- a/packages/tracer/Tracer.test.ts
+++ b/packages/tracer/Tracer.test.ts
@@ -488,4 +488,95 @@ describe('tracer.adapters', () => {
       asserts.assertEquals(provider(), {});
     });
   });
+
+  describe('wrapClient (the outbound Witness adapter)', () => {
+    it('opens a CLIENT-kind span, same witness contract as wrap', async () => {
+      const { tracer, exporter } = tracerWith();
+      const result = await tracer.wrapClient(
+        {
+          name: 'restler.github GET',
+          attributes: { 'restler.vendor': 'github', dropped: { deep: true } },
+        },
+        () => Promise.resolve(42),
+      );
+      asserts.assertEquals(result, 42);
+      const span = exporter.find('restler.github GET')!;
+      asserts.assertEquals(span.kind, SpanKind.CLIENT);
+      asserts.assertEquals(span.attributes['restler.vendor'], 'github');
+      asserts.assertEquals('dropped' in span.attributes, false);
+    });
+
+    it('is ambient-active while fn runs — the propagation precondition', async () => {
+      const { tracer } = tracerWith();
+      const witness = tracer.wrapClient; // detached — must stay bound
+      await witness({ name: 'out' }, () => {
+        asserts.assert('traceId' in tracer.logContext());
+        return Promise.resolve();
+      });
+    });
+
+    it('records and rethrows errors', async () => {
+      const { tracer, exporter } = tracerWith();
+      await asserts.assertRejects(
+        () =>
+          tracer.wrapClient(
+            { name: 'boom.client' },
+            () => Promise.reject(new Error('down')),
+          ),
+        Error,
+        'down',
+      );
+      asserts.assertEquals(
+        exporter.find('boom.client')!.events[0]!.attributes[
+          'exception.message'
+        ],
+        'down',
+      );
+    });
+  });
+
+  describe('propagation (the headerProvider adapter)', () => {
+    it('returns {} outside any span — request goes out unpropagated', () => {
+      const { tracer } = tracerWith();
+      asserts.assertEquals(tracer.propagation(), {});
+    });
+
+    it('returns a valid traceparent carrying the ACTIVE span', () => {
+      const { tracer } = tracerWith();
+      tracer.startActiveSpan('op', (span) => {
+        const headers = tracer.propagation();
+        asserts.assertEquals(
+          headers['traceparent'],
+          `00-${span.context.traceId}-${span.context.spanId}-01`,
+        );
+        // The output is itself a valid carrier — round-trips through extract.
+        const parent = extract(headers);
+        asserts.assertEquals(parent!.traceId, span.context.traceId);
+      });
+    });
+
+    it('serialises unsampled spans with the flag CLEAR', () => {
+      const { tracer } = tracerWith({ sampler: alwaysOffSampler });
+      tracer.startActiveSpan('dropped', (span) => {
+        asserts.assertEquals(
+          tracer.propagation()['traceparent'],
+          `00-${span.context.traceId}-${span.context.spanId}-00`,
+        );
+      });
+    });
+
+    it('carries the wrapClient span when composed — restler wiring', async () => {
+      const { tracer } = tracerWith();
+      const provider = tracer.propagation; // detached — must stay bound
+      await tracer.wrapClient({ name: 'out' }, () => {
+        const inner = tracer.logContext() as { spanId: string };
+        // The header carries THIS request's span, not some outer one.
+        asserts.assert(
+          provider()['traceparent']!.includes(inner.spanId),
+        );
+        return Promise.resolve();
+      });
+      asserts.assertEquals(provider(), {});
+    });
+  });
 });

--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -28,7 +28,7 @@ import { activeSpan } from './activeSpan.ts';
 import { Span } from './Span.ts';
 import { randomIdGenerator } from './ids.ts';
 import { alwaysOnSampler } from './samplers.ts';
-import { FLAG_SAMPLED } from './propagation.ts';
+import { FLAG_SAMPLED, inject } from './propagation.ts';
 import { TracerConfigError } from './errors/mod.ts';
 import type {
   Attributes,
@@ -66,9 +66,8 @@ export class Tracer extends Options<TracerOptions> {
    */
   constructor(options: TracerOptions) {
     super();
-    this._setOptions(options, {
+    this._setOptions({ idGenerator: randomIdGenerator, ...options }, {
       sampler: alwaysOnSampler,
-      idGenerator: randomIdGenerator,
       resource: {},
     });
   }
@@ -169,7 +168,7 @@ export class Tracer extends Options<TracerOptions> {
    * @returns The new {@link Span}.
    */
   public startSpan(name: string, options: SpanOptions = {}): Span {
-    const idGenerator = this.getOption('idGenerator') as IdGenerator;
+    const idGenerator = this._getOption('idGenerator') as IdGenerator;
     const parent = this.__resolveParent(options);
     const kind = options.kind ?? SpanKind.INTERNAL;
     const attributes = options.attributes ?? {};
@@ -179,7 +178,7 @@ export class Tracer extends Options<TracerOptions> {
     // only roots consult the sampler.
     const sampled = parent !== undefined
       ? (parent.traceFlags & FLAG_SAMPLED) !== 0
-      : (this.getOption('sampler') as Sampler)({
+      : (this._getOption('sampler') as Sampler)({
         traceId,
         name,
         kind,
@@ -285,6 +284,50 @@ export class Tracer extends Options<TracerOptions> {
     info: { name: string; attributes?: Record<string, unknown> },
     fn: () => Promise<T>,
   ): Promise<T> => {
+    return this.startActiveSpan(
+      info.name,
+      { attributes: this.__witnessAttributes(info) },
+      fn,
+    );
+  };
+
+  /**
+   * {@link Tracer.wrap} with `SpanKind.CLIENT` — the Witness-shaped adapter
+   * for **outbound** operations (an HTTP request, a call into another
+   * service). CLIENT kind is what trace backends use to draw
+   * service-dependency edges, so a wrapped outbound call shows up as an edge
+   * in the service map rather than internal work.
+   *
+   * A bound arrow, so it works detached:
+   *
+   * ```ts
+   * const api = new GitHubAPI(token, {
+   *   witness: tracer.wrapClient, // span per outbound request
+   *   headerProvider: tracer.propagation, // traceparent per request
+   * });
+   * ```
+   *
+   * Same contract and attribute sanitisation as {@link Tracer.wrap}.
+   */
+  public readonly wrapClient = <T>(
+    info: { name: string; attributes?: Record<string, unknown> },
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    return this.startActiveSpan(
+      info.name,
+      { kind: SpanKind.CLIENT, attributes: this.__witnessAttributes(info) },
+      fn,
+    );
+  };
+
+  /**
+   * Attribute values outside the OTLP-representable set (strings, numbers,
+   * booleans, and arrays of those) are dropped rather than exported
+   * malformed — witness callers pass `Record<string, unknown>`.
+   */
+  private __witnessAttributes(
+    info: { attributes?: Record<string, unknown> },
+  ): Attributes {
     const attributes: Attributes = {};
     for (const [key, value] of Object.entries(info.attributes ?? {})) {
       if (
@@ -299,8 +342,8 @@ export class Tracer extends Options<TracerOptions> {
         attributes[key] = value as Attributes[string];
       }
     }
-    return this.startActiveSpan(info.name, { attributes }, fn);
-  };
+    return attributes;
+  }
 
   /**
    * Composition-root adapter for slogger's `contextProvider`: the active
@@ -332,12 +375,37 @@ export class Tracer extends Options<TracerOptions> {
   };
 
   /**
+   * Composition-root adapter for **outbound propagation** (restler's
+   * `headerProvider`, or any per-request header seam): the active span's
+   * context as a W3C `traceparent` header, so the downstream service joins
+   * this trace instead of starting its own.
+   *
+   * Returns `{}` outside any span — the request simply goes out
+   * unpropagated. An **unsampled** span still serialises (with the sampled
+   * flag clear), so downstream learns the sampling decision rather than
+   * re-deciding for itself. A bound arrow, so it works detached:
+   *
+   * ```ts
+   * // restler (>= 1.1): every outbound request carries traceparent
+   * const api = new GitHubAPI(token, { headerProvider: tracer.propagation });
+   *
+   * // pairs with the per-request CLIENT span from `witness: tracer.wrapClient`
+   * // — the provider runs inside the witnessed window, so the header carries
+   * // that request's own span id.
+   * ```
+   */
+  public readonly propagation = (): Record<string, string> => {
+    const span = activeSpan.get();
+    return span === undefined ? {} : { traceparent: inject(span.context) };
+  };
+
+  /**
    * Flush and release the exporter. Call before process exit so buffered spans
    * are not lost.
    */
   public async shutdown(): Promise<void> {
     await Promise.allSettled(this.__pending);
-    const exporter = this.getOption('exporter') as SpanExporter | undefined;
+    const exporter = this._getOption('exporter') as SpanExporter | undefined;
     await exporter?.shutdown?.();
   }
 
@@ -356,8 +424,8 @@ export class Tracer extends Options<TracerOptions> {
   /** `service.name` merged with any user-supplied resource attributes. */
   private __resourceAttributes(): Attributes {
     return {
-      ...(this.getOption('resource') as Attributes),
-      'service.name': this.getOption('serviceName') as string,
+      ...(this._getOption('resource') as Attributes),
+      'service.name': this._getOption('serviceName') as string,
     };
   }
 
@@ -366,7 +434,7 @@ export class Tracer extends Options<TracerOptions> {
    * broken collector must never surface as an application error.
    */
   private __export(data: SpanData): void {
-    const exporter = this.getOption('exporter') as SpanExporter | undefined;
+    const exporter = this._getOption('exporter') as SpanExporter | undefined;
     if (exporter === undefined) return;
     let promise: Promise<void>;
     // The two failure modes need two different guards, and both are load-bearing:

--- a/packages/tracer/deno.json
+++ b/packages/tracer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tundralibs/tracer",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Cross-runtime distributed tracing — W3C Trace Context propagation, automatic span nesting via ambient async context, pluggable samplers and exporters",
   "license": "MIT",
   "exports": {

--- a/packages/tracer/docs/Tracer-Recipes.md
+++ b/packages/tracer/docs/Tracer-Recipes.md
@@ -365,6 +365,24 @@ router.use(tracing);
 Open a `CLIENT` span and inject `traceparent`, so the callee joins this trace
 rather than starting its own.
 
+For API clients built on [`@tundralibs/restler`](../../restler/README.md)
+(≥ 1.1) this is wiring, not code — restler's two hooks compose through the
+ambient store with no coupling in either direction:
+
+```typescript
+const api = new GitHubAPI(token, {
+  witness: tracer.wrapClient, // CLIENT span per outbound request
+  headerProvider: tracer.propagation, // traceparent — carries THAT span's id
+});
+```
+
+`headerProvider` runs inside the witnessed window, so the header carries the
+per-request span, not the distant server span. Either hook also works alone:
+`headerProvider` by itself still propagates (downstream parents to whatever
+span is active), `witness` by itself still draws the client edge in the
+service map. For raw `fetch` — or any client without a header seam — wrap it
+yourself:
+
 ```typescript
 const tracedFetch = (input: string, init: RequestInit = {}) =>
   tracer.startActiveSpan(

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tundralibs/tracer",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Cross-runtime distributed tracing — W3C Trace Context propagation, automatic span nesting via ambient async context, pluggable samplers and exporters",
   "license": "MIT",
   "type": "module",

--- a/packages/utils/Events.test.ts
+++ b/packages/utils/Events.test.ts
@@ -1,6 +1,25 @@
 import * as asserts from '@std/asserts';
 import { describe, it } from '@tundralibs/compat';
-import { Events } from './Events.ts';
+import { type EventCallback, Events } from './Events.ts';
+
+/** Test harness: re-exposes the protected emission surface. */
+class TestEvents<
+  E extends Record<string, EventCallback> = Record<string, EventCallback>,
+> extends Events<E> {
+  public emit<K extends keyof E>(event: K, ...args: Parameters<E[K]>): this {
+    return this._emit(event, ...args);
+  }
+  public emitSync<K extends keyof E>(
+    event: K,
+    ...args: Parameters<E[K]>
+  ): Promise<this> {
+    return this._emitSync(event, ...args);
+  }
+  public listenerErrors: unknown[] = [];
+  protected override _onListenerError(_e: PropertyKey, err: unknown): void {
+    this.listenerErrors.push(err);
+  }
+}
 
 // Helper function to create a delayed function
 const createDelayedFunction = (delay: number, callback: () => void) => {
@@ -13,7 +32,7 @@ const createDelayedFunction = (delay: number, callback: () => void) => {
 describe('utils.Events', () => {
   it('should register and emit untyped events', () => {
     let cnt = 0;
-    const events = new Events();
+    const events = new TestEvents();
     const cb = (_name: string) => cnt++;
     events.on('hello', cb);
     events.emit('hello', 'world');
@@ -25,7 +44,7 @@ describe('utils.Events', () => {
       greet: (name: string) => void;
     };
     let cnt = 0;
-    const events = new Events<EventMap>();
+    const events = new TestEvents<EventMap>();
     const cb = (_name: string) => cnt += 2;
     events.on('greet', cb);
     events.emit('greet', 'world');
@@ -35,7 +54,7 @@ describe('utils.Events', () => {
   it(
     'should not wait for async callbacks when using emit',
     async () => {
-      const events = new Events();
+      const events = new TestEvents();
       let cnt = 0;
 
       // Create callbacks that increment counter after a delay
@@ -65,7 +84,7 @@ describe('utils.Events', () => {
   it(
     'should register and emit async events synchronously',
     async () => {
-      const events = new Events();
+      const events = new TestEvents();
       let cnt = 3;
       let timer1: ReturnType<typeof setTimeout> | undefined;
       const cb = async (_name: string) => {
@@ -91,7 +110,7 @@ describe('utils.Events', () => {
 
   it('should unregister specific event listeners', () => {
     let cnt = 0;
-    const events = new Events();
+    const events = new TestEvents();
     const cb = (_name: string) => cnt++;
     const cb2 = (_name: string) => cnt++;
     const cb3 = (_name: string) => cnt++;
@@ -103,7 +122,7 @@ describe('utils.Events', () => {
 
   it('should unregister all event listeners', () => {
     let cnt = 0;
-    const events = new Events();
+    const events = new TestEvents();
     const cb = (_name: string) => cnt++;
     const cb2 = (_name: string) => cnt++;
     const cb3 = (_name: string) => cnt++;
@@ -115,7 +134,7 @@ describe('utils.Events', () => {
 
   it('should call "once" event listeners only once', () => {
     let cnt = 0;
-    const events = new Events();
+    const events = new TestEvents();
     const cb = (_name: string) => cnt++;
     const cb2 = (_name: string) => cnt++;
     events.once('hello', [cb, cb2]);
@@ -125,14 +144,14 @@ describe('utils.Events', () => {
   });
 
   it('should not throw when emitting an unregistered event', () => {
-    const events = new Events();
+    const events = new TestEvents();
     events.emit('hello');
   });
 
   it(
     'should not throw when emitting an unregistered event',
     async () => {
-      const events = new Events();
+      const events = new TestEvents();
       // Both methods should be tested separately
       events.emit('hello');
       await events.emitSync('hello');
@@ -142,7 +161,7 @@ describe('utils.Events', () => {
   it('should support method chaining', () => {
     let count1 = 0;
     let count2 = 0;
-    const events = new Events();
+    const events = new TestEvents();
 
     // Chain multiple method calls
     events
@@ -157,7 +176,7 @@ describe('utils.Events', () => {
 
   it('should not register duplicate callbacks', () => {
     let count = 0;
-    const events = new Events();
+    const events = new TestEvents();
     const callback = () => count++;
 
     // Register the same callback twice
@@ -171,7 +190,7 @@ describe('utils.Events', () => {
   it('should handle multiple event types independently', () => {
     let count1 = 0;
     let count2 = 0;
-    const events = new Events();
+    const events = new TestEvents();
 
     events.on('event1', () => count1++);
     events.on('event2', () => count2++);
@@ -187,7 +206,7 @@ describe('utils.Events', () => {
 
   it('should continue execution when callbacks throw errors', () => {
     let executedCallbacks = 0;
-    const events = new Events();
+    const events = new TestEvents();
 
     events.on('error-test', [
       () => {
@@ -198,22 +217,20 @@ describe('utils.Events', () => {
       },
     ]);
 
-    try {
-      events.emit('error-test');
-      asserts.fail('Should have thrown an error');
-    } catch (e) {
-      asserts.assertEquals((e as Error).message, 'Test error');
-      asserts.assertEquals(
-        executedCallbacks,
-        0,
-        'Second callback should not execute after error',
-      );
-    }
+    // Isolated emission: the throw is contained (routed to
+    // _onListenerError) and the NEXT listener still runs.
+    events.emit('error-test');
+    asserts.assertEquals(executedCallbacks, 1);
+    asserts.assertEquals(events.listenerErrors.length, 1);
+    asserts.assertEquals(
+      (events.listenerErrors[0] as Error).message,
+      'Test error',
+    );
   });
 
   it('should handle async errors in emitSync', async () => {
     let executedCallbacks = 0;
-    const events = new Events();
+    const events = new TestEvents();
 
     events.on('async-error', [
       () => {
@@ -224,22 +241,19 @@ describe('utils.Events', () => {
       },
     ]);
 
-    try {
-      await events.emitSync('async-error');
-      asserts.fail('Should have thrown an error');
-    } catch (e) {
-      asserts.assertEquals((e as Error).message, 'Async test error');
-      asserts.assertEquals(
-        executedCallbacks,
-        0,
-        'Second callback should not execute after error',
-      );
-    }
+    // _emitSync is the HANDLED path: the rejection propagates to the
+    // awaiting caller and later listeners do not run.
+    await asserts.assertRejects(
+      () => events.emitSync('async-error'),
+      Error,
+      'Async test error',
+    );
+    asserts.assertEquals(executedCallbacks, 0);
   });
 
   it('should allow off() to remove an array of callbacks', () => {
     let count = 0;
-    const events = new Events();
+    const events = new TestEvents();
     const callback1 = () => count++;
     const callback2 = () => count++;
 
@@ -251,7 +265,7 @@ describe('utils.Events', () => {
   });
 
   it('should handle nested event emissions', () => {
-    const events = new Events();
+    const events = new TestEvents();
     let outerCount = 0;
     let innerCount = 0;
 
@@ -276,7 +290,7 @@ describe('utils.Events', () => {
   });
 
   it('should correctly handle once() with nested emissions', () => {
-    const events = new Events();
+    const events = new TestEvents();
     let count = 0;
 
     events.once('test', () => {
@@ -296,7 +310,7 @@ describe('utils.Events', () => {
   it(
     'should not fail when registering an empty callback array',
     () => {
-      const events = new Events();
+      const events = new TestEvents();
       events.on('test', []);
       events.emit('test'); // Should not throw
     },
@@ -305,7 +319,7 @@ describe('utils.Events', () => {
   it(
     'should not fail when off() is called for non-existent callbacks',
     () => {
-      const events = new Events();
+      const events = new TestEvents();
       const callback = () => {};
 
       // Register no callbacks
@@ -318,7 +332,7 @@ describe('utils.Events', () => {
   );
 
   it('should properly handle multiple arguments', () => {
-    const events = new Events<{
+    const events = new TestEvents<{
       multiArg: (arg1: number, arg2: string, arg3: boolean) => void;
     }>();
 
@@ -339,7 +353,7 @@ describe('utils.Events', () => {
   it(
     'should maintain correct execution order in emitSync',
     async () => {
-      const events = new Events();
+      const events = new TestEvents();
       const executionOrder: number[] = [];
 
       events.on('ordered', [
@@ -364,7 +378,7 @@ describe('utils.Events', () => {
   );
 
   it('should allow once() to work with async callbacks', async () => {
-    const events = new Events();
+    const events = new TestEvents();
     let count = 0;
 
     events.once('async-once', async () => {
@@ -390,7 +404,7 @@ describe('utils.Events', () => {
         complexEvent: (obj: { id: number; name: string }) => void;
       };
 
-      const events = new Events<ComplexEventMap>();
+      const events = new TestEvents<ComplexEventMap>();
       let receivedObject: { id: number; name: string } | null = null;
 
       events.on('complexEvent', (obj) => {
@@ -412,14 +426,14 @@ describe('utils.Events', () => {
   );
 
   it('should return this when off() is called for non-existent event', () => {
-    const events = new Events();
+    const events = new TestEvents();
     // off on event that was never registered should not throw
     const result = events.off('nonexistent');
     asserts.assertStrictEquals(result, events);
   });
 
   it('should return this when emit() is called for event with no listeners', () => {
-    const events = new Events();
+    const events = new TestEvents();
     const result = events.emit('noop');
     asserts.assertStrictEquals(result, events);
   });
@@ -428,10 +442,10 @@ describe('utils.Events', () => {
     type TestEvents = { ping: () => void };
     class TestEmitter extends Events<TestEvents> {
       fire(): this {
-        return this._emit('ping');
+        return this._emitRaw('ping');
       }
       fireWithListeners(): this {
-        return this._emit('ping');
+        return this._emitRaw('ping');
       }
     }
     const emitter = new TestEmitter();
@@ -444,7 +458,7 @@ describe('utils.Events', () => {
     type TestEvents = { ping: (n: number) => void };
     class TestEmitter extends Events<TestEvents> {
       fire(n: number): this {
-        return this._emit('ping', n);
+        return this._emitRaw('ping', n);
       }
     }
     const emitter = new TestEmitter();
@@ -454,5 +468,55 @@ describe('utils.Events', () => {
     });
     emitter.fire(42);
     asserts.assertStrictEquals(received, 42);
+  });
+});
+
+describe('utils.Events hardening (protected emission wave)', () => {
+  it('snapshot semantics: listeners added during an emission fire next time', () => {
+    const events = new TestEvents();
+    let lateRan = 0;
+    events.on('e', () => {
+      events.on('e', () => lateRan++);
+    });
+    events.emit('e');
+    asserts.assertEquals(lateRan, 0); // not in THIS emission
+    events.emit('e');
+    asserts.assertEquals(lateRan, 1); // joined the next one
+  });
+
+  it('once() is removable via off(original) and dedupes', () => {
+    const events = new TestEvents();
+    let fired = 0;
+    const cb = () => fired++;
+    events.once('e', cb);
+    events.off('e', cb); // original callback, wrapper resolved internally
+    events.emit('e');
+    asserts.assertEquals(fired, 0);
+
+    events.once('e', cb);
+    events.once('e', cb); // duplicate — no-op like on()
+    events.emit('e');
+    asserts.assertEquals(fired, 1);
+    events.emit('e');
+    asserts.assertEquals(fired, 1); // once means once
+  });
+
+  it('async listener rejection in emit() is routed to _onListenerError', async () => {
+    const events = new TestEvents();
+    let after = 0;
+    events.on('e', [
+      async () => {
+        throw new Error('async boom');
+      },
+      () => after++,
+    ]);
+    events.emit('e');
+    await new Promise((r) => setTimeout(r, 5));
+    asserts.assertEquals(after, 1);
+    asserts.assertEquals(events.listenerErrors.length, 1);
+    asserts.assertEquals(
+      (events.listenerErrors[0] as Error).message,
+      'async boom',
+    );
   });
 });

--- a/packages/utils/Events.ts
+++ b/packages/utils/Events.ts
@@ -1,21 +1,33 @@
 /**
- * @fileoverview {@link Events} — a tiny typed event emitter with
- * `on` / `off` / `once` / `emit` / `emitSync`. The generic parameter
- * `E` maps event names to their callback signatures so the compiler
- * can validate args at every call site.
+ * @fileoverview {@link Events} — a tiny typed event emitter with a
+ * public `on` / `off` / `once` subscription surface and PROTECTED
+ * emission (`_emit` / `_emitSync` / `_emitRaw`): only the owning class
+ * fires its events, so outsiders cannot forge lifecycle signals.
+ * Listeners are isolated per emission — a throwing or rejecting
+ * listener is routed to {@link Events._onListenerError}, never
+ * propagated into the emitter or other listeners.
  *
  * @module
  */
 
-// deno-lint-ignore-file
-
 /** Sync or async callback registered with {@link Events.on}. */
+// deno-lint-ignore no-explicit-any
 export type EventCallback = (...args: any[]) => unknown;
 
 /**
  * Typed event emitter. Subclass with an `E` map of event-name to
  * callback signature; the compiler then enforces correct arg types
- * at every `on`/`emit` site.
+ * at every `on`/`_emit` site.
+ *
+ * Emission semantics:
+ * - Emission is `protected` — the public surface is subscription only.
+ * - Each emission iterates a SNAPSHOT of the listener set: listeners
+ *   added during an emission fire from the next emission; listeners
+ *   removed during an emission still receive the current one.
+ * - Listeners are isolated: a synchronous throw or an asynchronous
+ *   rejection (from `_emit`'s fire-and-forget promises) is caught and
+ *   routed to {@link Events._onListenerError}; remaining listeners
+ *   still run.
  *
  * @typeParam E - Map of event names to callback signatures.
  *
@@ -26,7 +38,7 @@ export type EventCallback = (...args: any[]) => unknown;
  *   error: (e: Error) => void;
  * }
  * class App extends Events<AppEvents> {
- *   run() { this.emit('start'); }
+ *   run() { this._emit('start'); }
  * }
  * ```
  */
@@ -34,6 +46,11 @@ export class Events<
   E extends Record<string, EventCallback> = Record<string, EventCallback>,
 > {
   private readonly __events: Map<keyof E, Set<EventCallback>> = new Map();
+  /** Per-event map of original `once` callback → self-removing wrapper. */
+  private readonly __onceWrappers: Map<
+    keyof E,
+    Map<EventCallback, EventCallback>
+  > = new Map();
 
   /**
    * Register `callback` (or each function in an array) for `event`.
@@ -60,7 +77,9 @@ export class Events<
 
   /**
    * Remove `callback` from `event` (or every listener for `event`
-   * when `callback` is omitted).
+   * when `callback` is omitted). Accepts the ORIGINAL callback for
+   * listeners registered via {@link Events.once} — the internal
+   * wrapper is resolved automatically.
    */
   public off<K extends keyof E>(event: K, callback?: E[K]): this;
   public off<K extends keyof E>(event: K, callback?: E[K][]): this;
@@ -70,6 +89,7 @@ export class Events<
     }
     if (callback === undefined) {
       this.__events.delete(event);
+      this.__onceWrappers.delete(event);
       return this;
     }
     const eventCallbacks = this.__events.get(event);
@@ -77,15 +97,27 @@ export class Events<
 
     if (Array.isArray(callback)) {
       for (const cb of callback) {
-        eventCallbacks.delete(cb);
+        this.off(event, cb as E[keyof E]);
       }
+      return this;
+    }
+    const wrappers = this.__onceWrappers.get(event);
+    const wrapper = wrappers?.get(callback);
+    if (wrapper !== undefined) {
+      eventCallbacks.delete(wrapper);
+      wrappers!.delete(callback);
     } else {
       eventCallbacks.delete(callback);
     }
     return this;
   }
 
-  /** Like {@link on}, but each listener fires at most once. */
+  /**
+   * Like {@link Events.on}, but each listener fires at most once.
+   * Duplicate registrations are no-ops (matching `on`), and the
+   * listener can be removed before firing with
+   * `off(event, originalCallback)`.
+   */
   public once<K extends keyof E>(event: K, callback: E[K]): this;
   public once<K extends keyof E>(event: K, callback: E[K][]): this;
   public once(event: string, callback: EventCallback | EventCallback[]) {
@@ -94,40 +126,52 @@ export class Events<
         this.once(event, cb as E[keyof E]);
       }
       return this;
-    } else {
-      const onceCallback = (...args: Parameters<E[keyof E]>) => {
-        this.off(event, onceCallback as E[keyof E]);
-        return callback(...args);
-      };
-      return this.on(event, onceCallback as E[keyof E]);
     }
+    let wrappers = this.__onceWrappers.get(event);
+    if (wrappers?.has(callback)) return this; // dedupe, like on()
+    if (wrappers === undefined) {
+      wrappers = new Map();
+      this.__onceWrappers.set(event, wrappers);
+    }
+    const wrapper: EventCallback = (...args: unknown[]) => {
+      // Self-remove by WRAPPER identity — virtual dispatch, so a
+      // subclass that layers its own wrapping in on()/off() (keyed by
+      // what IT received, i.e. this wrapper) translates the removal
+      // correctly. The original→wrapper mapping is cleaned here so the
+      // off(original) support never leaks entries.
+      wrappers!.delete(callback);
+      this.off(event, wrapper as E[keyof E]);
+      return callback(...args);
+    };
+    wrappers.set(callback, wrapper);
+    return this.on(event, wrapper as E[keyof E]);
   }
 
   /**
-   * Fire `event` and call every listener with `args`. Listeners run
-   * in registration order; promises returned by async listeners are
-   * not awaited (use {@link emitSync} for that).
+   * Fire `event`, calling every listener with `args` (registration
+   * order, snapshot semantics). Promises returned by async listeners
+   * are not awaited — their rejections are routed to
+   * {@link Events._onListenerError} (use {@link Events._emitSync} to
+   * await listeners).
    */
-  emit<K extends keyof E>(
+  protected _emit<K extends keyof E>(
     event: K,
     ...args: Parameters<E[K]>
   ): this {
-    const callbacks = this.__events.get(event);
-    if (!callbacks) {
-      return this;
-    }
-
-    for (const cb of callbacks) {
-      cb(...args);
-    }
-    return this;
+    return this.__dispatchEvent(event, args);
   }
 
   /**
-   * Like {@link emit} but awaits each listener in turn — the next
-   * listener does not start until the previous one resolves.
+   * Like {@link Events._emit} but awaits each listener in turn — the
+   * next listener does not start until the previous one settles.
+   *
+   * Unlike the fire-and-forget `_emit`, a throw/rejection here
+   * PROPAGATES to the awaiting caller (and stops later listeners):
+   * `_emitSync` is the deliberate, handled emission path — the caller
+   * chose to await and owns the failure. Use `_emit` when emission
+   * must never affect the emitter.
    */
-  async emitSync<K extends keyof E>(
+  protected async _emitSync<K extends keyof E>(
     event: K,
     ...args: Parameters<E[K]>
   ): Promise<this> {
@@ -135,43 +179,64 @@ export class Events<
     if (!callbacks) {
       return this;
     }
-
-    for (const cb of callbacks) {
+    for (const cb of [...callbacks]) {
       await cb(...args);
     }
-
     return this;
   }
 
   /**
-   * Variance-tolerant emit for use inside generic base classes.
+   * Variance-tolerant {@link Events._emit} for use inside generic base
+   * classes.
    *
-   * The strictly-typed {@link emit} requires `Parameters<E[K]>` for its args,
-   * which TypeScript can't always resolve when `E` is a generic parameter
-   * (e.g. inside a base class that declares `<E extends BaseEvents>`). In
-   * those contexts, the call site knows the event/args match `BaseEvents`
-   * but TS refuses to project them through the generic constraint.
-   *
-   * `_emit` keeps the typed key parameter (so typos still error) while
-   * accepting `unknown[]` args. Use this only inside base classes for
-   * events declared in the constrained base — never expose it as the
-   * public emission API.
+   * The strictly-typed `_emit` requires `Parameters<E[K]>` for its
+   * args, which TypeScript can't always resolve when `E` is a generic
+   * parameter (e.g. inside a base class that declares
+   * `<E extends BaseEvents>`). In those contexts the call site knows
+   * the event/args match `BaseEvents`, but TS refuses to project them
+   * through the generic constraint. `_emitRaw` keeps the typed key
+   * parameter (so typos still error) while accepting `unknown[]` args.
+   * Same isolation and snapshot semantics as `_emit`.
    *
    * @example
    * ```typescript
    * abstract class Base<E extends BaseEvents> extends Events<E> {
    *   protected _onConnect(): void {
-   *     // Strict emit fails: variance on E['connect'].
-   *     this._emit('connect', this.id);  // works
+   *     // Strict _emit fails: variance on E['connect'].
+   *     this._emitRaw('connect', this.id); // works
    *   }
    * }
    * ```
    */
-  protected _emit<K extends keyof E>(event: K, ...args: unknown[]): this {
+  protected _emitRaw<K extends keyof E>(event: K, ...args: unknown[]): this {
+    return this.__dispatchEvent(event, args);
+  }
+
+  /**
+   * Listener-fault hook: every synchronous throw and every rejection
+   * from a fire-and-forget async listener lands here. The default
+   * reports to `console.error`; override to route into a logger or
+   * metrics. MUST NOT throw.
+   */
+  protected _onListenerError(event: PropertyKey, error: unknown): void {
+    console.error(`[events] '${String(event)}' listener error:`, error);
+  }
+
+  /** Shared isolated dispatch for {@link Events._emit} / {@link Events._emitRaw}. */
+  private __dispatchEvent<K extends keyof E>(event: K, args: unknown[]): this {
     const callbacks = this.__events.get(event);
-    if (!callbacks) return this;
-    for (const cb of callbacks) {
-      cb(...args);
+    if (!callbacks) {
+      return this;
+    }
+    for (const cb of [...callbacks]) {
+      try {
+        const out = cb(...args) as unknown;
+        if (out instanceof Promise) {
+          out.catch((error) => this._onListenerError(event, error));
+        }
+      } catch (error) {
+        this._onListenerError(event, error);
+      }
     }
     return this;
   }

--- a/packages/utils/Options.test.ts
+++ b/packages/utils/Options.test.ts
@@ -7,6 +7,18 @@ describe('utils.Options', () => {
   type Opt = { a?: string; b?: number; c: boolean };
   type Evnt = { change: () => void };
   class TypedOptions extends Options<Opt, Evnt> {
+    public getOption<K extends string>(key: K) {
+      // deno-lint-ignore no-explicit-any
+      return this._getOption(key as any);
+    }
+    public getOptions() {
+      return this._getOptions();
+    }
+    // deno-lint-ignore no-explicit-any
+    public emit(event: any, ...args: unknown[]) {
+      // deno-lint-ignore no-explicit-any
+      return this._emitRaw(event, ...args as any);
+    }
     constructor(opt: EventOptionKeys<Opt, Evnt>) {
       super();
       super._setOptions(opt, { b: 10 });
@@ -41,6 +53,18 @@ describe('utils.Options', () => {
   }
 
   class UnTypedOptions extends Options {
+    public getOption<K extends string>(key: K) {
+      // deno-lint-ignore no-explicit-any
+      return this._getOption(key as any);
+    }
+    public getOptions() {
+      return this._getOptions();
+    }
+    // deno-lint-ignore no-explicit-any
+    public emit(event: any, ...args: unknown[]) {
+      // deno-lint-ignore no-explicit-any
+      return this._emitRaw(event, ...args as any);
+    }
     constructor(
       opt: EventOptionKeys<
         Record<string, unknown>,
@@ -186,5 +210,55 @@ describe('utils.Options', () => {
     snapshot.c = false;
     asserts.assertStrictEquals(options.getOption('c'), true);
     asserts.assertStrictEquals(options.getOptions().c, true);
+  });
+});
+
+describe('utils.Options hardening (group merge + safe copies)', () => {
+  type GroupOpts = {
+    name: string;
+    server: { port: number; host: string; secure: boolean };
+    tags: string[];
+  };
+  class Grouped extends Options<GroupOpts> {
+    constructor(cfg: Partial<GroupOpts>) {
+      super();
+      this._setOptions(cfg, {
+        server: { port: 8080, host: 'localhost', secure: false },
+        tags: ['default'],
+      });
+    }
+    public read<K extends keyof GroupOpts>(key: K): GroupOpts[K] {
+      return this._getOption(key);
+    }
+    public readAll(): GroupOpts {
+      return this._getOptions();
+    }
+  }
+
+  it('a partial group merges UNDER the group defaults', () => {
+    const o = new Grouped({
+      name: 'x',
+      server: { port: 9999 } as GroupOpts['server'],
+    });
+    asserts.assertEquals(o.read('server').port, 9999); // caller wins
+    asserts.assertEquals(o.read('server').host, 'localhost'); // default kept
+    asserts.assertEquals(o.read('server').secure, false); // default kept
+  });
+
+  it('arrays replace wholesale (no merging)', () => {
+    const o = new Grouped({ name: 'x', tags: ['a'] });
+    asserts.assertEquals(o.read('tags'), ['a']);
+  });
+
+  it('explicit undefined leaves the default in place', () => {
+    const o = new Grouped({ name: 'x', server: undefined });
+    asserts.assertEquals(o.read('server').port, 8080);
+  });
+
+  it('_getOptions() nested group copies cannot corrupt the store', () => {
+    const o = new Grouped({ name: 'x' });
+    const bag = o.readAll();
+    bag.server.port = -1;
+    asserts.assertEquals(o.read('server').port, 8080); // store untouched
   });
 });

--- a/packages/utils/Options.ts
+++ b/packages/utils/Options.ts
@@ -21,14 +21,27 @@ export type EventOptionKeys<
   };
 
 /**
+ * Is `value` a plain object (object literal / null-prototype) — as
+ * opposed to an array, class instance, function, or primitive?
+ * Grouped-option merging and defensive copying apply only to these.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
  * Base class combining a typed option store with an {@link Events}
  * emitter. Subclasses call `_setOptions(config, defaults)` from their
- * constructor and override {@link _processOption} to validate or
- * transform values before they're stored.
+ * constructor and override {@link Options._processOption} to validate
+ * or transform values before they're stored.
  *
- * Options live in a {@link PrivateObject} — callers read via
- * `getOption`/`getOptions`/`hasOption`, but only the subclass can
- * write (via the protected `_setOption*` methods).
+ * Options live in a {@link PrivateObject}: the store is readable only
+ * by the subclass (`_getOption`/`_getOptions`) and writable only via
+ * the protected `_setOption*` methods — option bags routinely carry
+ * credentials, so nothing is exposed on the public surface beyond
+ * {@link Options.hasOption}.
  *
  * @typeParam O - Option keys and their value types.
  * @typeParam E - Event names and their callback signatures.
@@ -43,6 +56,9 @@ export type EventOptionKeys<
  *     super();
  *     this._setOptions(c, { port: 5432 });
  *   }
+ *   get port(): number {
+ *     return this._getOption('port');
+ *   }
  * }
  *
  * new Db({ host: 'localhost', _onconnect: () => {} });
@@ -54,24 +70,36 @@ export abstract class Options<
 > extends Events<E> {
   private readonly __options: PrivateObject<O> = privateObject<O>();
 
-  constructor() {
-    super();
-  }
-
+  /** Whether `key` is present in the option store. */
   public hasOption<K extends keyof O>(key: K): boolean {
     return this.__options.has(key);
   }
 
-  public getOption<K extends keyof O>(key: K): O[K] {
+  /**
+   * Read one option. Protected: option bags routinely carry
+   * credentials — expose specific values through purpose-built public
+   * getters instead of the raw store.
+   */
+  protected _getOption<K extends keyof O>(key: K): O[K] {
     return this.__options.get(key);
   }
 
-  public getOptions(): O {
-    // Return a shallow copy so mutating the result (e.g.
-    // `getOptions().port = -1`) cannot write into the internal store and
-    // bypass `_processOption` validation. Callers must go through
-    // `_setOption` to change stored options.
-    return { ...this.__options.asObject() };
+  /**
+   * Read a defensive copy of the whole option bag: the bag itself is
+   * copied and every plain-object GROUP value is copied one level
+   * deep, so mutating the result (including `result.group.key = x`)
+   * cannot write into the internal store and bypass
+   * {@link Options._processOption} validation. Non-plain values
+   * (class instances, functions, arrays) are returned as-is.
+   */
+  protected _getOptions(): O {
+    const source = this.__options.asObject();
+    const copy: Record<string, unknown> = {};
+    for (const key in source) {
+      const value = source[key];
+      copy[key] = isPlainObject(value) ? { ...value } : value;
+    }
+    return copy as O;
   }
 
   protected _setOption<K extends keyof O>(key: K, value: O[K]): this {
@@ -82,17 +110,35 @@ export abstract class Options<
   /**
    * Apply `defaults`, override with `options`, then route each entry:
    * `_on<EventName>` keys register listeners, everything else flows
-   * through {@link _setOption} (and therefore {@link _processOption}).
+   * through {@link Options._setOption} (and therefore
+   * {@link Options._processOption}).
+   *
+   * Merging is GROUP-AWARE: when both the default and the incoming
+   * value for a key are plain objects, they are merged one level deep
+   * (`{ ...default, ...incoming }`) — a caller passing a partial
+   * `server: { port: 8080 }` keeps the other `server` defaults instead
+   * of clobbering the whole group. Non-plain values (arrays, class
+   * instances) replace wholesale. An explicitly-`undefined` incoming
+   * value defers to the default when one exists — and still reaches
+   * {@link Options._processOption} when there is none, so required-
+   * option validation keeps working.
    */
   protected _setOptions(
     options: EventOptionKeys<O, E>,
     defaults?: Partial<O>,
   ): this {
-    const finalOptions = { ...defaults } as EventOptionKeys<O, E>;
+    const finalOptions = { ...defaults } as Record<string, unknown>;
     for (const key in options) {
-      if (Object.hasOwn(options, key)) {
-        (finalOptions as Record<string, unknown>)[key] = options[key];
-      }
+      if (!Object.hasOwn(options, key)) continue;
+      const incoming = (options as Record<string, unknown>)[key];
+      // Explicit undefined defers to the default WHEN one exists;
+      // without a default it flows through so _processOption still
+      // sees (and can reject) a required-but-missing value.
+      if (incoming === undefined && Object.hasOwn(finalOptions, key)) continue;
+      const base = finalOptions[key];
+      finalOptions[key] = isPlainObject(incoming) && isPlainObject(base)
+        ? { ...base, ...incoming }
+        : incoming;
     }
     for (const key in finalOptions) {
       if (key.startsWith('_on')) {
@@ -108,9 +154,9 @@ export abstract class Options<
   }
 
   /**
-   * Validation/transformation hook for {@link _setOption}. Override to
-   * coerce or reject values; the default returns the input unchanged.
-   * Throw to reject.
+   * Validation/transformation hook for {@link Options._setOption}.
+   * Override to coerce or reject values; the default returns the input
+   * unchanged. Throw to reject.
    */
   protected _processOption(key: keyof O, value: O[typeof key]): O[typeof key] {
     return value;

--- a/packages/utils/docs/Utils-Events.md
+++ b/packages/utils/docs/Utils-Events.md
@@ -1,19 +1,26 @@
 # Utils - Events
 
-Type-safe event system with comprehensive async support.
+Type-safe event emitter with protected emission and per-listener
+isolation.
 
 [← Back to Utils](../README.md)
 
 ## Overview
 
-The Events class provides a robust, type-safe event handling system:
+The Events class provides a typed event surface for classes to expose:
 
-- **Type Safety**: Full TypeScript generic support
-- **Async Support**: Both sync and async event callbacks
-- **Multiple Listeners**: Register multiple callbacks per event
-- **One-Time Listeners**: Automatic cleanup after single use
-- **Error Isolation**: Individual callback failures don't affect others
-- **Method Chaining**: Fluent API design
+- **Type Safety**: the generic parameter maps event names to callback
+  signatures, checked at every `on`/`_emit` site
+- **Protected Emission**: only the class that owns the events can fire
+  them — holders of an instance subscribe via `on`/`once`/`off` but
+  cannot forge lifecycle events
+- **Per-Listener Isolation**: on the fire-and-forget paths, a listener
+  that throws (or an async listener that rejects) is contained and
+  reported — other listeners still run, and the emitter is unaffected
+- **One-Time Listeners**: `once()` auto-removes after a single fire,
+  dedupes like `on()`, and is removable via `off(event, callback)`
+- **Snapshot Semantics**: listeners added during an emission fire from
+  the next emission
 
 ## Installation
 
@@ -26,164 +33,115 @@ deno add @tundralibs/utils
 ### Constructor
 
 ```typescript
-new Events<T>();
+class MyClass extends Events<T> {}
 ```
 
-**Type Parameter `T`**: Object mapping event names to callback signatures
+**Type Parameter `T`**: Object mapping event names to callback
+signatures.
 
-### Methods
+### Public methods (subscription)
 
-- `on(event, callback)`: Register event listener
-- `once(event, callback)`: Register one-time listener
-- `off(event, callback)`: Remove event listener
-- `emit(event, ...args)`: Trigger event (async)
-- `emitSync(event, ...args)`: Trigger event (sync)
+- `on(event, callback)`: Register a listener (or an array of them);
+  duplicates are no-ops
+- `once(event, callback)`: Register a one-time listener; removable
+  before firing with `off(event, callback)`
+- `off(event, callback?)`: Remove a listener (or all listeners for the
+  event when omitted)
+
+### Protected methods (emission — for the owning class)
+
+- `_emit(event, ...args)`: Fire-and-forget. Listeners run in
+  registration order; sync throws and async rejections are routed to
+  `_onListenerError`, never propagated
+- `_emitSync(event, ...args)`: Awaits each listener in turn. A
+  throw/rejection **propagates to the awaiting caller** and stops later
+  listeners — this is the deliberate, handled emission path
+- `_emitRaw(event, ...args)`: Variance-tolerant `_emit` for generic
+  base classes (typed event key, `unknown[]` args)
+- `_onListenerError(event, error)`: Hook receiving every contained
+  listener fault; defaults to `console.error` — override to route into
+  a logger
 
 ## Usage Examples
 
-### Basic Event Handling
+### An emitting class
 
 ```typescript
 import { Events } from '@tundralibs/utils';
 
-interface MyEvents {
-  userLogin: (user: User) => void;
-  dataUpdate: (data: any[]) => void;
+interface StoreEvents {
+  change: (data: unknown) => void;
   error: (error: Error) => void;
 }
 
-const events = new Events<MyEvents>();
+class DataStore extends Events<StoreEvents> {
+  #data: unknown;
 
-// Register listener
-events.on('userLogin', (user) => {
-  console.log(`Welcome ${user.name}!`);
-});
-
-// Emit event
-events.emit('userLogin', currentUser);
-```
-
-### Async Event Handlers
-
-```typescript
-interface AppEvents {
-  save: (data: Data) => Promise<void>;
-  load: () => Promise<Data>;
+  setData(data: unknown) {
+    this.#data = data;
+    this._emit('change', data); // emission is the owner's privilege
+  }
 }
 
-const events = new Events<AppEvents>();
-
-// Async handler
-events.on('save', async (data) => {
-  await database.save(data);
-  console.log('Saved successfully');
-});
-
-// Emit and wait for all handlers
-await events.emit('save', myData);
+const store = new DataStore();
+store.on('change', (data) => console.log('changed:', data));
+store.setData({ hello: 'world' });
 ```
 
-### One-Time Listeners
+### Awaited emission (`_emitSync`)
 
 ```typescript
-// Runs only once, then auto-removes
-events.once('ready', () => {
-  console.log('App initialized');
-  startServer();
-});
-
-events.emit('ready'); // Runs handler
-events.emit('ready'); // Handler already removed, no effect
-```
-
-### Multiple Handlers
-
-```typescript
-events.on('click', () => console.log('Handler 1'));
-events.on('click', () => console.log('Handler 2'));
-events.on('click', () => console.log('Handler 3'));
-
-events.emit('click');
-// Output:
-// Handler 1
-// Handler 2
-// Handler 3
-```
-
-### Removing Listeners
-
-```typescript
-const handler = (data: string) => console.log(data);
-
-events.on('message', handler);
-events.emit('message', 'Hello'); // Logs "Hello"
-
-events.off('message', handler);
-events.emit('message', 'World'); // No output
-```
-
-### Method Chaining
-
-```typescript
-events
-  .on('start', startHandler)
-  .on('stop', stopHandler)
-  .on('error', errorHandler);
-```
-
-### Error Handling
-
-```typescript
-events.on('process', () => {
-  throw new Error('Handler failed');
-});
-
-events.on('process', () => {
-  console.log('This still runs!');
-});
-
-// Errors in individual handlers don't affect others
-events.emit('process');
-```
-
-## Best Practices
-
-1. **Type Your Events**: Always define event interfaces
-2. **Use Once for Initialization**: One-time events for setup
-3. **Handle Errors**: Wrap handlers in try-catch when needed
-4. **Clean Up**: Call `off()` to prevent memory leaks
-
-## Common Patterns
-
-### Observer Pattern
-
-```typescript
-class DataStore extends Events<{ change: (data: any) => void }> {
-  private data: any;
-
-  setData(newData: any) {
-    this.data = newData;
-    this.emit('change', newData);
+class Pipeline extends Events<{ flush: () => Promise<void> }> {
+  async flush() {
+    // Each listener completes before the next starts; a rejection
+    // surfaces HERE, where the emitter can handle it.
+    await this._emitSync('flush');
   }
 }
 ```
 
-### Lifecycle Events
+### Listener isolation (fire-and-forget)
 
 ```typescript
-interface Lifecycle {
-  init: () => Promise<void>;
-  ready: () => void;
-  shutdown: () => Promise<void>;
-}
-
-const app = new Events<Lifecycle>();
-
-app.once('init', async () => {
-  await loadConfig();
-  app.emit('ready');
+store.on('change', () => {
+  throw new Error('listener bug');
 });
+store.on('change', () => {
+  console.log('this still runs'); // isolation: one bad listener
+}); //                               cannot stop the others
+
+store.setData(1); // the throw is reported via _onListenerError
 ```
+
+### Routing listener faults
+
+```typescript
+class Service extends Events<ServiceEvents> {
+  protected override _onListenerError(
+    event: PropertyKey,
+    error: unknown,
+  ): void {
+    logger.error(`listener failed on '${String(event)}'`, { error });
+  }
+}
+```
+
+### One-time listeners
+
+```typescript
+const onReady = () => startServer();
+app.once('ready', onReady);
+app.off('ready', onReady); // removable by the ORIGINAL callback
+```
+
+## Best Practices
+
+1. **Type your events** — always define an event interface
+2. **Emit from the owner only** — if outside code needs to cause an
+   event, expose a method that does the work and emits
+3. **Use `_emitSync` when the emitter must observe failures**; use
+   `_emit` when emission must never affect the emitter
+4. **Clean up** — call `off()` for long-lived emitters
 
 ## Related Utilities
 

--- a/packages/utils/docs/Utils-Options.md
+++ b/packages/utils/docs/Utils-Options.md
@@ -35,10 +35,20 @@ class MyClass extends Options<O, E> {
 
 ### Methods
 
-- `_setOptions(options, defaults)`: Set options with defaults
-- `getOption<K>(key)`: Get option value
+- `_setOptions(options, defaults)`: Apply defaults, then options, with
+  GROUP-AWARE merging: a partial plain-object group
+  (`server: { port: 8080 }`) merges UNDER the group's defaults instead
+  of replacing them; arrays and class instances replace wholesale; an
+  explicitly-`undefined` value defers to an existing default (and still
+  reaches `_processOption` when there is none, so required-option
+  validation works)
+- `_getOption<K>(key)`: Read one option (protected — option bags
+  routinely carry credentials; expose values through purpose-built
+  public getters)
 - `hasOption(key)`: Check if option exists
-- `getOptions()`: Get all current options as an object
+- `_getOptions()`: Read a defensive copy of the whole bag (nested
+  plain-object groups are copied too — mutating the result never
+  writes into the store)
 - All Events methods (`on`, `emit`, etc.)
 
 ## Usage Examples
@@ -72,9 +82,9 @@ class Database extends Options<DatabaseOptions, DatabaseEvents> {
   }
 
   async connect() {
-    const host = this.getOption('host');
-    const port = this.getOption('port');
-    const ssl = this.getOption('ssl');
+    const host = this._getOption('host');
+    const port = this._getOption('port');
+    const ssl = this._getOption('ssl');
 
     // Connection logic...
     this.emit('connect');
@@ -158,8 +168,8 @@ class HttpServer extends Options<ServerOptions, ServerEvents> {
   }
 
   start() {
-    const port = this.getOption('port');
-    const host = this.getOption('host');
+    const port = this._getOption('port');
+    const host = this._getOption('host');
 
     // Start server...
     this.emit('start');
@@ -199,7 +209,7 @@ abstract class Plugin extends Options<PluginOptions, PluginEvents> {
   }
 
   load() {
-    if (this.getOption('enabled')) {
+    if (this._getOption('enabled')) {
       this.emit('load');
       this.onLoad();
     }
@@ -211,7 +221,7 @@ abstract class Plugin extends Options<PluginOptions, PluginEvents> {
 
 class MyPlugin extends Plugin {
   onLoad() {
-    console.log(`${this.getOption('name')} loaded`);
+    console.log(`${this._getOption('name')} loaded`);
   }
 
   execute(data: any) {
@@ -235,7 +245,7 @@ class MyPlugin extends Plugin {
 ```typescript
 class Builder extends Options<BuilderOptions, BuilderEvents> {
   setHost(host: string) {
-    this.getOption('host'); // Current value
+    this._getOption('host'); // Current value
     return this; // Chainable
   }
 }
@@ -249,7 +259,7 @@ constructor(config: EventOptionKeys<Options, Events>) {
   this._setOptions(config, defaults);
   
   // Validate
-  if (this.getOption('port') < 1024) {
+  if (this._getOption('port') < 1024) {
     throw new Error('Port must be >= 1024');
   }
 }


### PR DESCRIPTION
## The Events/Options hardening wave

Root-cause fixes for the listener-safety and option-leak issues surfaced by the cronus adversarial reviews — applied at the source (`utils`) and adopted across every consumer in one atomic change.

### Events
- **Emission is protected** (`_emit`/`_emitSync`/`_emitRaw`) — public surface is `on`/`off`/`once`; instance holders can no longer forge lifecycle events
- **Per-listener isolation** on fire-and-forget paths: sync throws AND async rejections route to an overridable `_onListenerError` hook — no wedged emitters, no process-killing unhandled rejections. `_emitSync` deliberately keeps propagation (the awaited, handled path — pact's reviewed contract)
- `once()`: removable via `off(original)`, dedupes like `on()`, self-removes by wrapper identity (subclass wrapping layers — pact, cronus — stay correct)
- Snapshot iteration per emission

### Options
- `getOption`/`getOptions` → protected `_getOption`/`_getOptions` (option bags carry credentials)
- `_getOptions()` copies nested plain-object groups (no more write-through into the store)
- `_setOptions` group-aware merge: partial `server: { port }` keeps the other group defaults; explicit `undefined` defers to defaults but still reaches validation when none exists

### Suite adoption
Internal call-site renames across cacher, compat, cronus, drivers, norm, pact, restler, tracer; test harnesses/casts for the now-protected members; entrypoint module docs enriched for **slogger** (fixes the empty JSR overview), id, metro-man, doctor.

**Merge after** the cronus 1.0.0 release PR (#173) lands.

Validated: `deno task check` clean, `deno lint` clean (825 files), 16 package suites green locally (DB-live suites covered by CI services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)