### PR TITLE
fix(pact): import compat via subpaths instead of the root barrel

### DIFF
--- a/packages/pact/PACT.ts
+++ b/packages/pact/PACT.ts
@@ -29,7 +29,8 @@
  * @module
  */
 
-import { fetch as compatFetch, isDeno } from '@tundralibs/compat';
+import { fetch as compatFetch } from '@tundralibs/compat/fetch';
+import { isDeno } from '@tundralibs/compat/runtime';
 import { hash, hkdf } from '@tundralibs/crypt';
 import {
   decodeJWT as cryptDecodeJWT,


### PR DESCRIPTION
## What

Replaces the single `@tundralibs/compat` **root-barrel** import in pact with the precise subpaths. Internal import-path edit only — **zero API change**.

| File | Before | After |
| --- | --- | --- |
| `PACT.ts` | `import { fetch as compatFetch, isDeno } from '@tundralibs/compat'` | `fetch as compatFetch` from `/fetch`, `isDeno` from `/runtime` |

## Why

The compat root barrel re-exports **everything**, including `test.ts`. Its `bun:test` / `node:test` dynamic imports make a wrangler build of any consumer **hard-fail** — consumers currently need a wrangler `alias` stub as a workaround. The barrel also drags `webserver`, `cli`, and `net` into bundles that never use them.

## Verification

- `deno check packages/pact/mod.ts` — clean.
- `deno test --allow-all --parallel` in `packages/pact` — **18 passed (135 steps), 0 failed**.
- `deno bundle --platform=browser -o /tmp/pact-check.js packages/pact/mod.ts` succeeds.
- `grep -c "bun:test"` on pact's own bundle: still **1** after this PR alone, because pact also reaches the root barrels of two sibling packages — `@tundralibs/utils` (→ `envArgs.ts`) and `@tundralibs/id` (→ `ObjectID.ts`/`sequenceID.ts`), each of which still imports the compat barrel. Those are the sibling PRs in this set. Bundling with all four fixes applied together gives **0 occurrences of `bun:test`, 314.82 KB → 276.10 KB.**

Part of a four-PR set (slogger, id, pact, utils), each independent and branched from the same base — none stacked. Merging all four is what clears `bun:test` from every consumer graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)