### PR TITLE
fix(compat): load node builtins synchronously instead of via top-level await

### DIFF
--- a/packages/compat/_runtime-globals.test.ts
+++ b/packages/compat/_runtime-globals.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Tests for the runtime-global accessors.
+ *
+ * {@link loadBuiltin} is the seam that lets every other module in the
+ * package reach a Node built-in *synchronously*. Getting it wrong
+ * reintroduces the top-level await that async-poisons consumer bundles,
+ * so its contract is pinned here: never throw, and return `undefined`
+ * — not a rejected promise, not an exception — on every runtime or
+ * specifier that can't supply the module.
+ *
+ * @module
+ */
+
+import { describe, it } from './test.ts';
+import { Bun, loadBuiltin } from './_runtime-globals.ts';
+import { isBun } from './runtime.ts';
+import * as asserts from '@std/asserts';
+
+/**
+ * Run `fn` with `globalThis.process` replaced by `stub`, restoring the
+ * original property descriptor afterwards.
+ *
+ * Deno and Node define `process` as a configurable accessor and Bun as a
+ * configurable data property, so the swap works everywhere — but it is a
+ * global, so `fn` stays synchronous and the restore lives in a `finally`
+ * to keep the stub from leaking into sibling tests (Bun runs a file's
+ * tests in one process).
+ */
+const withProcess = <T>(stub: unknown, fn: () => T): T => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'process');
+  Object.defineProperty(globalThis, 'process', {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    return fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, 'process', original);
+    } else {
+      delete (globalThis as Record<string, unknown>).process;
+    }
+  }
+};
+
+describe({
+  name: 'compat._runtime-globals',
+  fn: () => {
+    describe('Bun', () => {
+      it('is the Bun global on Bun and undefined elsewhere', () => {
+        asserts.assertEquals(
+          Bun !== undefined,
+          isBun,
+          'Bun accessor must track the runtime',
+        );
+      });
+    });
+
+    describe('loadBuiltin', () => {
+      it('resolves a built-in synchronously — no promise', () => {
+        const os = loadBuiltin('node:os');
+        asserts.assertEquals(
+          typeof os?.hostname,
+          'function',
+          'node:os must resolve to the real module',
+        );
+        asserts.assertEquals(
+          os instanceof Promise,
+          false,
+          'must not be a promise — sync callers deref it immediately',
+        );
+      });
+
+      it('returns the same namespace on repeat calls', () => {
+        asserts.assertStrictEquals(
+          loadBuiltin('node:path'),
+          loadBuiltin('node:path'),
+          'built-ins are cached by the runtime, not re-instantiated',
+        );
+      });
+
+      it('returns undefined when the `when` guard is false', () => {
+        asserts.assertEquals(
+          loadBuiltin('node:os', false),
+          undefined,
+          'a false guard must skip the load entirely',
+        );
+      });
+
+      it('loads when the `when` guard is true', () => {
+        asserts.assertEquals(
+          typeof loadBuiltin('node:os', true)?.hostname,
+          'function',
+        );
+      });
+
+      it('returns undefined for a specifier that is no built-in', () => {
+        asserts.assertEquals(
+          loadBuiltin('node:not-a-real-builtin'),
+          undefined,
+          'unknown built-ins resolve to undefined, they do not throw',
+        );
+      });
+
+      it('returns undefined when process has no getBuiltinModule', () => {
+        // Node < 22.3 / Bun < 1.1.31 shaped runtime: `process` exists but
+        // the hook doesn't.
+        const result = withProcess(
+          { versions: { node: '20.0.0' } },
+          () => loadBuiltin('node:os'),
+        );
+        asserts.assertEquals(result, undefined);
+      });
+
+      it('returns undefined when there is no process global', () => {
+        // Browser / workerd-shaped runtime: nothing to load from. This is
+        // the path that must stay quiet — throwing here would move the
+        // failure from call time to *import* time and break the bundle.
+        const result = withProcess(undefined, () => loadBuiltin('node:fs'));
+        asserts.assertEquals(result, undefined);
+      });
+
+      it('restores the real process global after stubbing', () => {
+        withProcess(undefined, () => loadBuiltin('node:os'));
+        asserts.assertEquals(
+          typeof loadBuiltin('node:os')?.hostname,
+          'function',
+          'the stub must not leak into sibling tests',
+        );
+      });
+    });
+  },
+});

--- a/packages/compat/_runtime-globals.ts
+++ b/packages/compat/_runtime-globals.ts
@@ -1,5 +1,6 @@
 /**
- * Loose typed accessor for the Bun runtime globals.
+ * Loose typed accessors for runtime globals — the `Bun` object and the
+ * `process.getBuiltinModule` hook used to load Node built-ins.
  *
  * `@tundralibs/compat` references `Bun.serve` / `Bun.file` / etc. inside
  * `if (isBun)` branches, but neither Deno's nor Node's lib types know about
@@ -31,3 +32,28 @@ type BunGlobal = {
  * `if (isBun)` branches, so it is never accessed on Deno or Node.
  */
 export const Bun: BunGlobal = (globalThis as any).Bun;
+
+/**
+ * Synchronously resolve a Node built-in (`node:fs`, `node:os`, …) through
+ * `process.getBuiltinModule` — present on Deno 2, Node ≥ 22.3 and
+ * Bun ≥ 1.1.31, which is the whole matrix compat supports.
+ *
+ * Built-ins are loaded this way instead of with `await import()` at module
+ * scope because a single top-level await anywhere in a module graph makes
+ * esbuild (wrangler) and Rollup (Vite) lower *every* module initializer in
+ * that graph to an async function. Circular imports that are perfectly legal
+ * ESM — and work natively — then deadlock, so consumers bundling compat for
+ * workerd or the browser hang forever on import.
+ *
+ * The optional chaining returns `undefined` on runtimes with no such hook
+ * (browsers, workerd). Callers keep their existing guards, so a missing
+ * backend still yields the documented fallback or an
+ * `UnsupportedRuntimeError` at call time — never at import time.
+ *
+ * Returns `any` so each call site can annotate itself with the module's
+ * `typeof import('node:x')` shape without repeating the type; the binding
+ * being possibly-`undefined` off a supported runtime is exactly why every
+ * caller keeps a runtime guard.
+ */
+export const loadBuiltin = (id: string): any =>
+  (globalThis as any).process?.getBuiltinModule?.(id);

--- a/packages/compat/_runtime-globals.ts
+++ b/packages/compat/_runtime-globals.ts
@@ -45,15 +45,19 @@ export const Bun: BunGlobal = (globalThis as any).Bun;
  * ESM — and work natively — then deadlock, so consumers bundling compat for
  * workerd or the browser hang forever on import.
  *
- * The optional chaining returns `undefined` on runtimes with no such hook
- * (browsers, workerd). Callers keep their existing guards, so a missing
- * backend still yields the documented fallback or an
- * `UnsupportedRuntimeError` at call time — never at import time.
+ * `when` gates the load for modules a single runtime family needs — e.g.
+ * `node:dgram`, which only `udp.ts`'s Node branch touches — so the other
+ * runtimes don't pay to initialize them. Omit it when every supported
+ * runtime uses the module: the missing hook is itself the guard on
+ * runtimes that have no built-ins at all.
  *
- * Returns `any` so each call site can annotate itself with the module's
- * `typeof import('node:x')` shape without repeating the type; the binding
- * being possibly-`undefined` off a supported runtime is exactly why every
- * caller keeps a runtime guard.
+ * Never throws. Returns `undefined` when the hook is absent (browsers,
+ * workerd), when `when` is `false`, and when `id` names no built-in — so a
+ * missing backend still surfaces as the caller's documented fallback or an
+ * `UnsupportedRuntimeError` at call time, never at import time.
+ *
+ * Typed `any` so each call site annotates itself with that module's
+ * `typeof import('node:x')` shape instead of repeating the type here.
  */
-export const loadBuiltin = (id: string): any =>
-  (globalThis as any).process?.getBuiltinModule?.(id);
+export const loadBuiltin = (id: string, when: boolean = true): any =>
+  when ? (globalThis as any).process?.getBuiltinModule?.(id) : undefined;

--- a/packages/compat/cli/progress.ts
+++ b/packages/compat/cli/progress.ts
@@ -22,12 +22,14 @@
  */
 
 import { isBun, isDeno, isNode } from '../runtime.ts';
+import { loadBuiltin } from '../_runtime-globals.ts';
 import { isTTY } from './terminal.ts';
 
-let nodeProcess: typeof import('node:process');
-if (isDeno || isBun || isNode) {
-  nodeProcess = await import('node:process');
-}
+// Resolved synchronously (see {@link loadBuiltin}); a top-level
+// `await import()` would async-poison every bundle compat lands in.
+const nodeProcess: typeof import('node:process') = isDeno || isBun || isNode
+  ? loadBuiltin('node:process')
+  : undefined;
 
 /**
  * Minimal writable interface — just the `write` method. Lets us inject

--- a/packages/compat/cli/progress.ts
+++ b/packages/compat/cli/progress.ts
@@ -21,15 +21,14 @@
  * ```
  */
 
-import { isBun, isDeno, isNode } from '../runtime.ts';
 import { loadBuiltin } from '../_runtime-globals.ts';
 import { isTTY } from './terminal.ts';
 
 // Resolved synchronously (see {@link loadBuiltin}); a top-level
 // `await import()` would async-poison every bundle compat lands in.
-const nodeProcess: typeof import('node:process') = isDeno || isBun || isNode
-  ? loadBuiltin('node:process')
-  : undefined;
+// All three runtimes expose `node:process`; anything else gets
+// `undefined` and falls back to the injected stream.
+const nodeProcess: typeof import('node:process') = loadBuiltin('node:process');
 
 /**
  * Minimal writable interface — just the `write` method. Lets us inject

--- a/packages/compat/cli/prompt.ts
+++ b/packages/compat/cli/prompt.ts
@@ -33,18 +33,17 @@
  * ```
  */
 
-import { isBun, isDeno, isNode } from '../runtime.ts';
 import { loadBuiltin } from '../_runtime-globals.ts';
 
 // Resolved synchronously (see {@link loadBuiltin}). Both are dereferenced
 // from sync helpers (`_setRaw`, `_writeStdout`), and a top-level
 // `await import()` would async-poison every bundle compat lands in.
-const nodeReadline: typeof import('node:readline') = isDeno || isBun || isNode
-  ? loadBuiltin('node:readline')
-  : undefined;
-const nodeProcess: typeof import('node:process') = isDeno || isBun || isNode
-  ? loadBuiltin('node:process')
-  : undefined;
+// All three runtimes expose these; anything else gets `undefined`, which
+// the helpers below already treat as "no TTY available".
+const nodeReadline: typeof import('node:readline') = loadBuiltin(
+  'node:readline',
+);
+const nodeProcess: typeof import('node:process') = loadBuiltin('node:process');
 
 /**
  * Options for {@link prompt}.

--- a/packages/compat/cli/prompt.ts
+++ b/packages/compat/cli/prompt.ts
@@ -34,13 +34,17 @@
  */
 
 import { isBun, isDeno, isNode } from '../runtime.ts';
+import { loadBuiltin } from '../_runtime-globals.ts';
 
-let nodeReadline: typeof import('node:readline');
-let nodeProcess: typeof import('node:process');
-if (isDeno || isBun || isNode) {
-  nodeReadline = await import('node:readline');
-  nodeProcess = await import('node:process');
-}
+// Resolved synchronously (see {@link loadBuiltin}). Both are dereferenced
+// from sync helpers (`_setRaw`, `_writeStdout`), and a top-level
+// `await import()` would async-poison every bundle compat lands in.
+const nodeReadline: typeof import('node:readline') = isDeno || isBun || isNode
+  ? loadBuiltin('node:readline')
+  : undefined;
+const nodeProcess: typeof import('node:process') = isDeno || isBun || isNode
+  ? loadBuiltin('node:process')
+  : undefined;
 
 /**
  * Options for {@link prompt}.

--- a/packages/compat/cli/spinner.ts
+++ b/packages/compat/cli/spinner.ts
@@ -30,13 +30,15 @@
  */
 
 import { isBun, isDeno, isNode } from '../runtime.ts';
+import { loadBuiltin } from '../_runtime-globals.ts';
 import { isTTY } from './terminal.ts';
 import type { WritableLike } from './progress.ts';
 
-let nodeProcess: typeof import('node:process');
-if (isDeno || isBun || isNode) {
-  nodeProcess = await import('node:process');
-}
+// Resolved synchronously (see {@link loadBuiltin}); a top-level
+// `await import()` would async-poison every bundle compat lands in.
+const nodeProcess: typeof import('node:process') = isDeno || isBun || isNode
+  ? loadBuiltin('node:process')
+  : undefined;
 
 /**
  * Default spinner frames — Unicode braille pattern, renders as a

--- a/packages/compat/cli/spinner.ts
+++ b/packages/compat/cli/spinner.ts
@@ -29,16 +29,15 @@
  * ```
  */
 
-import { isBun, isDeno, isNode } from '../runtime.ts';
 import { loadBuiltin } from '../_runtime-globals.ts';
 import { isTTY } from './terminal.ts';
 import type { WritableLike } from './progress.ts';
 
 // Resolved synchronously (see {@link loadBuiltin}); a top-level
 // `await import()` would async-poison every bundle compat lands in.
-const nodeProcess: typeof import('node:process') = isDeno || isBun || isNode
-  ? loadBuiltin('node:process')
-  : undefined;
+// All three runtimes expose `node:process`; anything else gets
+// `undefined` and falls back to the injected stream.
+const nodeProcess: typeof import('node:process') = loadBuiltin('node:process');
 
 /**
  * Default spinner frames — Unicode braille pattern, renders as a

--- a/packages/compat/file.ts
+++ b/packages/compat/file.ts
@@ -36,13 +36,16 @@ type NodeFsHandle = Awaited<ReturnType<typeof import('node:fs').promises.open>>;
 // `await import()` — the sync variants (`readTextFileSync`, `statSync`, …)
 // need the backend before any promise can settle, and TLA here would make
 // bundlers turn every consumer module into an async initializer (see
-// {@link loadBuiltin}).
-const nodeFs: typeof import('node:fs') = isBun || isNode
-  ? loadBuiltin('node:fs')
-  : undefined;
-const nodeOs: typeof import('node:os') = isBun || isNode
-  ? loadBuiltin('node:os')
-  : undefined;
+// {@link loadBuiltin}). Deno reaches the same operations through `Deno.*`,
+// so it skips both loads.
+const nodeFs: typeof import('node:fs') = loadBuiltin(
+  'node:fs',
+  isBun || isNode,
+);
+const nodeOs: typeof import('node:os') = loadBuiltin(
+  'node:os',
+  isBun || isNode,
+);
 
 //#region Error Classes
 /**

--- a/packages/compat/file.ts
+++ b/packages/compat/file.ts
@@ -17,28 +17,32 @@
  * ```
  */
 
-import { Bun } from './_runtime-globals.ts';
+import { Bun, loadBuiltin } from './_runtime-globals.ts';
 import { isBun, isDeno, isNode, OS } from './runtime.ts';
 import { CompatError } from './Error.ts';
 import * as path from './path.ts';
 
-/** Node.js modules, lazily imported for Bun/Node environments */
+/** Node.js modules, loaded synchronously for Bun/Node environments */
 // Local alias for the Deno-only file handle — see _runtime-globals.ts.
 // The runtime object has `.read()/.write()/.sync()/.close()` etc.; the
 // `any` typing decouples us from Deno's lib type definition.
 // deno-lint-ignore no-explicit-any
 type DenoFsFile = any;
 
-let nodeFs: typeof import('node:fs');
-let nodeOs: typeof import('node:os');
-
 /** Node.js FileHandle type from fs.promises.open() */
 type NodeFsHandle = Awaited<ReturnType<typeof import('node:fs').promises.open>>;
 
-if (isBun || isNode) {
-  nodeFs = await import('node:fs');
-  nodeOs = await import('node:os');
-}
+// Resolved through `process.getBuiltinModule` rather than a top-level
+// `await import()` — the sync variants (`readTextFileSync`, `statSync`, …)
+// need the backend before any promise can settle, and TLA here would make
+// bundlers turn every consumer module into an async initializer (see
+// {@link loadBuiltin}).
+const nodeFs: typeof import('node:fs') = isBun || isNode
+  ? loadBuiltin('node:fs')
+  : undefined;
+const nodeOs: typeof import('node:os') = isBun || isNode
+  ? loadBuiltin('node:os')
+  : undefined;
 
 //#region Error Classes
 /**
@@ -3392,7 +3396,7 @@ export const makeTempFile: (options?: TempOptions) => Promise<string> = async (
     if (isDeno) {
       return await Deno.makeTempFile(opts);
     } else if (isBun || isNode) {
-      const tmpdir = opts.dir ?? (await import('node:os')).tmpdir();
+      const tmpdir = opts.dir ?? nodeOs.tmpdir();
       const prefix = opts.prefix ?? '';
       const suffix = opts.suffix ?? '';
       // Cryptographically-random name. Date.now()+Math.random() was
@@ -3436,7 +3440,6 @@ export const makeTempFileSync: (options?: TempOptions) => string = (
     if (isDeno) {
       return Deno.makeTempFileSync(opts);
     } else if (isBun || isNode) {
-      // Use dynamic import for node:os
       const { tmpdir } = nodeOs;
       const tempdir = opts.dir ?? tmpdir();
       const prefix = opts.prefix ?? '';
@@ -3482,7 +3485,7 @@ export const makeTempDir: (options?: TempOptions) => Promise<string> = async (
     if (isDeno) {
       return await Deno.makeTempDir(opts);
     } else if (isBun || isNode) {
-      const tmpdir = opts.dir ?? (await import('node:os')).tmpdir();
+      const tmpdir = opts.dir ?? nodeOs.tmpdir();
       const prefix = opts.prefix ?? '';
       const suffix = opts.suffix ?? '';
       // Cryptographically-random name. Date.now()+Math.random() was
@@ -3526,7 +3529,6 @@ export const makeTempDirSync: (options?: TempOptions) => string = (
     if (isDeno) {
       return Deno.makeTempDirSync(opts);
     } else if (isBun || isNode) {
-      // Use dynamic import for node:os
       const { tmpdir } = nodeOs;
       const tempdir = opts.dir ?? tmpdir();
       const prefix = opts.prefix ?? '';

--- a/packages/compat/mod.test.ts
+++ b/packages/compat/mod.test.ts
@@ -1,18 +1,177 @@
 /**
- * @fileoverview Tests for the package root barrel (`mod.ts`).
+ * @fileoverview Tests for the package root barrel (`mod.ts`) and the
+ * package-wide invariants consumers depend on.
  *
  * Guards that the headline API is re-exported as a runtime VALUE, not
  * type-only. A `type`-only re-export is erased at runtime, so consumers
  * doing `import { WebServer } from '@tundralibs/compat'` would receive
  * `undefined` and `new WebServer(...)` would throw "not a constructor".
  *
+ * Also guards that no module reintroduces top-level await — see the
+ * `no top-level await` suite for why that is load-bearing.
+ *
  * @module
  */
 
 import { describe, it } from './test.ts';
 import * as asserts from '@std/asserts';
+import { readDirSync, readTextFileSync } from './file.ts';
+import { join } from './path.ts';
 import { WebServer } from './mod.ts';
 import * as compat from './mod.ts';
+
+/** Package root — this file sits at `packages/compat/mod.test.ts`. */
+const PACKAGE_DIR = import.meta.dirname!;
+
+/**
+ * Files exempt from the no-top-level-await rule. `test.ts` loads the
+ * runtime's native test framework (`@std/testing/bdd`, `bun:test`,
+ * `node:test`), none of which is a built-in reachable through
+ * `process.getBuiltinModule`, so a dynamic import is the only option.
+ * It is a test-only entry point and never lands in an application
+ * bundle's module graph.
+ */
+const TLA_EXEMPT = new Set(['test.ts']);
+
+/**
+ * Blank out comments and string/template literals so the brace-depth
+ * scan below can't be fooled by a brace or the word `await` inside one.
+ * Newlines survive so reported line numbers stay accurate.
+ */
+const stripNonCode = (src: string): string => {
+  const out: string[] = [];
+  let i = 0;
+  const keep = (ch: string) => (ch === '\n' ? '\n' : ' ');
+  while (i < src.length) {
+    const ch = src[i]!;
+    const next = src[i + 1];
+    if (ch === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') out.push(keep(src[i++]!));
+    } else if (ch === '/' && next === '*') {
+      out.push(' ', ' ');
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
+        out.push(keep(src[i++]!));
+      }
+      out.push(' ', ' ');
+      i += 2;
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      out.push(' ');
+      i++;
+      while (i < src.length && src[i] !== ch) {
+        if (src[i] === '\\') {
+          out.push(' ', ' ');
+          i += 2;
+          continue;
+        }
+        out.push(keep(src[i++]!));
+      }
+      out.push(' ');
+      i++;
+    } else {
+      out.push(ch);
+      i++;
+    }
+  }
+  return out.join('');
+};
+
+/**
+ * Does the `{` at `braceIdx` open a function body rather than a block?
+ *
+ * Brace depth alone can't answer "is this await inside a function": the
+ * shape this package had to remove — `if (isNode) { x = await import(…) }`
+ * — sits one brace deep and is still top-level await. So a `{` counts as
+ * a function body when it follows `=>`, or follows a parameter list (with
+ * an optional return-type annotation) whose head is not a control-flow
+ * keyword.
+ */
+const opensFunction = (code: string, braceIdx: number): boolean => {
+  // Scans backwards over indices — slicing the prefix per brace would
+  // make this quadratic on a file the size of `file.ts`.
+  let i = braceIdx - 1;
+  const skipSpace = () => {
+    while (i >= 0 && /\s/.test(code[i]!)) i--;
+  };
+  skipSpace();
+  if (code[i] === '>' && code[i - 1] === '=') return true;
+  if (code[i] !== ')') {
+    // Maybe a return-type annotation: `(): Promise<void> {`. Anything
+    // structural before the `:` means this is a plain block.
+    while (i >= 0 && !'(){};:'.includes(code[i]!)) i--;
+    if (code[i] !== ':') return false;
+    i--;
+    skipSpace();
+    if (code[i] !== ')') return false;
+  }
+  // Walk back to the `(` that opens the parameter list.
+  let depth = 0;
+  for (; i >= 0; i--) {
+    if (code[i] === ')') depth++;
+    else if (code[i] === '(') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  i--;
+  skipSpace();
+  const end = i + 1;
+  while (i >= 0 && /[\w$]/.test(code[i]!)) i--;
+  const head = code.slice(i + 1, end);
+  return !['if', 'for', 'while', 'switch', 'catch'].includes(head);
+};
+
+/**
+ * Return the 1-based line numbers holding a module-scope `await` — i.e.
+ * top-level await. Walks the comment- and string-stripped source keeping
+ * a stack of open braces (function body vs. plain block); an `await`
+ * counts unless some enclosing brace opened a function. Concise arrow
+ * bodies carry no brace, so `=>` without one opens a function scope that
+ * runs to the end of the statement.
+ */
+const findTopLevelAwait = (src: string): number[] => {
+  const code = stripNonCode(src);
+  const hits: number[] = [];
+  const scopes: boolean[] = [];
+  let conciseArrow = false;
+  let line = 1;
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i]!;
+    if (ch === '\n') line++;
+    else if (ch === '{') scopes.push(opensFunction(code, i));
+    else if (ch === '}') scopes.pop();
+    else if (ch === ';') conciseArrow = false;
+    else if (ch === '=' && code[i + 1] === '>') {
+      const rest = code.slice(i + 2).replace(/^\s+/, '');
+      conciseArrow = !rest.startsWith('{');
+      i++;
+    } else if (/[\w$]/.test(ch)) {
+      if (
+        code.startsWith('await', i) && !/[.\w$]/.test(code[i - 1] ?? ' ') &&
+        /[\s(]/.test(code[i + 5] ?? '')
+      ) {
+        if (!conciseArrow && !scopes.includes(true)) hits.push(line);
+        i += 4;
+      } else {
+        while (i + 1 < code.length && /[\w$]/.test(code[i + 1]!)) i++;
+      }
+    }
+  }
+  return hits;
+};
+
+/** Every `.ts` source in the package, excluding tests and fixtures. */
+const sourceFiles = (dir: string, found: string[] = []): string[] => {
+  for (const entry of readDirSync(dir)) {
+    if (entry.isDirectory) {
+      if (entry.name === 'fixtures' || entry.name === 'docs') continue;
+      sourceFiles(join(dir, entry.name), found);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      found.push(join(dir, entry.name));
+    }
+  }
+  return found;
+};
 
 describe('compat.mod (root barrel)', () => {
   it('re-exports WebServer as a runtime value (not type-only)', () => {
@@ -41,5 +200,120 @@ describe('compat.mod (root barrel)', () => {
     );
     asserts.assertEquals(server.name, 'RootExportTest');
     asserts.assertEquals(server.mode, 'TCP');
+  });
+});
+
+// =============================================================================
+// No top-level await
+// -----------------------------------------------------------------------------
+// One top-level await anywhere in a module graph makes esbuild (wrangler)
+// and Rollup (Vite) lower EVERY module initializer in that graph to an
+// async function. Circular imports that are legal ESM and work natively —
+// guardian's StringGuardian <-> DateGuardian, slogger's Slogger <->
+// LogManager — then deadlock: `await init_A()` awaits `await init_B()`
+// which awaits `init_A()`. compat sits under all of them, so a single TLA
+// reintroduced here hangs those consumers' builds on import, with no error
+// message to trace it by. Node built-ins must come from
+// `process.getBuiltinModule` (see `loadBuiltin`) and npm packages from a
+// dynamic import inside an async function.
+// =============================================================================
+
+describe('compat.mod (no top-level await)', () => {
+  it('the detector flags module-scope await', () => {
+    // Pins the detector itself — a scan that can no longer fail would
+    // silently stop protecting the invariant.
+    asserts.assertEquals(
+      findTopLevelAwait(`const os = await import('node:os');\n`),
+      [1],
+    );
+    asserts.assertEquals(
+      // The exact shape this package removed: guarded, one brace deep,
+      // and still top-level await.
+      findTopLevelAwait(`if (isNode) {\n  x = await import('node:os');\n}\n`),
+      [2],
+      'a guarded top-level await is still top-level await',
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(`for (const m of mods) {\n  await load(m);\n}\n`),
+      [2],
+      'a module-scope loop body is not a function scope',
+    );
+  });
+
+  it('the detector ignores await inside functions', () => {
+    asserts.assertEquals(
+      findTopLevelAwait(
+        `async function f() {\n  const os = await import('node:os');\n}\n`,
+      ),
+      [],
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(
+        `async function f(): Promise<void> {\n  if (x) {\n    await g();\n  }\n}\n`,
+      ),
+      [],
+      'a return-type annotation still ends a parameter list',
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(
+        `class A {\n  async m() {\n    await g();\n  }\n}\n`,
+      ),
+      [],
+      'methods are function scopes',
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(`const f = async () => await load();\n`),
+      [],
+      'a concise arrow body is a function scope even without braces',
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(`const f = async () => {\n  await load();\n};\n`),
+      [],
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(`const x = awaited;\nconst y = a.await;\n`),
+      [],
+      'only the `await` operator counts, not lookalike identifiers',
+    );
+    asserts.assertEquals(
+      findTopLevelAwait(`// const os = await import('node:os');\n`),
+      [],
+      'commentary about top-level await is not top-level await',
+    );
+    asserts.assertEquals(
+      findTopLevelAwait("const s = `await import('x')`;\n"),
+      [],
+      'a string mentioning it is not it either',
+    );
+  });
+
+  it('no source module uses top-level await', () => {
+    const files = sourceFiles(PACKAGE_DIR);
+    asserts.assert(files.length > 10, 'walk must find the package sources');
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const name = file.slice(PACKAGE_DIR.length + 1);
+      if (TLA_EXEMPT.has(name)) continue;
+      for (const line of findTopLevelAwait(readTextFileSync(file))) {
+        offenders.push(`${name}:${line}`);
+      }
+    }
+    asserts.assertEquals(
+      offenders,
+      [],
+      `top-level await found — this async-poisons consumer bundles: ${
+        offenders.join(', ')
+      }`,
+    );
+  });
+
+  it('test.ts is the only exemption, and it is still exempt for cause', () => {
+    // If test.ts ever stops using TLA the exemption should go with it.
+    asserts.assert(
+      findTopLevelAwait(readTextFileSync(join(PACKAGE_DIR, 'test.ts')))
+        .length > 0,
+      'test.ts no longer needs its exemption — drop it from TLA_EXEMPT',
+    );
   });
 });

--- a/packages/compat/net.ts
+++ b/packages/compat/net.ts
@@ -17,6 +17,7 @@
  * ```
  */
 import { isBun, isDeno, isNode } from './runtime.ts';
+import { loadBuiltin } from './_runtime-globals.ts';
 import { ConnectionTimeoutError, UnsupportedRuntimeError } from './Error.ts';
 import type { TLSOptions, ValidatedTLS } from './common.ts';
 import { combineSignals, validateTLS } from './common.ts';
@@ -38,17 +39,22 @@ type DenoStartTlsOptions = any;
 // deno-lint-ignore no-explicit-any
 type DenoTlsCertifiedKeyPem = any;
 
-// Node.js imports
-let nodeNet: typeof import('node:net');
-let nodeTls: typeof import('node:tls');
-let nodeBuffer: typeof import('node:buffer');
-let nodeOs: typeof import('node:os');
-if (isBun || isNode) {
-  nodeNet = await import('node:net');
-  nodeTls = await import('node:tls');
-  nodeBuffer = await import('node:buffer');
-  nodeOs = await import('node:os');
-}
+// Node.js built-ins, resolved synchronously through
+// `process.getBuiltinModule` (see {@link loadBuiltin}). A top-level
+// `await import()` here would make bundlers lower every consumer module to
+// an async initializer, deadlocking legal circular imports.
+const nodeNet: typeof import('node:net') = isBun || isNode
+  ? loadBuiltin('node:net')
+  : undefined;
+const nodeTls: typeof import('node:tls') = isBun || isNode
+  ? loadBuiltin('node:tls')
+  : undefined;
+const nodeBuffer: typeof import('node:buffer') = isBun || isNode
+  ? loadBuiltin('node:buffer')
+  : undefined;
+const nodeOs: typeof import('node:os') = isBun || isNode
+  ? loadBuiltin('node:os')
+  : undefined;
 // deno-lint-ignore no-explicit-any
 const g = globalThis as any;
 

--- a/packages/compat/net.ts
+++ b/packages/compat/net.ts
@@ -42,19 +42,24 @@ type DenoTlsCertifiedKeyPem = any;
 // Node.js built-ins, resolved synchronously through
 // `process.getBuiltinModule` (see {@link loadBuiltin}). A top-level
 // `await import()` here would make bundlers lower every consumer module to
-// an async initializer, deadlocking legal circular imports.
-const nodeNet: typeof import('node:net') = isBun || isNode
-  ? loadBuiltin('node:net')
-  : undefined;
-const nodeTls: typeof import('node:tls') = isBun || isNode
-  ? loadBuiltin('node:tls')
-  : undefined;
-const nodeBuffer: typeof import('node:buffer') = isBun || isNode
-  ? loadBuiltin('node:buffer')
-  : undefined;
-const nodeOs: typeof import('node:os') = isBun || isNode
-  ? loadBuiltin('node:os')
-  : undefined;
+// an async initializer, deadlocking legal circular imports. Deno serves
+// every one of these from `Deno.*`, so it skips the loads.
+const nodeNet: typeof import('node:net') = loadBuiltin(
+  'node:net',
+  isBun || isNode,
+);
+const nodeTls: typeof import('node:tls') = loadBuiltin(
+  'node:tls',
+  isBun || isNode,
+);
+const nodeBuffer: typeof import('node:buffer') = loadBuiltin(
+  'node:buffer',
+  isBun || isNode,
+);
+const nodeOs: typeof import('node:os') = loadBuiltin(
+  'node:os',
+  isBun || isNode,
+);
 // deno-lint-ignore no-explicit-any
 const g = globalThis as any;
 

--- a/packages/compat/path.ts
+++ b/packages/compat/path.ts
@@ -7,7 +7,9 @@
  * @module
  */
 
+import * as stdPath from '@std/path';
 import { isBun, isDeno, isNode, OS } from './runtime.ts';
+import { loadBuiltin } from './_runtime-globals.ts';
 
 /** PATH-variable separator: `;` on Windows, `:` elsewhere. */
 export const DELIMITER: ';' | ':' = OS === 'WINDOWS' ? `;` : `:`;
@@ -18,7 +20,12 @@ export const SEPARATOR: '\\' | '/' = OS === 'WINDOWS' ? `\\` : `/`;
 /** Regex matching one-or-more path separators (Windows: `/` or `\`; else `/`). */
 export const SEPARATOR_PATTERN = OS === 'WINDOWS' ? /[\\/]+/ : /\/+/;
 
-let nativePath: {
+/**
+ * The slice of the `node:path` / `@std/path` surface this module
+ * re-exports. Internal to this file — the exported helpers below are the
+ * public contract.
+ */
+type NativePath = {
   basename(path: string, suffix?: string): string;
   dirname(path: string): string;
   extname(path: string): string;
@@ -43,10 +50,16 @@ let nativePath: {
   }): string;
 };
 
+// `@std/path` is pure JS, so a static import is bundler-safe; `node:path`
+// comes through `process.getBuiltinModule` (see {@link loadBuiltin}).
+// Neither may be a top-level `await import()` — one TLA anywhere in a
+// module graph makes esbuild/Rollup lower every initializer in that graph
+// to an async function, which deadlocks legal circular imports downstream.
+let nativePath: NativePath;
 if (isDeno) {
-  nativePath = await import('@std/path') as typeof nativePath;
+  nativePath = stdPath as NativePath;
 } else if (isBun || isNode) {
-  nativePath = await import('node:path') as typeof nativePath;
+  nativePath = loadBuiltin('node:path');
 }
 
 export const basename = (path: string, suffix?: string): string =>

--- a/packages/compat/runtime.ts
+++ b/packages/compat/runtime.ts
@@ -42,10 +42,9 @@ export const isNode: boolean = g.process?.versions?.node !== undefined &&
 // Node.js compat layer. Loaded synchronously (see {@link loadBuiltin}) so
 // `cpus()`, `totalmem()`, `freemem()`, and `uptime()` share a single backend
 // with no per-runtime branching. Stays `undefined` on unrecognized runtimes
-// (browsers, etc.) so the helpers can return safe fallbacks.
-const nodeOs: typeof import('node:os') = isDeno || isBun || isNode
-  ? loadBuiltin('node:os')
-  : undefined;
+// (browsers, etc.) — they have no `getBuiltinModule` — so the helpers can
+// return safe fallbacks.
+const nodeOs: typeof import('node:os') = loadBuiltin('node:os');
 
 // #region Runtime helpers
 /** Current process ID, or `undefined` on unknown runtimes. */

--- a/packages/compat/runtime.ts
+++ b/packages/compat/runtime.ts
@@ -17,6 +17,8 @@
  * ```
  */
 
+import { loadBuiltin } from './_runtime-globals.ts';
+
 export type Runtime = 'DENO' | 'BUN' | 'NODE' | 'UNKNOWN';
 export type OperatingSystem = 'WINDOWS' | 'LINUX' | 'DARWIN' | 'UNKNOWN';
 
@@ -37,14 +39,13 @@ export const isNode: boolean = g.process?.versions?.node !== undefined &&
   g.Bun === undefined && g.Deno === undefined;
 
 // `node:os` resolves on all three runtimes — Deno provides it through its
-// Node.js compat layer. Loaded lazily so `cpus()`, `totalmem()`,
-// `freemem()`, and `uptime()` share a single backend with no per-runtime
-// branching. Stays `undefined` on unrecognized runtimes (browsers, etc.)
-// so the helpers can return safe fallbacks.
-let nodeOs: typeof import('node:os');
-if (isDeno || isBun || isNode) {
-  nodeOs = await import('node:os');
-}
+// Node.js compat layer. Loaded synchronously (see {@link loadBuiltin}) so
+// `cpus()`, `totalmem()`, `freemem()`, and `uptime()` share a single backend
+// with no per-runtime branching. Stays `undefined` on unrecognized runtimes
+// (browsers, etc.) so the helpers can return safe fallbacks.
+const nodeOs: typeof import('node:os') = isDeno || isBun || isNode
+  ? loadBuiltin('node:os')
+  : undefined;
 
 // #region Runtime helpers
 /** Current process ID, or `undefined` on unknown runtimes. */

--- a/packages/compat/udp.ts
+++ b/packages/compat/udp.ts
@@ -23,12 +23,13 @@
  */
 import { isBun, isDeno, isNode } from './runtime.ts';
 import { UnsupportedRuntimeError } from './Error.ts';
-import { Bun } from './_runtime-globals.ts';
+import { Bun, loadBuiltin } from './_runtime-globals.ts';
 
-let nodeDgram: typeof import('node:dgram');
-if (isNode) {
-  nodeDgram = await import('node:dgram');
-}
+// Resolved synchronously (see {@link loadBuiltin}); a top-level
+// `await import()` would async-poison every bundle compat lands in.
+const nodeDgram: typeof import('node:dgram') = isNode
+  ? loadBuiltin('node:dgram')
+  : undefined;
 
 /**
  * Open UDP socket abstraction.

--- a/packages/compat/udp.ts
+++ b/packages/compat/udp.ts
@@ -27,9 +27,11 @@ import { Bun, loadBuiltin } from './_runtime-globals.ts';
 
 // Resolved synchronously (see {@link loadBuiltin}); a top-level
 // `await import()` would async-poison every bundle compat lands in.
-const nodeDgram: typeof import('node:dgram') = isNode
-  ? loadBuiltin('node:dgram')
-  : undefined;
+// Deno and Bun have native datagram sockets, so only Node loads this.
+const nodeDgram: typeof import('node:dgram') = loadBuiltin(
+  'node:dgram',
+  isNode,
+);
 
 /**
  * Open UDP socket abstraction.

--- a/packages/compat/watch.ts
+++ b/packages/compat/watch.ts
@@ -25,12 +25,14 @@
  */
 
 import { isBun, isDeno, isNode, RUNTIME } from './runtime.ts';
+import { loadBuiltin } from './_runtime-globals.ts';
 import { resolve } from './path.ts';
 
-let nodeFs: typeof import('node:fs');
-if (isBun || isNode) {
-  nodeFs = await import('node:fs');
-}
+// Resolved synchronously (see {@link loadBuiltin}); a top-level
+// `await import()` would async-poison every bundle compat lands in.
+const nodeFs: typeof import('node:fs') = isBun || isNode
+  ? loadBuiltin('node:fs')
+  : undefined;
 
 // deno-lint-ignore no-explicit-any
 const g = globalThis as any;

--- a/packages/compat/watch.ts
+++ b/packages/compat/watch.ts
@@ -30,9 +30,11 @@ import { resolve } from './path.ts';
 
 // Resolved synchronously (see {@link loadBuiltin}); a top-level
 // `await import()` would async-poison every bundle compat lands in.
-const nodeFs: typeof import('node:fs') = isBun || isNode
-  ? loadBuiltin('node:fs')
-  : undefined;
+// Deno watches through `Deno.watchFs`, so it skips the load.
+const nodeFs: typeof import('node:fs') = loadBuiltin(
+  'node:fs',
+  isBun || isNode,
+);
 
 // deno-lint-ignore no-explicit-any
 const g = globalThis as any;

--- a/packages/compat/webserver/WebServer.test.ts
+++ b/packages/compat/webserver/WebServer.test.ts
@@ -2216,6 +2216,74 @@ h87g/qBXJrxZ7o+w+KxL/Q==
     });
 
     it({
+      name: 'echoes over a live connection, twice, on separate servers',
+      // On Node the WebSocket backend is the `ws` npm package, which is
+      // NOT a Node built-in and so cannot come from
+      // `process.getBuiltinModule`. It is imported lazily on the async
+      // start path and the promise is memoized — importing it at module
+      // scope would reintroduce top-level await AND break Cloudflare
+      // Workers, which reports `process.versions.node` but cannot
+      // resolve npm packages. Running the round-trip twice against two
+      // servers proves the memoized module is still usable on the second
+      // start, not consumed or half-initialized by the first.
+      fn: async () => {
+        for (const round of ['first', 'second']) {
+          const port = getNextPort();
+          const received: string[] = [];
+
+          activeServer = new WebServer('Test', {
+            mode: 'TCP',
+            port,
+            hostname: 'localhost',
+            handler: () => new Response('Not a WebSocket'),
+            websocket: {
+              open: (ws) => ws.send('welcome'),
+              message: (ws, data) => ws.send(`echo:${data}`),
+            },
+          });
+
+          await activeServer.start();
+          await delay(100);
+
+          const ws = new WebSocket(`ws://localhost:${port}/`);
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(
+              () => reject(new Error(`${round} round timed out`)),
+              5000,
+            );
+            ws.addEventListener('message', (ev) => {
+              received.push(String(ev.data));
+              if (received.length === 1) {
+                ws.send('ping');
+              } else {
+                clearTimeout(timer);
+                ws.close();
+                resolve();
+              }
+            });
+            ws.addEventListener('error', () => {
+              clearTimeout(timer);
+              reject(new Error(`${round} round errored`));
+            });
+          });
+          await delay(50);
+
+          if (received[0] !== 'welcome' || received[1] !== 'echo:ping') {
+            throw new Error(
+              `Expected ['welcome','echo:ping'] on the ${round} round, got ${
+                JSON.stringify(received)
+              }`,
+            );
+          }
+
+          await activeServer.stop(false);
+          activeServer = null;
+          await delay(50);
+        }
+      },
+    });
+
+    it({
       name: 'should track WebSocket upgrade metrics',
       fn: async () => {
         const port = getNextPort();

--- a/packages/compat/webserver/WebServer.ts
+++ b/packages/compat/webserver/WebServer.ts
@@ -55,7 +55,7 @@
  * ```
  */
 
-import { Bun } from '../_runtime-globals.ts';
+import { Bun, loadBuiltin } from '../_runtime-globals.ts';
 
 import { isNode, RUNTIME } from '../runtime.ts';
 import { isFileSync, pathExistsSync, removeSync } from '../file.ts';
@@ -101,18 +101,34 @@ type BunServerWebSocket<_T = any> = any;
 // deno-lint-ignore no-explicit-any
 type DenoServeHandlerInfo = any;
 
-// Node.js imports
-let nodeHttp: typeof import('node:http');
-let nodeHttps: typeof import('node:https');
-// `ws` is the de-facto Node WebSocket implementation; pure-JS, no
-// native deps. Lazy-loaded so it isn't pulled in on Bun/Deno where
-// native WS support is used instead.
-let nodeWs: typeof import('ws');
-if (isNode) {
-  nodeHttp = await import('node:http');
-  nodeHttps = await import('node:https');
-  nodeWs = await import('ws');
-}
+// Node.js built-ins, resolved synchronously through
+// `process.getBuiltinModule` (see {@link loadBuiltin}) — never with a
+// top-level `await import()`, which would make bundlers lower every
+// consumer module to an async initializer and deadlock legal circular
+// imports.
+const nodeHttp: typeof import('node:http') = isNode
+  ? loadBuiltin('node:http')
+  : undefined;
+const nodeHttps: typeof import('node:https') = isNode
+  ? loadBuiltin('node:https')
+  : undefined;
+
+/**
+ * `ws` is the de-facto Node WebSocket implementation; pure-JS, no native
+ * deps. It is an npm package rather than a built-in, so a dynamic import
+ * is the only way to reach it — and that import must stay inside the async
+ * server-start path. At module scope it would both reintroduce top-level
+ * await and break runtimes that merely *look* like Node: Cloudflare
+ * Workers exposes `process.versions.node`, so an eval-time load there
+ * would fail for every consumer importing the compat barrel.
+ *
+ * The promise is memoized, so the module is fetched once no matter how
+ * many servers start.
+ */
+let nodeWsLoad: Promise<typeof import('ws')> | undefined;
+const loadNodeWs = (): Promise<
+  typeof import('ws')
+> => (nodeWsLoad ??= import('ws'));
 
 /** Minimal shape of a Deno HTTP server handle (avoids `typeof Deno` in public types). */
 type _DenoServerHandle = {
@@ -1789,7 +1805,7 @@ export class WebServer<T = unknown> {
    *
    * @internal
    */
-  protected _startNodeServer(): Promise<void> { // NOSONAR - Complexity acceptable for server start
+  protected async _startNodeServer(): Promise<void> { // NOSONAR - Complexity acceptable for server start
     const processNodeRequest = (
       req: InstanceType<typeof nodeHttp.IncomingMessage>,
       res: InstanceType<typeof nodeHttp.ServerResponse>,
@@ -1901,9 +1917,11 @@ export class WebServer<T = unknown> {
       server = nodeHttp.createServer(processNodeRequest);
     }
 
-    // Attach the WebSocket upgrade handler if configured.
+    // Attach the WebSocket upgrade handler if configured. `ws` is loaded
+    // here — on the async start path — so servers without a `websocket`
+    // handler never pull the package in at all.
     if (this.options.websocket) {
-      this.__attachNodeWebSocketUpgrade(server);
+      this.__attachNodeWebSocketUpgrade(server, await loadNodeWs());
     }
 
     // `server.listen()` returns synchronously and binds the port in a
@@ -1943,12 +1961,17 @@ export class WebServer<T = unknown> {
    * the socket or hands it off to `ws.WebSocketServer.handleUpgrade`
    * for the actual WebSocket handshake.
    *
+   * `ws` arrives as a parameter rather than a module binding — the
+   * caller loads it lazily (see {@link loadNodeWs}) so the package stays
+   * out of module evaluation.
+   *
    * @internal
    */
   private __attachNodeWebSocketUpgrade(
     server:
       | InstanceType<typeof nodeHttp.Server>
       | InstanceType<typeof nodeHttps.Server>,
+    nodeWs: typeof import('ws'),
   ): void {
     const wsHandler = this.options.websocket;
     if (!wsHandler) return;

--- a/packages/compat/webserver/WebServer.ts
+++ b/packages/compat/webserver/WebServer.ts
@@ -106,12 +106,12 @@ type DenoServeHandlerInfo = any;
 // top-level `await import()`, which would make bundlers lower every
 // consumer module to an async initializer and deadlock legal circular
 // imports.
-const nodeHttp: typeof import('node:http') = isNode
-  ? loadBuiltin('node:http')
-  : undefined;
-const nodeHttps: typeof import('node:https') = isNode
-  ? loadBuiltin('node:https')
-  : undefined;
+// Bun and Deno serve through their own APIs, so only Node loads these.
+const nodeHttp: typeof import('node:http') = loadBuiltin('node:http', isNode);
+const nodeHttps: typeof import('node:https') = loadBuiltin(
+  'node:https',
+  isNode,
+);
 
 /**
  * `ws` is the de-facto Node WebSocket implementation; pure-JS, no native


### PR DESCRIPTION
## Why

`packages/compat` guarded its Node built-ins behind module-scope top-level await:

```ts
let nodeOs: typeof import('node:os');
if (isDeno || isBun || isNode) {
  nodeOs = await import('node:os');   // TLA
}
```

That TLA async-poisons bundler output. When a consumer bundles with **esbuild** (wrangler) or **Rollup** (Vite), a single top-level await anywhere in the module graph lowers **every** module initializer in that graph to an `async` function. Packages with circular imports that are perfectly legal ESM and work fine natively — guardian's `StringGuardian` ↔ `DateGuardian`, slogger's `Slogger` ↔ `LogManager` — then deadlock: `await init_A()` awaits `await init_B()` which awaits `init_A()`.

This was verified empirically: importing guardian or slogger hangs forever in both a wrangler and a Vite consumer build today, and passes 24/24 (workerd) and 15/15 (browser) once compat's TLA is gone.

## The two replacement patterns

**1. `process.getBuiltinModule` for built-ins needed by sync code paths.** A new `loadBuiltin` helper lives alongside the existing `Bun` global accessor in `_runtime-globals.ts`:

```ts
export const loadBuiltin = (id: string): any =>
  (globalThis as any).process?.getBuiltinModule?.(id);
```

Call sites keep their existing runtime guards verbatim:

```ts
const nodeFs: typeof import('node:fs') = isBun || isNode
  ? loadBuiltin('node:fs')
  : undefined;
```

The optional chaining still yields `undefined` on browsers/workerd, so unsupported runtimes get their documented fallback or `UnsupportedRuntimeError` **at call time, never at import time** — identical to the old behaviour.

Applied to: `runtime.ts`, `file.ts`, `net.ts`, `watch.ts`, `udp.ts`, `path.ts` (node/bun branch), `cli/spinner.ts`, `cli/progress.ts`, `cli/prompt.ts`, `webserver/WebServer.ts` (`node:http` / `node:https`).

`path.ts`'s Deno branch keeps `@std/path`, now as a **static** import — pure JS, bundler-safe, behaviour unchanged.

**2. Function-scoped lazy `await import()` for async-only paths.** `webserver/WebServer.ts`'s `ws` is an npm package, not a built-in, so `getBuiltinModule` can't reach it. It moved into the async server-start path, memoized, and is passed into `__attachNodeWebSocketUpgrade`:

```ts
let nodeWsLoad: Promise<typeof import('ws')> | undefined;
const loadNodeWs = (): Promise<typeof import('ws')> => (nodeWsLoad ??= import('ws'));
```

This matters beyond the TLA: `ws` must not load at module-eval time **at all**, because Cloudflare Workers exposes `process.versions.node`, so compat detects `NODE` there and an eval-time load would break every consumer importing the compat barrel. As a bonus, servers configured without a `websocket` handler now never pull `ws` in.

## `test.ts` exception

`packages/compat/test.ts` keeps its TLA — it loads `bun:test` / `@std/testing/bdd` / `node:test`, which have no synchronous equivalent. It drops out of consumer graphs via separate PRs. Every other `await import(` hit in the package is now inside a function body.

## Verification

- `grep -rn "await import(" packages/compat --include="*.ts"` — real hits only in `test.ts`; everything else is prose in comments or inside a function body.
- **getBuiltinModule availability** confirmed locally on all three targets, and every module compat needs (`fs`, `os`, `net`, `tls`, `buffer`, `dgram`, `path`, `readline`, `process`, `http`) loads through it: Deno 2.9.4 ✅, Node v26.5.1 ✅, Bun 1.3.14 ✅.
- **Deno** `deno test --allow-all --parallel packages/compat` — 32 passed / 1004 steps / 0 failed / 1 ignored.
- **Bun** `bun test packages/compat` — 793 pass / 13 skip / 0 fail.
- **Node** `node --import tsx --test 'packages/compat/**/*.test.ts'` — 756 pass / 10 skip / 0 fail.
- `deno bundle --platform=browser` succeeds for `mod.ts`, `cli/mod.ts`, `webserver/mod.ts` and `websocket/mod.ts`; the emitted bundle contains no top-level `await`.
- Sync paths sanity-checked on Deno, Bun and Node (`getRuntime`, `hostname`, `cpus`, `totalmem`, `makeTempFileSync` + `writeTextFileSync` + `readTextFileSync` round-trip, `path.join`/`resolve`).
- `ws` proven absent from module eval: importing `webserver/mod.ts` and constructing a `WebServer` on Node with `node_modules/ws` renamed away succeeds. The lazy load is proven working by a Node WebSocket echo round-trip against a live `WebServer`.
- `deno fmt` + `deno lint` clean; `deno check` clean; `deno publish --dry-run` clean (no slow types).

No public API, export, or function signature changed.


---

## Follow-up: real tests for the new branches (2nd commit)

The first commit landed with 62.5% patch coverage. The cause was structural, not laziness: every call site read `isBun || isNode ? loadBuiltin('node:fs') : undefined`, and coverage is measured on the Deno leg only — so one arm of each ternary was dead by construction. Ten files, twenty half-covered branches.

**The guard moved into the loader** rather than being repeated per call site:

```ts
export const loadBuiltin = (id: string, when: boolean = true): any =>
  when ? (globalThis as any).process?.getBuiltinModule?.(id) : undefined;

// call site — one unconditional line, no dead arm
const nodeFs: typeof import('node:fs') = loadBuiltin('node:fs', isBun || isNode);
```

The conditional now lives in one place and is unit-tested in both directions. The `isDeno || isBun || isNode` guards in `runtime.ts` and `cli/*` were pure duplication — a runtime without `process.getBuiltinModule` already yields `undefined` — so they're gone, which also drops three now-unused runtime-flag imports.

**New tests**

- **`_runtime-globals.test.ts`** pins `loadBuiltin`'s contract: resolves a built-in synchronously (not a promise), honours `when` in both directions, and returns `undefined` — never throws — for an unknown specifier, for a `process` without `getBuiltinModule` (Node < 22.3 shaped), and for no `process` at all (browser/workerd shaped). The stubs swap `globalThis.process` synchronously and restore the original property descriptor in a `finally`, so nothing leaks into sibling tests on Bun, which shares one process per file.
- **`mod.test.ts`** gains the invariant this PR exists to protect: *no compat module may use top-level await.* The scan strips comments and string literals, then walks a stack of open braces distinguishing function bodies from plain blocks — brace depth alone would have missed `if (isNode) { x = await import(…) }`, which is exactly the shape being removed here. The detector is pinned by its own positive and negative samples so it can't rot into a no-op, and `test.ts`'s exemption is asserted to still be warranted. Verified it genuinely fails by temporarily reintroducing the old TLA in `udp.ts`.
- **`WebServer.test.ts`** runs a live WebSocket echo round-trip twice against two servers. On Node the backend is the lazily-imported, memoized `ws`; the second round proves the memoized module is still usable rather than consumed or half-initialized by the first start.

**Result:** patch coverage 62.5% → **88.7%**, with **zero partial branches**. The remainder is Node-only server-start code the Deno coverage leg cannot reach (`_startNodeServer`, the `ws` attach) plus one `node:path` line in `path.ts`'s non-Deno branch. No threshold was touched and no `c8 ignore` / lint-ignore was added.

Suites after the change: Deno 34 files / 1020 steps, Bun 807 pass / 13 skip, Node 770 pass / 10 skip — all green; browser bundles still clean for all four entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
