### PR TITLE
chore(infra): bump codeql-action init+analyze together; group actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,9 @@ updates:
     labels:
       - dependencies
       - infra
+    groups:
+      # Actions that version in lockstep (e.g. codeql init+analyze)
+      # must bump TOGETHER — split PRs can never go green.
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: javascript-typescript
 
       - name: Analyze
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
Replaces #169 and #170: the codeql-action `init`/`analyze` pair versions in lockstep, so dependabot's split PRs each fail CodeQL with a version-mismatch error in both merge orders. This bumps both to 4.37.6 atomically and adds a dependabot `groups` config so future github-actions bumps arrive as one PR.

Dependabot will auto-close #169/#170 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)