### PR TITLE
fix(utils): import compat via subpaths instead of the root barrel

### DIFF
--- a/packages/utils/envArgs.ts
+++ b/packages/utils/envArgs.ts
@@ -9,12 +9,9 @@
  */
 
 import * as path from '@tundralibs/compat/path';
-import {
-  getEnv,
-  hasPermissionSync,
-  readDirSync,
-  readTextFileSync,
-} from '@tundralibs/compat';
+import { readDirSync, readTextFileSync } from '@tundralibs/compat/file';
+import { hasPermissionSync } from '@tundralibs/compat/permissions';
+import { getEnv } from '@tundralibs/compat/runtime';
 import { type PrivateObject, privateObject } from './privateObject.ts';
 
 /**


### PR DESCRIPTION
## What

Replaces the single `@tundralibs/compat` **root-barrel** import in utils with the precise subpaths. Internal import-path edit only — **zero API change**.

`envArgs.ts` (which already imported `./path` via a subpath):

```diff
-import {
-  getEnv,
-  hasPermissionSync,
-  readDirSync,
-  readTextFileSync,
-} from '@tundralibs/compat';
+import { readDirSync, readTextFileSync } from '@tundralibs/compat/file';
+import { hasPermissionSync } from '@tundralibs/compat/permissions';
+import { getEnv } from '@tundralibs/compat/runtime';
```

Symbol homes confirmed against `packages/compat/mod.ts`.

## Why

The compat root barrel re-exports **everything**, including `test.ts`. Its `bun:test` / `node:test` dynamic imports make a wrangler build of any consumer **hard-fail** — consumers currently need a wrangler `alias` stub as a workaround. The barrel also drags `webserver`, `cli`, and `net` into bundles that never use them.

utils is the widest-reaching case: because `utils/mod.ts` re-exports `envArgs`, this one import put `compat/test.ts` into the graph of **every** package that imports `@tundralibs/utils` — including slogger and pact in this PR set.

## Verification

- `deno check packages/utils/mod.ts` — clean.
- `deno test --allow-all --parallel packages/utils` from the repo root — **29 passed (436 steps), 0 failed**. (Running from inside `packages/utils` instead shows 3 `Config` failures on both this branch and the base commit — the fixtures are addressed as `packages/utils/fixtures/...`, so those tests require repo-root cwd, which is what the root `test` task uses. Not related to this change.)
- `deno bundle --platform=browser -o /tmp/utils-check.js packages/utils/mod.ts` succeeds.
- `grep -c "bun:test"` on the bundle: **1 → 0**.
- Bundle size: **267.66 KB → 232.36 KB**.

Part of a four-PR set (slogger, id, pact, utils), each independent and branched from the same base — none stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)