### PR TITLE
fix(drivers): import compat via subpaths instead of the root barrel

### DIFF
--- a/packages/drivers/engines/maria/Engine.ts
+++ b/packages/drivers/engines/maria/Engine.ts
@@ -34,7 +34,7 @@
 /// <reference types="npm:@types/node@22" />
 import { type Connection, createConnection } from '$maria';
 import type { EventOptionKeys } from '@tundralibs/utils';
-import { validateTLS } from '@tundralibs/compat';
+import { validateTLS } from '@tundralibs/compat/common';
 import { MariaTranslator } from '@tundralibs/oql/translator';
 import { SQLEngine } from '../../SQLEngine.ts';
 import { EngineError, type EngineErrorCode } from '../../errors/mod.ts';

--- a/packages/drivers/engines/memcached/Engine.ts
+++ b/packages/drivers/engines/memcached/Engine.ts
@@ -33,11 +33,8 @@
  * ```
  */
 
-import {
-  connect,
-  type Connection,
-  type TLSOptions as CompatTLSOptions,
-} from '@tundralibs/compat';
+import type { TLSOptions as CompatTLSOptions } from '@tundralibs/compat/common';
+import { connect, type Connection } from '@tundralibs/compat/net';
 import type { EventOptionKeys } from '@tundralibs/utils';
 import { BaseEngine } from '../../BaseEngine.ts';
 import { EngineError } from '../../errors/mod.ts';

--- a/packages/drivers/engines/neon/_neonPgProxy.ts
+++ b/packages/drivers/engines/neon/_neonPgProxy.ts
@@ -24,7 +24,7 @@
  * @module
  */
 
-import { connect } from '@tundralibs/compat';
+import { connect } from '@tundralibs/compat/net';
 import { PgConnection } from '../postgres/PgConnection.ts';
 import { PgServerError } from '../postgres/PgServerError.ts';
 

--- a/packages/drivers/engines/postgres/Engine.ts
+++ b/packages/drivers/engines/postgres/Engine.ts
@@ -42,12 +42,8 @@
  * ```
  */
 
-import {
-  connect,
-  type Connection,
-  type TLSOptions,
-  upgradeTls,
-} from '@tundralibs/compat';
+import type { TLSOptions } from '@tundralibs/compat/common';
+import { connect, type Connection, upgradeTls } from '@tundralibs/compat/net';
 import type { EventOptionKeys } from '@tundralibs/utils';
 import { PostgresTranslator } from '@tundralibs/oql/translator';
 import { SQLEngine } from '../../SQLEngine.ts';

--- a/packages/drivers/engines/postgres/PgConnection.ts
+++ b/packages/drivers/engines/postgres/PgConnection.ts
@@ -8,7 +8,7 @@
  * @module
  */
 
-import type { Connection } from '@tundralibs/compat';
+import type { Connection } from '@tundralibs/compat/net';
 import { EngineError } from '../../errors/mod.ts';
 import { PgServerError } from './PgServerError.ts';
 import {

--- a/packages/drivers/engines/redis/Engine.ts
+++ b/packages/drivers/engines/redis/Engine.ts
@@ -29,10 +29,8 @@
  * ```
  */
 
-import {
-  connect,
-  type TLSOptions as CompatTLSOptions,
-} from '@tundralibs/compat';
+import type { TLSOptions as CompatTLSOptions } from '@tundralibs/compat/common';
+import { connect } from '@tundralibs/compat/net';
 import type { EventOptionKeys } from '@tundralibs/utils';
 import { BaseEngine } from '../../BaseEngine.ts';
 import { EngineError } from '../../errors/mod.ts';

--- a/packages/drivers/engines/redis/RedisConnection.ts
+++ b/packages/drivers/engines/redis/RedisConnection.ts
@@ -9,7 +9,7 @@
  * @module
  */
 
-import type { Connection } from '@tundralibs/compat';
+import type { Connection } from '@tundralibs/compat/net';
 import { EngineError } from '../../errors/mod.ts';
 import { encodeCommand, parseReply, type RespValue } from './resp.ts';
 

--- a/packages/drivers/engines/sqlite/adapter.ts
+++ b/packages/drivers/engines/sqlite/adapter.ts
@@ -13,8 +13,8 @@
  * @module
  */
 
-import { isBun, isDeno, isNode } from '@tundralibs/compat';
 import { pathExistsSync } from '@tundralibs/compat/file';
+import { isBun, isDeno, isNode } from '@tundralibs/compat/runtime';
 import { DriverError } from '../../errors/mod.ts';
 
 /** Uniform shape of a SQLite database handle across runtimes. */

--- a/packages/drivers/types/EngineSSLOptions.ts
+++ b/packages/drivers/types/EngineSSLOptions.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import type { TLSOptions } from '@tundralibs/compat';
+import type { TLSOptions } from '@tundralibs/compat/common';
 
 /**
  * SSL / TLS configuration for the connection.


### PR DESCRIPTION
## Why

The `@tundralibs/compat` **root barrel** re-exports `test.ts`, whose `bun:test` / `node:test` dynamic imports make Cloudflare Workers (wrangler/esbuild) builds of any consumer **hard-fail** unless the consumer adds an `alias` stub. Every `packages/drivers` module that reached for compat through the root barrel dragged the test harness into every downstream bundle.

This is the last step of the wave that already narrowed `utils`, `id`, `slogger` and `pact` (#195 / #192 / #191 / #194, all merged). Verified against current merged main: those four now bundle for browser with **zero** `bun:test` occurrences, but `@tundralibs/cacher` still showed **1** — because cacher → drivers (redis/memcached engines) → compat root barrel → `test.ts`. Narrowing drivers finishes the job for cacher and norm and shrinks every drivers consumer's bundle.

## What

All 9 non-test compat imports in `packages/drivers` now use precise subpaths. Symbol homes were read off `packages/compat/mod.ts`, not guessed:

| symbols | before | after |
| --- | --- | --- |
| `connect`, `Connection`, `upgradeTls` | `@tundralibs/compat` | `@tundralibs/compat/net` |
| `TLSOptions`, `validateTLS` | `@tundralibs/compat` | `@tundralibs/compat/common` |
| `isBun`, `isDeno`, `isNode` | `@tundralibs/compat` | `@tundralibs/compat/runtime` |

Files touched: `engines/redis/Engine.ts`, `engines/redis/RedisConnection.ts`, `engines/memcached/Engine.ts`, `engines/postgres/Engine.ts`, `engines/postgres/PgConnection.ts`, `engines/maria/Engine.ts`, `engines/sqlite/adapter.ts`, `engines/neon/_neonPgProxy.ts`, `types/EngineSSLOptions.ts`.

Type-only imports stay `import type`. Test files and the soak scripts keep the root barrel — they legitimately want `describe` / `it` / `listen`. **Zero API change**: internal import paths only, no exports added, removed, or renamed.

## The measurement

`deno bundle --platform=browser packages/cacher/mod.ts`:

| | before | after |
| --- | --- | --- |
| size | 331.14 KB (339,089 B) | **295.83 KB (302,928 B)** — −35.3 KB / −10.7% |
| modules | 189 | **166** |
| `bun:test` occurrences | 1 | **0** |
| `node:test` occurrences | 1 | **0** |

## Verification

- `deno task check:edge-safety` (packages/drivers) — **passes**, with an unchanged reachable-module count: neon 88, turso 88, d1 87 (identical to baseline, so nothing moved into or out of the edge runtime graph). `engines/neon/_neonPgProxy.ts` now names `compat/net` explicitly but remains test-only and out of every public barrel, exactly as before.
- `deno check` clean on `mod.ts`, `types/mod.ts`, all nine engine `mod.ts` entrypoints, `engines/neon/_neonPgProxy.ts`, plus downstream `packages/cacher/mod.ts` and `packages/norm/mod.ts`.
- `deno bundle --platform=browser` succeeds for `engines/{redis,memcached,neon,turso,d1,postgres}/mod.ts` (185.56 / 173.06 / 530.57 / 526.88 / 528.31 / 404.03 KB).
- `deno fmt` + `deno lint` clean on all 9 changed files.
- `deno test -A` (packages/drivers): **54 passed (911 steps), 5 ignored**, 4 failed — the 4 failures are `engines/{postgres,maria}/{Engine,Translator.live}.test.ts`, which need live Postgres/MariaDB env config and fail identically on unmodified `origin/main` (confirmed by re-running them on a stashed tree). Live Mongo/Redis suites skip locally for the same reason; CI has the services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)