### PR TITLE
fix(drivers): stop redis/memcached engines importing the root barrel

### DIFF
--- a/packages/drivers/engines/memcached/Engine.ts
+++ b/packages/drivers/engines/memcached/Engine.ts
@@ -39,13 +39,13 @@ import {
   type TLSOptions as CompatTLSOptions,
 } from '@tundralibs/compat';
 import type { EventOptionKeys } from '@tundralibs/utils';
-import {
-  BaseEngine,
-  type EngineCapabilities,
-  EngineError,
-  type EngineQueryResult,
-  type MemcachedEngineEvents,
-} from '../../mod.ts';
+import { BaseEngine } from '../../BaseEngine.ts';
+import { EngineError } from '../../errors/mod.ts';
+import type {
+  EngineCapabilities,
+  EngineQueryResult,
+  MemcachedEngineEvents,
+} from '../../types/mod.ts';
 import { looksLikeTlsRuntimeError } from '../../tls.ts';
 import type { MemcachedEngineOptions } from './types/mod.ts';
 

--- a/packages/drivers/engines/redis/Engine.ts
+++ b/packages/drivers/engines/redis/Engine.ts
@@ -34,13 +34,13 @@ import {
   type TLSOptions as CompatTLSOptions,
 } from '@tundralibs/compat';
 import type { EventOptionKeys } from '@tundralibs/utils';
-import {
-  BaseEngine,
-  type EngineCapabilities,
-  EngineError,
-  type EngineQueryResult,
-  type RedisEngineEvents,
-} from '../../mod.ts';
+import { BaseEngine } from '../../BaseEngine.ts';
+import { EngineError } from '../../errors/mod.ts';
+import type {
+  EngineCapabilities,
+  EngineQueryResult,
+  RedisEngineEvents,
+} from '../../types/mod.ts';
 import { looksLikeTlsRuntimeError } from '../../tls.ts';
 import type { RespValue } from './resp.ts';
 import { RedisConnection } from './RedisConnection.ts';


### PR DESCRIPTION
## Problem

`engines/redis/Engine.ts` and `engines/memcached/Engine.ts` value-imported `BaseEngine` and `EngineError` from `'../../mod.ts'` — the drivers **root barrel**. Because those are value (code) imports, the barrel becomes a runtime edge: root barrel → `engines/mod.ts` → every engine, including `sqlite/adapter.ts` with its `bun:sqlite` / `better-sqlite3` / `jsr:@db/sqlite` imports. That made browser/edge bundling of `@tundralibs/drivers/redis`, `@tundralibs/drivers/memcached`, and downstream `@tundralibs/cacher` fail:

```
error: Do not know how to load path: deno:jsr:@db/sqlite@^0.13.0
    at .../packages/drivers/engines/sqlite/adapter.ts:61:27
error: Import "better-sqlite3" not a dependency and not in import map ...
```

## Fix

Mirror the import hygiene the edge engines (neon/turso/d1) already follow — value imports from the precise defining modules, types type-only from `types/mod.ts`:

```ts
import { BaseEngine } from '../../BaseEngine.ts';
import { EngineError } from '../../errors/mod.ts';
import type {
  EngineCapabilities,
  EngineQueryResult,
  RedisEngineEvents, // MemcachedEngineEvents in memcached
} from '../../types/mod.ts';
```

No other non-test file value-imports a root barrel (`grep` for `'../../mod.ts'` / `'../mod.ts'` / `'./mod.ts'` is clean).

## Verification

- `deno bundle --platform=browser packages/drivers/engines/redis/mod.ts` — **was failing, now passes** (129 modules)
- `deno bundle --platform=browser packages/drivers/engines/memcached/mod.ts` — **was failing, now passes** (127 modules)
- `deno bundle --platform=browser packages/cacher/mod.ts` — **was failing via this chain, now passes** (189 modules)
- `deno task check:edge-safety` — OK (neon/turso/d1)
- `deno check` on `packages/drivers/mod.ts` + both engine entrypoints — clean
- `deno fmt` / `deno lint` on changed files — clean
- Unit tests without live DB services: 27 passed (703 steps), 0 failed. Live redis/memcached/postgres/maria/mongo engine tests need running services — covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)