### PR TITLE
fix(slogger): import compat via subpaths instead of the root barrel

### DIFF
--- a/packages/slogger/Slogger.ts
+++ b/packages/slogger/Slogger.ts
@@ -9,7 +9,8 @@ import {
   variableReplacer,
 } from '@tundralibs/utils';
 import { ulid } from '@tundralibs/id';
-import { hostname, onExit } from '@tundralibs/compat';
+import { hostname } from '@tundralibs/compat/net';
+import { onExit } from '@tundralibs/compat/runtime';
 import { AbstractHandler, type HandlerOptions } from './handlers/mod.ts';
 import type { SloggerFormatter, SlogObject } from './types/mod.ts';
 import { LogManager } from './LogManager.ts';

--- a/packages/slogger/formatters/rfc5424.ts
+++ b/packages/slogger/formatters/rfc5424.ts
@@ -17,7 +17,7 @@
  *
  * @module
  */
-import { PID } from '@tundralibs/compat';
+import { PID } from '@tundralibs/compat/runtime';
 import { type SyslogFacilities } from '@tundralibs/utils';
 import type { SloggerFormatter, SlogObject } from '../types/mod.ts';
 

--- a/packages/slogger/handlers/handler/FileHandler.ts
+++ b/packages/slogger/handlers/handler/FileHandler.ts
@@ -7,7 +7,7 @@ import {
   moveFile,
   openFile,
   stat,
-} from '@tundralibs/compat';
+} from '@tundralibs/compat/file';
 import { format } from '@std/datetime';
 import { SyslogSeverities, variableReplacer } from '@tundralibs/utils';
 import { SloggerConfigError, SloggerHandlerError } from '../../errors/mod.ts';

--- a/packages/slogger/handlers/handler/HTTPHandler.ts
+++ b/packages/slogger/handlers/handler/HTTPHandler.ts
@@ -1,4 +1,5 @@
-import { fetch, hasPermissionSync } from '@tundralibs/compat';
+import { fetch } from '@tundralibs/compat/fetch';
+import { hasPermissionSync } from '@tundralibs/compat/permissions';
 import { jsonFormatter } from '../../formatters/mod.ts';
 import type { SlogObject } from '../../types/SlogObject.ts';
 import { AbstractHandler, type HandlerOptions } from '../AbstractHandler.ts';

--- a/packages/slogger/handlers/handler/SyslogHandler.ts
+++ b/packages/slogger/handlers/handler/SyslogHandler.ts
@@ -5,12 +5,8 @@
  *
  * @module
  */
-import {
-  connect,
-  type Connection,
-  type UdpSocket,
-  udpSocket,
-} from '@tundralibs/compat';
+import { connect, type Connection } from '@tundralibs/compat/net';
+import { type UdpSocket, udpSocket } from '@tundralibs/compat/udp';
 import { AbstractHandler, type HandlerOptions } from '../AbstractHandler.ts';
 import type { SlogObject } from '../../types/SlogObject.ts';
 import { SloggerConfigError, SloggerHandlerError } from '../../errors/mod.ts';

--- a/packages/slogger/handlers/handler/TCPHandler.ts
+++ b/packages/slogger/handlers/handler/TCPHandler.ts
@@ -19,7 +19,7 @@
  * @module
  */
 
-import { connect, type Connection } from '@tundralibs/compat';
+import { connect, type Connection } from '@tundralibs/compat/net';
 import { AbstractHandler, type HandlerOptions } from '../AbstractHandler.ts';
 import { SloggerConfigError, SloggerHandlerError } from '../../errors/mod.ts';
 


### PR DESCRIPTION
## What

Replaces the six `@tundralibs/compat` **root-barrel** imports in slogger with the precise subpaths. Internal import-path edits only — **zero API change**.

| File | Before | After |
| --- | --- | --- |
| `Slogger.ts` | `import { hostname, onExit } from '@tundralibs/compat'` | `hostname` from `/net`, `onExit` from `/runtime` |
| `formatters/rfc5424.ts` | `import { PID } from '@tundralibs/compat'` | `PID` from `/runtime` |
| `handlers/handler/HTTPHandler.ts` | `import { fetch, hasPermissionSync } from '@tundralibs/compat'` | `fetch` from `/fetch`, `hasPermissionSync` from `/permissions` |
| `handlers/handler/TCPHandler.ts` | `import { connect, type Connection } from '@tundralibs/compat'` | same symbols from `/net` |
| `handlers/handler/SyslogHandler.ts` | `connect, Connection, UdpSocket, udpSocket` from barrel | `connect`/`Connection` from `/net`, `UdpSocket`/`udpSocket` from `/udp` |
| `handlers/handler/FileHandler.ts` | `AsyncFileHandle, ensureDirSync, moveFile, openFile, stat` from barrel | same symbols from `/file` |

Test files are untouched — they legitimately use `@tundralibs/compat` for `describe`/`it`/`listen`.

## Why

The compat root barrel re-exports **everything**, including `test.ts`. Its `bun:test` / `node:test` dynamic imports make a wrangler build of any consumer **hard-fail** — consumers currently need a wrangler `alias` stub as a workaround. The barrel also drags `webserver`, `cli`, and `net` into bundles that never use them.

## Verification

- `deno check packages/slogger/mod.ts` — clean.
- `deno test --allow-all --parallel` in `packages/slogger` — **22 passed (347 steps), 0 failed**.
- `deno bundle --platform=browser` succeeds.
- `bun:test` occurrences in the browser bundle: **1 → 0**, once the sibling PRs for `utils` and `id` land. slogger reaches `mod.ts` for both packages, and their root barrels (`utils/mod.ts` → `envArgs.ts`, `id/mod.ts` → `ObjectID.ts`/`sequenceID.ts`) still import the compat barrel — that is the sole remaining source. Verified by bundling with all four package fixes applied together: **0 occurrences of `bun:test`, 203 → 182 modules, 286 KB → 251 KB.**

Part of a four-PR set (slogger, id, pact, utils), each independent and branched from the same base — none stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)