### PR TITLE
fix(id): import compat via subpaths instead of the root barrel

### DIFF
--- a/packages/id/ObjectID.ts
+++ b/packages/id/ObjectID.ts
@@ -30,7 +30,7 @@
  * const customId = customGen(); // Uses "srv" as machine identifier
  * ```
  */
-import { getProcessId } from '@tundralibs/compat';
+import { getProcessId } from '@tundralibs/compat/runtime';
 import { ALPHA_NUMERIC, nanoID } from './nanoID.ts';
 import { InvalidOptionError } from './errors/mod.ts';
 

--- a/packages/id/sequenceID.ts
+++ b/packages/id/sequenceID.ts
@@ -63,7 +63,7 @@
  * const customId = customSeq(); // Starts counting from 1000
  * ```
  */
-import { getProcessId } from '@tundralibs/compat';
+import { getProcessId } from '@tundralibs/compat/runtime';
 import { InvalidOptionError } from './errors/mod.ts';
 
 /**


### PR DESCRIPTION
## What

Replaces the two `@tundralibs/compat` **root-barrel** imports in id with the precise subpath. Internal import-path edits only — **zero API change**.

| File | Before | After |
| --- | --- | --- |
| `ObjectID.ts` | `import { getProcessId } from '@tundralibs/compat'` | `import { getProcessId } from '@tundralibs/compat/runtime'` |
| `sequenceID.ts` | `import { getProcessId } from '@tundralibs/compat'` | `import { getProcessId } from '@tundralibs/compat/runtime'` |

`getProcessId` is exported by `compat/runtime.ts` (confirmed against `packages/compat/mod.ts`).

## Why

The compat root barrel re-exports **everything**, including `test.ts`. Its `bun:test` / `node:test` dynamic imports make a wrangler build of any consumer **hard-fail** — consumers currently need a wrangler `alias` stub as a workaround. The barrel also drags `webserver`, `cli`, and `net` into bundles that never use them; id's browser bundle was almost entirely barrel drag for the sake of one function.

## Verification

- `deno check packages/id/mod.ts` — clean.
- `deno test --allow-all --parallel` in `packages/id` — **10 passed (93 steps), 0 failed**.
- `deno bundle --platform=browser -o /tmp/id-check.js packages/id/mod.ts` succeeds.
- `grep -c "bun:test"` on the bundle: **1 → 0**.
- Bundle size: **122.71 KB → 86.64 KB** (94 modules), a ~29% cut from this two-line change.

Part of a four-PR set (slogger, id, pact, utils), each independent and branched from the same base — none stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)