### PR TITLE
fix(ambient): load AsyncLocalStorage without a static node:async_hooks import

### DIFF
--- a/packages/ambient/ambient.test.ts
+++ b/packages/ambient/ambient.test.ts
@@ -1,7 +1,9 @@
 import * as asserts from '@std/asserts';
 import { describe, it } from '@tundralibs/compat/test';
-import { ambient } from './mod.ts';
-import type { RequestContext } from './mod.ts';
+import { ambient, createContext } from './mod.ts';
+import { buildAmbient } from './ambient.ts';
+import { assertAsyncLocalStorage } from './createContext.ts';
+import type { Context, RequestContext } from './mod.ts';
 
 describe('ambient', () => {
   it('is empty outside any run scope', () => {
@@ -73,5 +75,102 @@ describe('ambient', () => {
     const seed: RequestContext = { correlationId: 'c5' };
     ambient.run(seed, () => ambient.set('userId', 'u'));
     asserts.assertEquals(seed.userId, undefined);
+  });
+
+  it('builds the store on first use and reuses that one instance', () => {
+    // The store is created lazily, so the very first access must still be a
+    // fully working context — and every later access must land on the same
+    // instance. A second store would not observe the first's writes, so a
+    // value written through `set` and read back through `get` (two separate
+    // accessor calls, hence two separate store lookups) proves reuse.
+    ambient.run({ correlationId: 'm1' }, () => {
+      ambient.set('userId', 'u_m1');
+      asserts.assertEquals(ambient.get()?.userId, 'u_m1');
+    });
+    ambient.run({ correlationId: 'm2' }, () => {
+      asserts.assertEquals(ambient.get()?.correlationId, 'm2');
+      asserts.assertEquals(ambient.get()?.userId, undefined); // fresh scope
+    });
+  });
+});
+
+describe('ambient (runtime without AsyncLocalStorage)', () => {
+  /**
+   * Stands in for a browser: the store can never be built. It fails through the
+   * real `assertAsyncLocalStorage` guard, so this exercises the production
+   * error rather than a copy of its message — if the message changes, these
+   * tests follow it automatically.
+   */
+  const noAsyncLocalStorage = (): never => {
+    assertAsyncLocalStorage(null);
+    throw new Error('unreachable: assertAsyncLocalStorage should have thrown');
+  };
+
+  const degraded = buildAmbient(noAsyncLocalStorage);
+
+  it('get() returns undefined instead of throwing', () => {
+    asserts.assertEquals(degraded.get(), undefined);
+  });
+
+  it('set() is a silent no-op', () => {
+    degraded.set('userId', 'u_1'); // must not throw
+    asserts.assertEquals(degraded.get(), undefined);
+  });
+
+  it('active() reports false instead of throwing', () => {
+    asserts.assertEquals(degraded.active(), false);
+  });
+
+  it('run() throws the documented TypeError', () => {
+    asserts.assertThrows(
+      () => degraded.run({ correlationId: 'c' }, () => 'never'),
+      TypeError,
+      'AsyncLocalStorage',
+    );
+  });
+
+  it('child() throws the documented TypeError', () => {
+    asserts.assertThrows(
+      () => degraded.child({ spanId: 's' }, () => 'never'),
+      TypeError,
+      'AsyncLocalStorage',
+    );
+  });
+
+  it('run() does not run the callback when it throws', () => {
+    let ran = false;
+    asserts.assertThrows(() =>
+      degraded.run({ correlationId: 'c' }, () => {
+        ran = true;
+      })
+    );
+    // Failing loudly is the point: silently running `fn` outside any context
+    // would hand the callback a scope that does not exist.
+    asserts.assertEquals(ran, false);
+  });
+
+  it('names the supported runtimes in the error', () => {
+    const error = asserts.assertThrows(
+      () => degraded.run({}, () => 'never'),
+    ) as TypeError;
+    asserts.assertStringIncludes(error.message, '@tundralibs/ambient');
+    asserts.assertStringIncludes(error.message, 'node:async_hooks');
+    asserts.assertStringIncludes(error.message, 'Deno, Bun, and Node.js >= 22');
+  });
+
+  it('works normally again once the resolver supplies a store', () => {
+    // The seam is honoured in the working direction too, so the degradation
+    // above is genuinely driven by store availability and not by the seam
+    // itself being broken.
+    const store: Context<RequestContext> = createContext<RequestContext>();
+    const working = buildAmbient(() => store);
+    working.run({ correlationId: 'w1' }, () => {
+      working.set('userId', 'u_w');
+      asserts.assertEquals(working.get()?.correlationId, 'w1');
+      asserts.assertEquals(working.get()?.userId, 'u_w');
+      asserts.assertEquals(working.active(), true);
+    });
+    asserts.assertEquals(working.get(), undefined);
+    asserts.assertEquals(working.active(), false);
   });
 });

--- a/packages/ambient/ambient.ts
+++ b/packages/ambient/ambient.ts
@@ -26,23 +26,8 @@
  * ```
  */
 
-import { assertAsyncLocalStorage, createContext } from './createContext.ts';
+import { createContext } from './createContext.ts';
 import type { Ambient, Context, RequestContext } from './types/mod.ts';
-
-/**
- * Whether this runtime can back a context store at all, probed once at load.
- * The probe deliberately swallows the throw: importing this package must never
- * fail, so that a browser bundle can pull it in and simply find no active
- * context — see {@link storeOrUndefined}.
- */
-const HAS_ASYNC_LOCAL_STORAGE: boolean = ((): boolean => {
-  try {
-    assertAsyncLocalStorage();
-    return true;
-  } catch {
-    return false;
-  }
-})();
 
 /** The single process-wide store, once built. See {@link requireStore}. */
 let store: Context<RequestContext> | undefined;
@@ -63,45 +48,66 @@ function requireStore(): Context<RequestContext> {
 }
 
 /**
- * The shared store, or `undefined` where the runtime provides no
- * `AsyncLocalStorage`. The read-only members use this so they keep their
- * documented never-throws contract everywhere: with no store there is no active
- * context, which is exactly the "called outside any scope" case they already
- * handle.
+ * Build the {@link Ambient} surface over `resolveStore` — the supplier of the
+ * backing store, which throws where the runtime cannot provide one.
  *
- * @returns The shared {@link Context}, or `undefined` on ALS-less runtimes.
+ * Exported (but not re-exported from the package root, so not public API) only
+ * so the ALS-less degradation path — unreachable on any supported runtime — is
+ * unit-testable via the `resolveStore` seam, mirroring the `candidate` seam on
+ * `assertAsyncLocalStorage`.
+ *
+ * @internal
+ * @param resolveStore - Supplies the shared {@link Context}; throws where none
+ *   can exist.
+ * @returns An {@link Ambient} bound to `resolveStore`.
  */
-function storeOrUndefined(): Context<RequestContext> | undefined {
-  if (!HAS_ASYNC_LOCAL_STORAGE) return undefined;
-  return requireStore();
+export function buildAmbient(
+  resolveStore: () => Context<RequestContext>,
+): Ambient {
+  /**
+   * The store, or `undefined` where none can exist. The read-only members go
+   * through this so they keep their documented never-throws contract
+   * everywhere: no store means no active context, which is exactly the "called
+   * outside any scope" case they already handle. `resolveStore` throws only for
+   * that one reason, so there is no other failure being swallowed here.
+   */
+  const readStore = (): Context<RequestContext> | undefined => {
+    try {
+      return resolveStore();
+    } catch {
+      return undefined;
+    }
+  };
+
+  return {
+    run<R>(seed: RequestContext, fn: () => R): R {
+      return resolveStore().run({ ...seed }, fn);
+    },
+
+    child<R>(patch: RequestContext, fn: () => R): R {
+      const active = resolveStore();
+      // `active.get()` may be `undefined` (called outside a scope); spreading
+      // `undefined` contributes nothing, so no explicit fallback is needed.
+      return active.run({ ...active.get(), ...patch }, fn);
+    },
+
+    get(): RequestContext | undefined {
+      return readStore()?.get();
+    },
+
+    set(key: string, value: unknown): void {
+      const current = readStore()?.get();
+      if (current !== undefined) current[key] = value;
+    },
+
+    active(): boolean {
+      return readStore()?.active() ?? false;
+    },
+  };
 }
 
 /**
  * The request-scoped context accessor the suite shares — see {@link Ambient}
  * for the full surface.
  */
-export const ambient: Ambient = {
-  run<R>(seed: RequestContext, fn: () => R): R {
-    return requireStore().run({ ...seed }, fn);
-  },
-
-  child<R>(patch: RequestContext, fn: () => R): R {
-    const active = requireStore();
-    // `active.get()` may be `undefined` (called outside a scope); spreading
-    // `undefined` contributes nothing, so no explicit fallback is needed.
-    return active.run({ ...active.get(), ...patch }, fn);
-  },
-
-  get(): RequestContext | undefined {
-    return storeOrUndefined()?.get();
-  },
-
-  set(key: string, value: unknown): void {
-    const current = storeOrUndefined()?.get();
-    if (current !== undefined) current[key] = value;
-  },
-
-  active(): boolean {
-    return storeOrUndefined()?.active() ?? false;
-  },
-};
+export const ambient: Ambient = buildAmbient(requireStore);

--- a/packages/ambient/ambient.ts
+++ b/packages/ambient/ambient.ts
@@ -26,11 +26,55 @@
  * ```
  */
 
-import { createContext } from './createContext.ts';
-import type { Ambient, RequestContext } from './types/mod.ts';
+import { assertAsyncLocalStorage, createContext } from './createContext.ts';
+import type { Ambient, Context, RequestContext } from './types/mod.ts';
 
-/** The single process-wide store backing the {@link RequestContext}. */
-const store = createContext<RequestContext>();
+/**
+ * Whether this runtime can back a context store at all, probed once at load.
+ * The probe deliberately swallows the throw: importing this package must never
+ * fail, so that a browser bundle can pull it in and simply find no active
+ * context — see {@link storeOrUndefined}.
+ */
+const HAS_ASYNC_LOCAL_STORAGE: boolean = ((): boolean => {
+  try {
+    assertAsyncLocalStorage();
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+/** The single process-wide store, once built. See {@link requireStore}. */
+let store: Context<RequestContext> | undefined;
+
+/**
+ * The store backing the {@link RequestContext}, built on first use and memoized
+ * thereafter. Construction is deferred rather than done at module scope purely
+ * so that *importing* the package is side-effect-free on runtimes without
+ * `AsyncLocalStorage`; on every supported runtime the store is still a single
+ * process-wide instance shared by all callers.
+ *
+ * @returns The one shared {@link Context}.
+ * @throws {TypeError} When the runtime provides no `AsyncLocalStorage`
+ *   (`node:async_hooks`) — raised by {@link createContext}.
+ */
+function requireStore(): Context<RequestContext> {
+  return (store ??= createContext<RequestContext>());
+}
+
+/**
+ * The shared store, or `undefined` where the runtime provides no
+ * `AsyncLocalStorage`. The read-only members use this so they keep their
+ * documented never-throws contract everywhere: with no store there is no active
+ * context, which is exactly the "called outside any scope" case they already
+ * handle.
+ *
+ * @returns The shared {@link Context}, or `undefined` on ALS-less runtimes.
+ */
+function storeOrUndefined(): Context<RequestContext> | undefined {
+  if (!HAS_ASYNC_LOCAL_STORAGE) return undefined;
+  return requireStore();
+}
 
 /**
  * The request-scoped context accessor the suite shares — see {@link Ambient}
@@ -38,25 +82,26 @@ const store = createContext<RequestContext>();
  */
 export const ambient: Ambient = {
   run<R>(seed: RequestContext, fn: () => R): R {
-    return store.run({ ...seed }, fn);
+    return requireStore().run({ ...seed }, fn);
   },
 
   child<R>(patch: RequestContext, fn: () => R): R {
-    // `store.get()` may be `undefined` (called outside a scope); spreading
+    const active = requireStore();
+    // `active.get()` may be `undefined` (called outside a scope); spreading
     // `undefined` contributes nothing, so no explicit fallback is needed.
-    return store.run({ ...store.get(), ...patch }, fn);
+    return active.run({ ...active.get(), ...patch }, fn);
   },
 
   get(): RequestContext | undefined {
-    return store.get();
+    return storeOrUndefined()?.get();
   },
 
   set(key: string, value: unknown): void {
-    const current = store.get();
+    const current = storeOrUndefined()?.get();
     if (current !== undefined) current[key] = value;
   },
 
   active(): boolean {
-    return store.active();
+    return storeOrUndefined()?.active() ?? false;
   },
 };

--- a/packages/ambient/createContext.ts
+++ b/packages/ambient/createContext.ts
@@ -23,8 +23,42 @@
  * ```
  */
 
-import { AsyncLocalStorage } from 'node:async_hooks';
+import type { AsyncLocalStorage } from 'node:async_hooks';
 import type { Context } from './types/mod.ts';
+
+/**
+ * The slice of the global object this module reads: `process.getBuiltinModule`,
+ * the synchronous accessor for a runtime's built-in modules. Every member is
+ * optional because none of them exist in a browser, which is the entire point
+ * of going through it.
+ */
+type BuiltinModuleHost = {
+  process?: {
+    getBuiltinModule?: (
+      id: 'node:async_hooks',
+    ) => { AsyncLocalStorage?: typeof AsyncLocalStorage } | undefined;
+  };
+};
+
+/**
+ * The runtime's `AsyncLocalStorage`, or `undefined` where the runtime has no
+ * `node:async_hooks` (browsers).
+ *
+ * Resolved through `process.getBuiltinModule` rather than a static
+ * `import { AsyncLocalStorage } from 'node:async_hooks'` so that merely
+ * *importing* this package never fails: a static specifier is resolved at
+ * module-eval time and is fatal in a browser bundle, whereas this lookup is a
+ * plain optional-chained property read that yields `undefined` there. Every
+ * supported runtime exposes it — Node >= 22.3, Bun >= 1.1.31, Deno 2.x and
+ * Cloudflare Workers under `nodejs_compat` — so on those the constructor is
+ * resolved eagerly and synchronously, exactly as the static import was. Where
+ * it resolves to `undefined`, {@link createContext} throws at call time via
+ * {@link assertAsyncLocalStorage}.
+ */
+const AsyncLocalStorageCtor: typeof AsyncLocalStorage | undefined =
+  (globalThis as BuiltinModuleHost).process?.getBuiltinModule?.(
+    'node:async_hooks',
+  )?.AsyncLocalStorage;
 
 /**
  * Assert that the runtime provides `AsyncLocalStorage` (`node:async_hooks`),
@@ -42,7 +76,7 @@ import type { Context } from './types/mod.ts';
  *   provides no `AsyncLocalStorage`.
  */
 export function assertAsyncLocalStorage(
-  candidate: unknown = AsyncLocalStorage,
+  candidate: unknown = AsyncLocalStorageCtor,
 ): void {
   if (typeof candidate !== 'function') {
     throw new TypeError(
@@ -69,7 +103,10 @@ export function assertAsyncLocalStorage(
  */
 export function createContext<T>(): Context<T> {
   assertAsyncLocalStorage();
-  const store = new AsyncLocalStorage<T>();
+  // The assert above guarantees the constructor resolved; the cast just carries
+  // that guarantee past `AsyncLocalStorageCtor`'s `| undefined`.
+  const Ctor = AsyncLocalStorageCtor as typeof AsyncLocalStorage;
+  const store = new Ctor<T>();
   return {
     run: <R>(value: T, fn: () => R): R => store.run(value, fn),
     get: (): T | undefined => store.getStore(),

--- a/packages/ambient/types/Ambient.ts
+++ b/packages/ambient/types/Ambient.ts
@@ -24,6 +24,10 @@ export type Ambient = {
    * @param seed - Initial fields for the new {@link RequestContext}.
    * @param fn - The function to run within the context.
    * @returns Whatever `fn` returns.
+   * @throws {TypeError} When the runtime provides no `AsyncLocalStorage`
+   *   (`node:async_hooks`) — e.g. a browser. Establishing a scope is the one
+   *   thing that cannot degrade, so it fails loudly rather than silently
+   *   running `fn` outside any context.
    */
   run<R>(seed: RequestContext, fn: () => R): R;
 
@@ -37,24 +41,31 @@ export type Ambient = {
    * @param patch - Fields to overlay on the inherited context.
    * @param fn - The function to run within the child context.
    * @returns Whatever `fn` returns.
+   * @throws {TypeError} When the runtime provides no `AsyncLocalStorage`
+   *   (`node:async_hooks`) — same rationale as {@link Ambient.run}.
    */
   child<R>(patch: RequestContext, fn: () => R): R;
 
   /**
    * The active {@link RequestContext}, or `undefined` outside any
-   * {@link Ambient.run} scope. Never throws.
+   * {@link Ambient.run} scope. Never throws — including on runtimes with no
+   * `AsyncLocalStorage`, where no scope can ever be active.
    */
   get(): RequestContext | undefined;
 
   /**
    * Set `key` on the active {@link RequestContext}. A silent no-op (never
-   * throws) when called outside any {@link Ambient.run} scope.
+   * throws) when called outside any {@link Ambient.run} scope, or on a runtime
+   * with no `AsyncLocalStorage`.
    *
    * @param key - Field name to set.
    * @param value - Value to store.
    */
   set(key: string, value: unknown): void;
 
-  /** `true` when an {@link Ambient.run} scope is active, `false` otherwise. */
+  /**
+   * `true` when an {@link Ambient.run} scope is active, `false` otherwise —
+   * including on runtimes with no `AsyncLocalStorage`. Never throws.
+   */
   active(): boolean;
 };


### PR DESCRIPTION
## Why

`@tundralibs/ambient` could not be imported in a browser at all — it failed at
module load, taking every downstream consumer that pulls ambient in with it.
Two independent causes, both fixed here:

1. `createContext.ts` opened with a static
   `import { AsyncLocalStorage } from 'node:async_hooks'`. A static specifier is
   resolved at **module-eval time**, so the import itself was fatal.
2. `ambient.ts` then called `createContext()` at **module scope** to build the
   singleton — so even with the import fixed, importing `mod.ts` still threw at
   load, just from the guard instead of from module resolution.

The package already had the right design in mind: `assertAsyncLocalStorage()`
throws an actionable `TypeError` when the runtime has no ALS, and
`createContext()` calls it. The intent was always *load everywhere, throw at
call time*. These two eager evaluations were what made that unreachable.

## 1. The `getBuiltinModule` pattern

```ts
import type { AsyncLocalStorage } from 'node:async_hooks'; // erased, browser-safe

const AsyncLocalStorageCtor: typeof AsyncLocalStorage | undefined =
  (globalThis as BuiltinModuleHost).process?.getBuiltinModule?.(
    'node:async_hooks',
  )?.AsyncLocalStorage;
```

`process.getBuiltinModule` is a **synchronous** built-in accessor, so this is
not a lazy/async retrofit — the constructor is still resolved eagerly at module
scope, exactly as the static import did. What changes is the failure mode: in a
browser the expression short-circuits to `undefined` instead of blowing up on an
unresolvable specifier.

Availability (all **verified locally**, not assumed):

| Runtime | Version here | `typeof process.getBuiltinModule` |
| --- | --- | --- |
| Deno | 2.9.4 | `function` |
| Node | v26.5.1 | `function` |
| Bun | 1.3.14 | `function` |

Supported floors: Node >= 22.3, Bun >= 1.1.31, Deno 2.x, Cloudflare Workers
under `nodejs_compat`.

A small local `BuiltinModuleHost` type models the global slice being read, so
the lookup needs no `any` and stays lint-clean.

## 2. The singleton is built on first use

`ambient.ts` now constructs the store on first use and memoizes it, so importing
the package is side-effect-free everywhere. The documented contracts are
**preserved rather than changed**:

- `get()` / `set()` / `active()` keep their "never throws" / "silent no-op"
  guarantee on ALS-less runtimes. With no store there is no active context —
  precisely the "called outside any scope" case these members already document
  and handle, so they return `undefined` / no-op / `false`.
- `run()` / `child()` genuinely cannot function without ALS, so they throw the
  existing `TypeError` at call time rather than silently running the callback
  outside any context. `@throws` added to both on the `Ambient` type.

No public API, export, or error message changed.

## 3. The degradation contract is tested, not exempted

Those degradation branches are exactly the kind of behaviour that regresses
silently, so they are covered by real tests — no lowered thresholds, no
ignore comments.

Testing them needs a seam, because ALS availability is decided at module load
and is always present on the runtimes CI runs. Re-importing the module under a
doctored global does **not** work: cache-busting `ambient.ts` still resolves the
already-cached `createContext.ts`, so the stub has no effect. `ambient.ts`
therefore builds its accessor through an internal
`buildAmbient(resolveStore)` — the same seam the package already uses to make
the otherwise-unreachable `assertAsyncLocalStorage` guard testable via its
`candidate` parameter. `buildAmbient` is not re-exported from `mod.ts`, so the
public API is unchanged.

A welcome simplification falls out: the load-time availability probe is gone.
The read-only members derive "no store" from `resolveStore` throwing, which is
the same signal in production and under test.

The stand-in resolver fails through the **real** `assertAsyncLocalStorage`, so
the assertions track the production message rather than copying it. No global is
stubbed, so nothing can bleed between tests.

## Verification

Supported runtimes — **nothing observable changes**:

- Ambient suite passes on all three CI runtimes: **Deno 2.9.4, Bun 1.3.14 and
  Node v26.5.1 — 27 tests each, 0 failures.**
- `deno fmt` / `deno lint` / `deno check packages/ambient/mod.ts` — clean.
- Coverage back to **100% branch / function / line** on `ambient.ts`,
  `createContext.ts` and `mod.ts`.
- The browser bundle run on **unmodified Node and Bun**: `child()` inherits and
  overlays, the parent scope survives, and two separate `run()` calls share one
  store — confirming the memoized singleton is still process-wide.

Browsers — **the actual goal, verified end-to-end**:

- `deno bundle --platform=browser` succeeds; `grep -c 'from "node:async_hooks"'`
  on the output returns **0**. The only `async_hooks` occurrences left are the
  `getBuiltinModule` string argument and the error message text.
- That bundle imported with `process.getBuiltinModule` deleted (standing in for
  a browser):

```
MODULE LOADED OK, exports: ambient, createContext

Degrading members (expect undefined / no-op / false):
  ambient.get() -> undefined
  ambient.set() -> undefined
  ambient.active() -> false
  ambient.get() after set() -> undefined

Scope-establishing members (expect the TypeError):
  ambient.run() threw TypeError: @tundralibs/ambient requires 'AsyncLocalStorage' …
  ambient.child() threw TypeError: @tundralibs/ambient requires 'AsyncLocalStorage' …
  createContext() threw TypeError: @tundralibs/ambient requires 'AsyncLocalStorage' …
```

The same load previously failed outright with that `TypeError` at module scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)