### PR TITLE
chore: tidy changelogs and codify import/type-folder conventions

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -11,6 +11,7 @@ quietly breaking the pattern.
 - [File and folder naming](#file-and-folder-naming)
 - [Exported types live in a `types/` folder](#exported-types-live-in-a-types-folder)
 - [Custom errors live in an `errors/` folder](#custom-errors-live-in-an-errors-folder)
+- [Imports go through folder barrels](#imports-go-through-folder-barrels)
 - [Privacy prefixing](#privacy-prefixing)
 - [JSDoc: link custom types, declare throws](#jsdoc-link-custom-types-declare-throws)
 - [Module-level constants are `UPPER_SNAKE_CASE`](#module-level-constants-are-upper_snake_case)
@@ -131,6 +132,21 @@ export type { ClearOptions, HTTPMethod, ... } from './types/mod.ts';
 // don't re-export from implementation — duplicates the root mod.ts
 // and creates two import paths for the same type.
 ```
+
+### Large type surfaces may group into subfolders
+
+A package with many exported types MAY organise `types/` into
+subsystem subfolders (`types/application/`, `types/context/`, …).
+The EXPORTED IDENTIFIER spells the full namespace chain — package
+prefix + subfolder + file — while the FILE NAME is just the leaf:
+`types/application/Events.ts` exports `RapidApplicationEvents`;
+`types/Middleware.ts` (the root implies the package prefix) exports
+`RapidMiddleware`. Never a bare `Events` or `Middleware` — generic
+names collide across packages; the identifier must stand alone at
+any import site. `types/mod.ts` remains the single barrel over all
+of it — subfolders get no `mod.ts` of their own. Internal-only
+types never move here at all — they stay in the file that uses them
+(see below).
 
 ### Internal types stay where they're used
 
@@ -265,6 +281,33 @@ assertion failure during setup) can keep raw `throw new Error(...)`
 without breaking the rules. The `errors/` folder appears the
 moment you have a second distinct failure mode you'd want callers
 to branch on.
+
+## Imports go through folder barrels
+
+Every project folder in a package — including internal-only ones
+like `utils/` or `transports/` — carries a `mod.ts` barrel, and
+imports follow three rules:
+
+- **Cross-folder imports go through the barrel.** A file in
+  `context/` importing a parser writes
+  `from '../utils/mod.ts'`, never `from '../utils/parseBody.ts'`.
+  The folder's surface is its barrel; reaching around it couples
+  callers to the folder's internal layout.
+- **Same-folder siblings import directly** (`from './Context.ts'`).
+  Routing a sibling import through the folder's own barrel creates a
+  self-cycle for nothing.
+- **One import statement per module.** Merge value and type imports:
+  `import { WebServer, type WebSocketHandler } from '…'` — never two
+  `import` lines with the same specifier.
+
+Test files are the exception to the first rule: a test imports its
+paired file directly (`parseBody.test.ts` → `./parseBody.ts`), same
+as it sits next to it.
+
+Cycle care: when a barrel re-exports a runtime module that imports
+back across folders (the middleware runner importing the context
+base, say), keep that back-edge `import type` — a type-only import
+erases at compile time and cannot create a runtime cycle.
 
 ## Privacy prefixing
 

--- a/packages/ambient/CHANGELOG.md
+++ b/packages/ambient/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 * **ambient:** build the shared store on first use, not at import ([f81ca54](https://github.com/TundraSoft/TundraLibs/commit/f81ca547d77e1b8cd9162ce6f09673e85c8b6335))
 * **ambient:** load AsyncLocalStorage without a static node:async_hooks import ([a9ea905](https://github.com/TundraSoft/TundraLibs/commit/a9ea905c7a746da0acce6f4d9712856de6917613))
-* **ambient:** load AsyncLocalStorage without a static node:async_hooks import ([5f645f0](https://github.com/TundraSoft/TundraLibs/commit/5f645f06d23cd31b5051d8856c33b4f677cbc64b))
 
 ## [0.2.2](https://github.com/TundraSoft/TundraLibs/compare/ambient-v0.2.1...ambient-v0.2.2) (2026-08-09)
 
@@ -15,7 +14,6 @@
 ### Documentation
 
 * **ambient:** adopt tracer.logContext in the integration guide ([dd076f2](https://github.com/TundraSoft/TundraLibs/commit/dd076f21640bb2c2ea1d5b728a34eeca47553d40))
-* **ambient:** adopt tracer.logContext in the integration guide ([9dd620c](https://github.com/TundraSoft/TundraLibs/commit/9dd620ca8101d5c2d8eb59e7c6ece58a92e04f3a))
 
 ## [0.2.1](https://github.com/TundraSoft/TundraLibs/compare/ambient-v0.2.0...ambient-v0.2.1) (2026-08-09)
 

--- a/packages/cacher/CHANGELOG.md
+++ b/packages/cacher/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/cacher-v1.0.0-dev11...cacher-v1.0.0) (2026-08-01)
 
@@ -21,7 +20,6 @@
 ### Documentation
 
 * **cacher:** correct thrown error/code in engines documentation ([0c8b2b2](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0c8b2b23f71bd5697e69e6e1b67dde248b888356))
-* **cacher:** correct thrown error/code in engines documentation ([e6b1990](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e6b1990f2cc430e024471e80470c3b5d20705888))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/cacher-v1.0.0-dev9...cacher-v1.0.0-dev10) (2026-07-27)
 
@@ -37,11 +35,8 @@
 ### Bug Fixes
 
 * **cacher:** resolve round-3 review findings ([71fb882](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/71fb882d4a7e9389a24a133b17bc8d6f693a0eaf))
-* **cacher:** resolve round-3 review findings ([d1e5985](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d1e59855dc9b7f7f547570673dae2eab60738ee3))
 * **cacher:** resolve round-4 review findings ([8b0462a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8b0462a88fed47701ca5d170c24e8f6d8a6f4644))
-* **cacher:** resolve round-4 review findings ([a30c4a5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a30c4a5f707417b27db4031437dc4cebdab454e1))
 * **cacher:** resolve round-5 review findings ([3b3133b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3b3133b1053bfbb9e3a5477c129059916821ca91))
-* **cacher:** resolve round-5 review findings ([a4304ff](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a4304ff80ba1ea23fe1e2847721441a035efcde8))
 
 ## [1.0.0-dev8](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/cacher-v1.0.0-dev7...cacher-v1.0.0-dev8) (2026-07-23)
 
@@ -51,7 +46,6 @@
 * **cacher:** close re-review findings — namespace-scoped clear, exptime-0, Value split ([dc51abe](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/dc51abe0e65d224a6a71ab36971f83b37fc1a723))
 * **cacher:** namespace-scoped Memcached clear, permanent expiry=0, Value type split ([edc57e0](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/edc57e0ee0c155099ce68e8635491d7aa5c52e4e))
 * **cacher:** resolve 8 review findings (password leak, has/get mismatch, expiry footgun) ([3f9959d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3f9959dabb79a908fad71ab2a82a439ff2725ed4))
-* **cacher:** resolve 8 review findings (password leak, has/get mismatch, expiry footgun) ([496b188](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/496b188670ae368b6c4b5106ba2f06c0c66c478a))
 
 
 ### Documentation

--- a/packages/compat/CHANGELOG.md
+++ b/packages/compat/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **compat:** load node builtins synchronously instead of via top-level await ([1e48583](https://github.com/TundraSoft/TundraLibs/commit/1e48583cb314d24c503535b09fc8d524be67347a))
-* **compat:** load node builtins synchronously instead of via top-level await ([6d0cdef](https://github.com/TundraSoft/TundraLibs/commit/6d0cdef0d2b4171014b1f3e9583dd6ccb8799757))
 
 ## [1.1.1](https://github.com/TundraSoft/TundraLibs/compare/compat-v1.1.0...compat-v1.1.1) (2026-08-12)
 
@@ -21,7 +20,6 @@
 ### Features
 
 * **compat:** report the actual bound port on WebServer ([3507c3d](https://github.com/TundraSoft/TundraLibs/commit/3507c3d9391ac8ec4e379ebad69e011ee880ce7f))
-* **compat:** report the actual bound port on WebServer ([1cc2c88](https://github.com/TundraSoft/TundraLibs/commit/1cc2c8838ccea6c935e712951678a084c81882fa))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/compat-v1.0.0-dev10...compat-v1.0.0) (2026-08-01)
 
@@ -36,7 +34,6 @@
 ### Bug Fixes
 
 * **compat:** value-export WebServer from root barrel; fix broken doc examples ([541dd62](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/541dd620394875b0a61535191b268d1565bb339a))
-* **compat:** value-export WebServer from root barrel; fix broken doc examples ([be8a57a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/be8a57aa6e61096da1ad7bdf1073de6346f42460))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/compat-v1.0.0-dev8...compat-v1.0.0-dev9) (2026-07-25)
 
@@ -45,7 +42,6 @@
 
 * **compat:** correct malformed-Host docs to match per-runtime behavior ([2815119](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/281511946de681887a602940c1542744f4622540))
 * **compat:** resolve round-3 review findings ([7e7da05](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7e7da05b64eb24e7172e957c7185578e3fce6684))
-* **compat:** resolve round-3 review findings ([3fccee6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3fccee66ccfcec55194fb87566ebc08b904c9302))
 * **compat:** resolve round-4 review findings ([ae7c2c9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/ae7c2c929822632ce816a4ecc788201c9267fcd4))
 
 ## [1.0.0-dev8](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/compat-v1.0.0-dev7...compat-v1.0.0-dev8) (2026-07-23)
@@ -56,7 +52,6 @@
 * **compat:** close re-review findings — doc drift, write byte count, WS avg metric, abort cleanup, Deno TLS parity ([1340300](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/13403006e629bc8ce6458f471d0962c59a181999))
 * **compat:** close re-review findings (doc drift, write byte count, WS metric, abort cleanup, Deno TLS parity) ([1927f9f](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1927f9fc0b8c2def6097d62fa76c9543550a8046))
 * **compat:** resolve 11 review findings (socket crash, silent failures, cross-runtime divergences) ([994443d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/994443d84c4ee0a10cc3c0a332d2d794e8633341))
-* **compat:** resolve 11 review findings (socket crash, silent failures, cross-runtime divergences) ([89695c5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/89695c5e42c347c05dd70e17b6440ff48459e46b))
 
 
 ### Documentation

--- a/packages/cronus/CHANGELOG.md
+++ b/packages/cronus/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## 1.0.0 (2026-08-12)
 
@@ -14,7 +13,6 @@
 ### Features
 
 * **cronus:** cross-runtime minute-resolution cron scheduler ([d9226c6](https://github.com/TundraSoft/TundraLibs/commit/d9226c65fe1ef91acf09efd862502dd15b21f6c5))
-* **cronus:** cross-runtime minute-resolution cron scheduler ([d84bd4b](https://github.com/TundraSoft/TundraLibs/commit/d84bd4b99fdfb3fe805c2b10c96a369e31705625))
 
 
 ### Bug Fixes

--- a/packages/crypt/CHANGELOG.md
+++ b/packages/crypt/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 * **crypt:** bound the label length in PEM_ARMOUR too ([3e94ad9](https://github.com/TundraSoft/TundraLibs/commit/3e94ad9d0b595bf7ffd74730d866d44718b42e30))
 * **crypt:** remove polynomial-ReDoS backtracking from PEM parsing ([541a405](https://github.com/TundraSoft/TundraLibs/commit/541a405e5bf70b7318015ec9d4497b0ab0099105))
-* **crypt:** remove polynomial-ReDoS backtracking from PEM parsing ([7b38afc](https://github.com/TundraSoft/TundraLibs/commit/7b38afc30ec4fe3d676c223012c07a087615e36d))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/crypt-v1.0.0-dev12...crypt-v1.0.0) (2026-08-01)
 
@@ -22,7 +21,6 @@
 ### Documentation
 
 * **crypt:** fix non-exported import example + AES MAC description ([8791da5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8791da5c3d679fb9b7ad1417559551cf49051974))
-* **crypt:** fix non-exported import example + AES MAC description ([1a1c0c3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1a1c0c3a50ab5c4b2934cf385d73e71d9c80f213))
 
 ## [1.0.0-dev11](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/crypt-v1.0.0-dev10...crypt-v1.0.0-dev11) (2026-07-27)
 
@@ -30,7 +28,6 @@
 ### Bug Fixes
 
 * **crypt:** pbkdf2Verify returns false on malformed hash instead of throwing ([efcc1cd](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/efcc1cd4f9ce7e31058992b8545c70bc72152040))
-* **crypt:** pbkdf2Verify returns false on malformed hash instead of throwing ([0ce690f](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0ce690f4c957f01d2cf45957df1e09205b08fc44))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/crypt-v1.0.0-dev9...crypt-v1.0.0-dev10) (2026-07-25)
 
@@ -38,11 +35,8 @@
 ### Bug Fixes
 
 * **crypt:** resolve round-3 review findings ([2e027a4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2e027a47e5a5954b124c436034131ca7162877e6))
-* **crypt:** resolve round-3 review findings ([ba17be3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/ba17be32e756d493b971ff7aca0c36b59b79c605))
 * **crypt:** resolve round-4 review findings ([41189c6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/41189c65f4ab9b505d9cc09d9befbec4d726ecf2))
-* **crypt:** resolve round-4 review findings ([db67fd9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/db67fd9edf54005cd3cbd6faf094577ceccdbaa4))
 * **crypt:** resolve round-6 review findings ([1b4b7f7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1b4b7f7844dd7123267b5d6a7f2fd2fb4890fc0e))
-* **crypt:** resolve round-6 review findings ([2497bee](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2497beeddfd649e7810da18c6385dc847ee1c92e))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/crypt-v1.0.0-dev8...crypt-v1.0.0-dev9) (2026-07-23)
 
@@ -50,17 +44,13 @@
 ### Features
 
 * **crypt:** accept RFC 9068 typ values in verifyJWT ([9df39a3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/9df39a380609ddf1f77596e008e637a37e498904))
-* **crypt:** accept RFC 9068 typ values in verifyJWT ([aea29f2](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/aea29f2b43fee0069919b91abad5f86a776ce8e1))
 * **crypt:** add ECDSA (ES256/384/512) and accept CryptoKey/JWK keys ([fdf5aa2](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fdf5aa2450c4d4bce43d387e43de20f37e067013))
-* **crypt:** add ECDSA (ES256/384/512) and accept CryptoKey/JWK keys ([569d092](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/569d092134551eb06754f54c6e774f6ef25f269a))
 
 
 ### Bug Fixes
 
 * **crypt:** close re-review findings — BIP39 NFKD normalization, doc drift ([174f9d0](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/174f9d0ecc1a250d24040fe994c7b6c6d0c9754b))
-* **crypt:** close re-review findings — BIP39 NFKD normalization, doc drift ([6f81226](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/6f812268931f3502d01a950efc5fedce12b29a80))
 * **crypt:** close review findings — honest RSA sizing, OTP SHA-1 defaults, PS* refresh, 12-byte GCM nonce ([b457c8f](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b457c8fbca02cdb4304c1f73ea560a4dff9c675a))
-* **crypt:** close review findings — honest RSA sizing, OTP SHA-1 defaults, PS* refresh, 12-byte GCM nonce ([f6f5ef9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/f6f5ef9c4232c569d75cc1a81129da03a44805d6))
 * **crypt:** treat JWT typ as optional per RFC 7519 §5.1 ([4272b62](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4272b62af629e0acddea0f3978d7bf3c44333a6c))
 
 

--- a/packages/doctor/CHANGELOG.md
+++ b/packages/doctor/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/doctor-v1.0.0-dev6...doctor-v1.0.0) (2026-08-01)
 
@@ -21,7 +20,6 @@
 ### Documentation
 
 * **doctor:** document CircularDependencyError in the errors reference ([d3538d1](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d3538d175602d81cb748648121887d7eaa13aca5))
-* **doctor:** document CircularDependencyError in the errors reference ([5610c94](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5610c945a43f36fa5f0c964348f2b1e4f71f4321))
 
 ## [1.0.0-dev5](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/doctor-v1.0.0-dev4...doctor-v1.0.0-dev5) (2026-07-25)
 
@@ -29,13 +27,9 @@
 ### Bug Fixes
 
 * **doctor:** narrow factory scope-fallback to the returned instance ([74910d6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/74910d61fd7f04e830c91b3afa9de0fd3a243cda))
-* **doctor:** narrow factory scope-fallback to the returned instance ([11878f3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/11878f336cc2d1356b37ddcb686dda7a79a18a3f))
 * **doctor:** resolve round-3 review findings ([b1c31f6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b1c31f62944b162c014d1c033ec49c991acf6d7b))
-* **doctor:** resolve round-3 review findings ([98404eb](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/98404eb2f2137418515f715fd23475689611f960))
 * **doctor:** resolve round-4 review findings ([b07d1cc](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b07d1cc903ab1be139fa572a154dd9e42ef927aa))
-* **doctor:** resolve round-4 review findings ([a2aa0d6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a2aa0d6f0adf2c7abe0b3c26862c7dfbdc0249a5))
 * **doctor:** resolve round-5 review findings ([fcb4cd3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fcb4cd3bca1fc502b037daaba236273fd773eb12))
-* **doctor:** resolve round-5 review findings ([de8ec04](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/de8ec04ff92bd3fb5205f63c331b26d4a9f174b4))
 * **doctor:** resolve round-6 review findings ([5991450](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5991450d963033370f391d9a0d158eec4990a0d0))
 * **doctor:** treat a factory-returned @Inoculate'd instance exactly once ([252ee25](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/252ee250eaf50c5b660314c75e90f28fb1d7b902))
 
@@ -50,9 +44,7 @@
 ### Bug Fixes
 
 * **doctor:** close re-review findings — unwrap @Inoculate in dispense/knows ([2236c7b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2236c7b003ac131211c5b6b8d6fbda3f98a76e14))
-* **doctor:** close re-review findings — unwrap @Inoculate in dispense/knows ([096e2e1](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/096e2e1b288ad9c4bffe37c27be90cbb9790ee27))
 * **doctor:** close review findings — treat-failure eviction, wrapper parity, scanner hardening ([c09d95b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c09d95ba8dbd09a82995a2f971d07e7e13b64bc3))
-* **doctor:** close review findings — treat-failure eviction, wrapper parity, scanner hardening ([5e07a0c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5e07a0c9964c6042c4348daab842ac190288307d))
 
 ## [1.0.0-dev3](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/doctor-v1.0.0-dev2...doctor-v1.0.0-dev3) (2026-07-14)
 

--- a/packages/drivers/CHANGELOG.md
+++ b/packages/drivers/CHANGELOG.md
@@ -6,11 +6,7 @@
 ### Bug Fixes
 
 * **drivers:** import compat via subpaths instead of the root barrel ([c6d66b0](https://github.com/TundraSoft/TundraLibs/commit/c6d66b0a70b6cff7ff9c7d7d2d9259ea10911421))
-* **drivers:** import compat via subpaths instead of the root barrel ([3fa601f](https://github.com/TundraSoft/TundraLibs/commit/3fa601fdf4573feeb43a9a636fd8b91ec7aa9f97))
 * **drivers:** stop redis/memcached engines importing the root barrel ([7066d91](https://github.com/TundraSoft/TundraLibs/commit/7066d914e9c3aad374a603e2b1c013dd1a48dcb9))
-* **drivers:** stop redis/memcached engines importing the root barrel ([e7ee7da](https://github.com/TundraSoft/TundraLibs/commit/e7ee7da72bfcc072e9fe55397fbab873bfdff7df))
-* **id:** republish as 1.0.3 ([5de296b](https://github.com/TundraSoft/TundraLibs/commit/5de296b9ae28eaf1786a1397f0262f940395b02a))
-* **id:** republish as 1.0.3 ([b9de287](https://github.com/TundraSoft/TundraLibs/commit/b9de28704db3e488c41892898c3a9a38e044a1fc))
 
 ## [1.0.2](https://github.com/TundraSoft/TundraLibs/compare/drivers-v1.0.1...drivers-v1.0.2) (2026-08-12)
 
@@ -18,7 +14,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.0.1](https://github.com/TundraSoft/TundraLibs/compare/drivers-v1.0.0...drivers-v1.0.1) (2026-08-09)
 
@@ -26,7 +21,6 @@
 ### Documentation
 
 * **drivers:** document the event seam for tracing and metrics ([15016dd](https://github.com/TundraSoft/TundraLibs/commit/15016dd4752510634c6b2a289288cabf8f43ac8c))
-* **drivers:** document the event seam for tracing and metrics ([23e601e](https://github.com/TundraSoft/TundraLibs/commit/23e601ea3a32fe2989ec3135b69363f67cdc8838))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/drivers-v1.0.0-dev11...drivers-v1.0.0) (2026-08-01)
 
@@ -41,7 +35,6 @@
 ### Documentation
 
 * **drivers:** fix error-handling examples to use the real engine API ([66168de](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/66168de8a89e4c81ecc9a883edde740416eee255))
-* **drivers:** fix error-handling examples to use the real engine API ([68566bd](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/68566bd2d0612421003e448e89e15023d6dbe5e7))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/drivers-v1.0.0-dev9...drivers-v1.0.0-dev10) (2026-07-27)
 
@@ -49,7 +42,6 @@
 ### Bug Fixes
 
 * **drivers:** skip backtick and [bracket] identifiers in Bun placeholder rewrite ([98d88e5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/98d88e5e9af5bb04c1284dd907b2e857f60c6e78))
-* **drivers:** skip backtick and [bracket] identifiers in Bun placeholder rewrite ([a90eae2](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a90eae27317aeee926a08382adb99477d22989e8))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/drivers-v1.0.0-dev8...drivers-v1.0.0-dev9) (2026-07-25)
 
@@ -57,9 +49,7 @@
 ### Bug Fixes
 
 * **drivers:** resolve round-3 review findings ([9e95777](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/9e9577734633a7780ce2ff9fadd28a829fe4fe25))
-* **drivers:** resolve round-3 review findings ([d06cccf](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d06cccfac93877d308854c961e483ec4b3e59529))
 * **drivers:** resolve round-4 review findings ([24ba320](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/24ba320e5bdbe187950d7dd89fc48ca3cce7eb0e))
-* **drivers:** resolve round-4 review findings ([1826571](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1826571e51117de948559838088491a79465e01f))
 
 ## [1.0.0-dev8](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/drivers-v1.0.0-dev7...drivers-v1.0.0-dev8) (2026-07-23)
 
@@ -67,11 +57,9 @@
 ### Bug Fixes
 
 * **drivers:** close re-review findings — tx-timeout busy guard, SCRAM mutual-auth, memcached ttl=0 ([0f46673](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0f466732ab2440fd2f6cf08a38ba4b635bc9d469))
-* **drivers:** close re-review findings — tx-timeout busy guard, SCRAM mutual-auth, memcached ttl=0 ([c234aba](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c234aba624f5c0fa9cc5c4cc1e01a5e270bb2083))
 * **drivers:** close review findings — idle-eviction min floor, CAS injection, MULTI connection health ([71cdcfc](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/71cdcfc3a0e6cbe0ce19dfb82de623add0ed6ce5))
 * **drivers:** close review findings — idle-eviction min floor, CAS injection, MULTI health ([4ae407c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4ae407c3d132bd653e39cac8c363471781fdb4ef))
 * **drivers:** preserve RESP 64-bit integer precision; SASLprep SCRAM passwords ([2d2e0e9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2d2e0e9ebb23429ddb46456722c7a14e97e5002e))
-* **drivers:** preserve RESP 64-bit integer precision; SASLprep SCRAM passwords ([381c21d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/381c21d372e6ec35ac7ee1381a5a7790d7d55447))
 
 
 ### Documentation

--- a/packages/guardian/CHANGELOG.md
+++ b/packages/guardian/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Documentation
 
 * **guardian:** fix object default-mode and nullable-fallback examples ([c5e0cb7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c5e0cb7a109a102f767cb4541cf390df4dc4c93e))
-* **guardian:** fix object default-mode and nullable-fallback examples ([25e0031](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/25e00318f7847052f54da7cf033304a42b78c6ff))
 
 ## [1.0.0-dev11](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/guardian-v1.0.0-dev10...guardian-v1.0.0-dev11) (2026-07-28)
 
@@ -21,7 +20,6 @@
 ### Documentation
 
 * **guardian:** fix object default-mode and nullable-fallback examples ([c5e0cb7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c5e0cb7a109a102f767cb4541cf390df4dc4c93e))
-* **guardian:** fix object default-mode and nullable-fallback examples ([25e0031](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/25e00318f7847052f54da7cf033304a42b78c6ff))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/guardian-v1.0.0-dev9...guardian-v1.0.0-dev10) (2026-07-27)
 
@@ -29,7 +27,6 @@
 ### Bug Fixes
 
 * **guardian:** optional() function-default routes on callability, not 'then' presence ([d70da7c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d70da7c59521feea794b94d417132c652cb9fdf4))
-* **guardian:** optional() function-default routes on callability, not 'then' presence ([45ca7ab](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/45ca7ab1011109b1690f8409889e321efb924e60))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/guardian-v1.0.0-dev8...guardian-v1.0.0-dev9) (2026-07-25)
 
@@ -37,12 +34,9 @@
 ### Bug Fixes
 
 * **guardian:** eliminate thenable-adoption idiom across all guards ([e4fe4a1](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e4fe4a19beb6d167307fa63d66a15b2bb5415bac))
-* **guardian:** eliminate thenable-adoption idiom across all guards ([1f268bb](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1f268bb26c76219496ef35389bf081668d9c52c3))
 * **guardian:** refuse thenable-shaped values on async parseAsync chains ([2aa23e3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2aa23e327ee1f2480f989420f161938e9afe074d))
 * **guardian:** resolve round-3 review findings ([1a75cc7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1a75cc7e5360e8fc3cb3832064a6860c8bc9a8c4))
-* **guardian:** resolve round-3 review findings ([560b295](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/560b295e9d9918cf6efab83cab663a0c44f33df0))
 * **guardian:** resolve round-4 review findings ([bd0d024](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/bd0d02476778d48bd1345696f1a55cc1411784d7))
-* **guardian:** resolve round-4 review findings ([d8f9a21](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d8f9a21f6dbb2fcc8b04fa55a702ca003ddb9516))
 * **guardian:** resolve round-5 review findings ([5d10b00](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5d10b00a482c98d8519ceff0c3c8151cb7accd82))
 * **guardian:** resolve round-6 review findings ([75bcb8c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/75bcb8c76b3a88a42bfb3e092b1a7d9fb55b8180))
 
@@ -52,7 +46,6 @@
 ### Bug Fixes
 
 * **guardian:** close re-review findings — nested async bypass, error secret leak, sync promise defaults, noSqlInjection ([2a4399a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2a4399a9c754934f56680ca470b8899d84fda23d))
-* **guardian:** close re-review findings — nested async bypass, error secret leak, sync promise defaults, noSqlInjection ([abc4e62](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/abc4e62c59926c406bb8355d267ac531653c72c7))
 * **guardian:** close review findings — async .test(), renameField, no-op transforms, errors/ move ([c64b009](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c64b009d1d0439e5b64293866fbd8eed98fb3e9f))
 * **guardian:** Date transforms emit a schema matching their output type ([dd98a74](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/dd98a74c77b2885ec823b842b77265ef577643ab))
 * **guardian:** DiscriminatedUnion _cloneWith carries the custom errorMessage ([4e0bf53](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4e0bf53a69d752dea5fdaff9f1c1d6c07c3da637))

--- a/packages/id/CHANGELOG.md
+++ b/packages/id/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **id:** republish as 1.0.3 ([5de296b](https://github.com/TundraSoft/TundraLibs/commit/5de296b9ae28eaf1786a1397f0262f940395b02a))
-* **id:** republish as 1.0.3 ([b9de287](https://github.com/TundraSoft/TundraLibs/commit/b9de28704db3e488c41892898c3a9a38e044a1fc))
 
 ## [1.0.2](https://github.com/TundraSoft/TundraLibs/compare/id-v1.0.1...id-v1.0.2) (2026-08-13)
 
@@ -14,7 +13,6 @@
 ### Bug Fixes
 
 * **id:** import compat via subpaths instead of the root barrel ([7e87260](https://github.com/TundraSoft/TundraLibs/commit/7e87260acaf90cb3b4b9352f03abf5ab21b31167))
-* **id:** import compat via subpaths instead of the root barrel ([51223ab](https://github.com/TundraSoft/TundraLibs/commit/51223ab07494d645c9c547aaef61b3f62b903809))
 
 ## [1.0.1](https://github.com/TundraSoft/TundraLibs/compare/id-v1.0.0...id-v1.0.1) (2026-08-12)
 
@@ -22,7 +20,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/id-v1.0.0-dev12...id-v1.0.0) (2026-08-01)
 
@@ -37,7 +34,6 @@
 ### Documentation
 
 * **id:** correct simpleID daily counter reset behavior (resets to 0, not seed) ([23ca48f](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/23ca48fbcbe41c7ee3800c2d1d47cee42f419eac))
-* **id:** correct simpleID daily counter reset behavior (resets to 0, not seed) ([e7c5b58](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e7c5b58798b681a49dcb0fc92ace3637264e6da8))
 
 ## [1.0.0-dev11](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/id-v1.0.0-dev10...id-v1.0.0-dev11) (2026-07-28)
 
@@ -45,7 +41,6 @@
 ### Documentation
 
 * **id:** correct nanoID alphabet + sequenceID counter documentation ([0b54804](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0b54804c62474bbb758de4f1887994c080b3162d))
-* **id:** correct nanoID alphabet + sequenceID counter documentation ([4b2c9a9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4b2c9a90c8fc7707204ece3e83f8dfe050de6036))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/id-v1.0.0-dev9...id-v1.0.0-dev10) (2026-07-27)
 
@@ -53,7 +48,6 @@
 ### Documentation
 
 * **id:** correct cuid timestamp-overflow year comment (2059, not ~4503) ([6f86c1d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/6f86c1d2c8b6126c3ac68a1f27cdd9cbf8b922f4))
-* **id:** correct cuid timestamp-overflow year comment (2059, not ~4503) ([ffa5e4c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/ffa5e4c674b5b4fdf49aeed882c5f7a61aceebf1))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/id-v1.0.0-dev8...id-v1.0.0-dev9) (2026-07-25)
 
@@ -62,12 +56,8 @@
 
 * **id:** add round-3 regression tests and doc updates ([109bb05](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/109bb05fe9f4c846fa7e0841a5f7b18697023411))
 * **id:** resolve round-3 review findings ([a330907](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a330907f47dbbbb86a04a11ffa2b90921db96556))
-* **id:** resolve round-3 review findings ([825cf78](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/825cf78dd1293734f4bbd924f883533337b3a767))
-* **id:** resolve round-3 review findings ([f04bfba](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/f04bfba942bc37469b97bab8a485127b0329aa6e))
 * **id:** resolve round-4 review findings ([4c40cf4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4c40cf48c465d7c0844083fa3ef52829e6d46416))
-* **id:** resolve round-4 review findings ([2fa1e48](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2fa1e48ff391e16f00c31881e6cf931c9ee60352))
 * **id:** resolve round-5 review findings ([ab82456](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/ab824564d067093cdc1bafb3fc82928651c16d37))
-* **id:** resolve round-5 review findings ([a8369cb](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a8369cb0c1876f28882daed773170e192e46a06d))
 
 ## [1.0.0-dev8](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/id-v1.0.0-dev7...id-v1.0.0-dev8) (2026-07-23)
 
@@ -77,7 +67,6 @@
 * **id:** close re-review findings — errors/ folder, width-bounded ObjectID timestamp, cheaper simpleID, doc drift ([229eb3b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/229eb3be0644b5e32087868c0a20a1faa4b82245))
 * **id:** close re-review findings (errors/ folder, ObjectID timestamp width, simpleID perf, doc drift) ([765d092](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/765d0921afa0b9557d21b0565c024946c583882d))
 * **id:** resolve 10 review findings (ObjectID overflow, doc drift, fake-coverage tests) ([da3ae13](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/da3ae135a724420584cf9752223f3b6cd41789f5))
-* **id:** resolve 10 review findings (ObjectID overflow, doc drift, fake-coverage tests) ([8988890](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/89888907572f2dec67ff906961a2de24dbf240fc))
 
 
 ### Documentation

--- a/packages/metro-man/CHANGELOG.md
+++ b/packages/metro-man/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.0.1](https://github.com/TundraSoft/TundraLibs/compare/metro-man-v1.0.0...metro-man-v1.0.1) (2026-08-09)
 
@@ -14,7 +13,6 @@
 ### Documentation
 
 * **metro-man:** cross-link the sibling observability pillars ([2ded4b1](https://github.com/TundraSoft/TundraLibs/commit/2ded4b1148c221ef33b199e0e462dfff3785a5fd))
-* **metro-man:** cross-link the sibling observability pillars ([9099fe1](https://github.com/TundraSoft/TundraLibs/commit/9099fe1797e27c25cce021654b15cdcdaee83196))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/metro-man-v1.0.0-dev7...metro-man-v1.0.0) (2026-08-01)
 
@@ -29,7 +27,6 @@
 ### Bug Fixes
 
 * **metro-man:** de-duplicate histogram buckets / summary quantiles ([67d9000](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/67d9000894cfcc09e8a56c34de48e5741bc556c6))
-* **metro-man:** de-duplicate histogram buckets / summary quantiles ([7886d25](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7886d253147df3b9f14899261abd9db451aca5e7))
 
 ## [1.0.0-dev6](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/metro-man-v1.0.0-dev5...metro-man-v1.0.0-dev6) (2026-07-27)
 
@@ -37,13 +34,11 @@
 ### Bug Fixes
 
 * **metro-man:** de-duplicate collect() selection list so families aren't emitted twice ([de57c54](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/de57c54475d342d62afd9163711f4dcf6ad89e43))
-* **metro-man:** de-duplicate collect() selection list so families aren't emitted twice ([c0e0630](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c0e0630883894f29523c8c11043192610706ad68))
 
 
 ### Documentation
 
 * **metro-man:** note collect() de-duplicates a repeated selection name ([2fc3c62](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2fc3c620089e51e288eaced6b4dc1c4e227118af))
-* **metro-man:** note collect() de-duplicates a repeated selection name ([c54ecef](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c54ecefa7c17841ed3bdcee925e31b26d7c15091))
 
 ## [1.0.0-dev5](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/metro-man-v1.0.0-dev4...metro-man-v1.0.0-dev5) (2026-07-25)
 
@@ -51,10 +46,8 @@
 ### Bug Fixes
 
 * **metro-man:** resolve round-3 review findings ([53c7e3d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/53c7e3dbae699c15db4dd7942e7a2904697f6e6f))
-* **metro-man:** resolve round-3 review findings ([b3e7974](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b3e7974bb9f3b8b64172fdeb140d7d78633ec271))
 * **metro-man:** resolve round-4 review findings ([d5295f8](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d5295f882a6d0474c2076e3c26577b7e5b83b508))
 * **metro-man:** resolve round-5 review findings ([023edbd](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/023edbde2b021b35c0cb90e917f3617f89264be0))
-* **metro-man:** resolve round-5 review findings ([98f8845](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/98f884586c0a39a369efbdbafc4b48a682fbe6b3))
 * **metro-man:** terminate Prometheus exposition with a trailing line feed ([448a109](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/448a1099f352aec6e2e2d1d379e967aa8fc54923))
 
 
@@ -69,9 +62,7 @@
 
 * **metro-man:** close re-review findings — reject non-finite Summary window ([a8ad297](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a8ad29788220a0352a70a8135a60cedf0078f09f))
 * **metro-man:** close review findings — validation, bounded retention, ordering ([1c3c82a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1c3c82a77b57869689743ec547a48ab8f2341bb8))
-* **metro-man:** close review findings — validation, bounded retention, ordering ([39097e8](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/39097e8269247288b8186b3501655f237c771a1c))
 * **metro-man:** make Summary _sum/_count cumulative (Prometheus semantics) ([e176a1b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e176a1bda80a8ba52bb51e853cf35db08abbf9ae))
-* **metro-man:** make Summary _sum/_count cumulative (Prometheus semantics) ([fbea47a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fbea47ac8f353deeb7364ee2efefbf2cf3fc66ef))
 * **metro-man:** reject non-finite Summary window and Histogram buckets ([2592c89](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2592c895c6cc002d28ab254b54e1c5d5b8b86cb7))
 
 ## [1.0.0-dev3](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/metro-man-v1.0.0-dev2...metro-man-v1.0.0-dev3) (2026-07-14)

--- a/packages/norm/CHANGELOG.md
+++ b/packages/norm/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.1.1](https://github.com/TundraSoft/TundraLibs/compare/norm-v1.1.0...norm-v1.1.1) (2026-08-09)
 
@@ -14,7 +13,6 @@
 ### Documentation
 
 * **norm:** adopt tracer.wrap in the witness example ([6cc6ced](https://github.com/TundraSoft/TundraLibs/commit/6cc6ced985bdacb6046dae6ea5144bff307b25cb))
-* **norm:** adopt tracer.wrap in the witness example ([a5cf376](https://github.com/TundraSoft/TundraLibs/commit/a5cf376d870ec65e660aa1f4f1cebe17562657ee))
 
 ## [1.1.0](https://github.com/TundraSoft/TundraLibs/compare/norm-v1.0.1...norm-v1.1.0) (2026-08-09)
 
@@ -22,7 +20,6 @@
 ### Features
 
 * **norm:** add the witness observability hook ([30643d0](https://github.com/TundraSoft/TundraLibs/commit/30643d07e0d9cbb71bb68cf6d9ed08c88ca0bd62))
-* **norm:** add the witness observability hook ([93affba](https://github.com/TundraSoft/TundraLibs/commit/93affba080aeed2d354dd93d5cd5779b1c10859b))
 
 ## [1.0.1](https://github.com/TundraSoft/TundraLibs/compare/norm-v1.0.0...norm-v1.0.1) (2026-08-09)
 
@@ -30,7 +27,6 @@
 ### Bug Fixes
 
 * **norm:** remove polynomial-ReDoS backtracking from Migrator dir trim ([262c987](https://github.com/TundraSoft/TundraLibs/commit/262c9875e1ba84a7b05e879b9af03ca9ed93dc80))
-* **norm:** remove polynomial-ReDoS backtracking from Migrator dir trim ([585b44a](https://github.com/TundraSoft/TundraLibs/commit/585b44a4a7c657b3f50f50934c02a44da359c7c8))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/norm-v1.0.0-dev0.7...norm-v1.0.0) (2026-08-01)
 
@@ -45,7 +41,6 @@
 ### Documentation
 
 * **norm:** list decryptError in the README event surface ([d973025](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d97302582a7f60f58bc121e8769f5449e23377e6))
-* **norm:** list decryptError in the README event surface ([9f5b0aa](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/9f5b0aa7c311903e3ba0c92bed0c893e5a790c4e))
 
 ## [1.0.0-dev0.6](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/norm-v1.0.0-dev0.5...norm-v1.0.0-dev0.6) (2026-07-27)
 
@@ -69,7 +64,6 @@
 ### Bug Fixes
 
 * **norm:** resolve round-3 review findings ([efb814d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/efb814d5f65cf46e0cc21cf374f12941d510317f))
-* **norm:** resolve round-3 review findings ([4f96393](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4f963939d9b37b48d741119a6b35c9f580effdb3))
 * **norm:** resolve round-4 review findings ([7921e96](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7921e9659d46eada63fcbf18daf44a1a9fc960c4))
 * **norm:** resolve round-5 review findings ([4ae1940](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4ae1940915d8507a35f3068b90727027cb7adcd8))
 
@@ -77,7 +71,6 @@
 ### Documentation
 
 * **norm:** document scope enforcement on upsert/truncate + migrator transaction timeout ([fbf99ea](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fbf99ea5237f32302dd292ce3f43cc662a1f5019))
-* **norm:** document scope enforcement on upsert/truncate + migrator transaction timeout ([8284215](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8284215f2bea067994715d34080cbdcd0eea42c0))
 * **norm:** document scoped-upsert pre-flight SELECT cost and residual race ([b85df65](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b85df65b70f697b0fa3ba0b5caa31c915dd24160))
 
 ## [1.0.0-dev0.3](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/norm-v1.0.0-dev0.2...norm-v1.0.0-dev0.3) (2026-07-23)
@@ -86,9 +79,7 @@
 ### Bug Fixes
 
 * **norm:** close re-review findings — advisory-lock affinity, scoped hashed filters, chunkSize guard ([b437248](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b437248c75dc4678031ee54712e2f91cfe555f09))
-* **norm:** close re-review findings — advisory-lock affinity, scoped hashed filters, chunkSize guard ([722d474](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/722d474aea44227e2f97022d23dc3644f3a789e2))
 * **norm:** close review findings — migration lock leak, atomic apply, grouped-read warning ([b6f005d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b6f005d9799b2858abad4860490b4b3a0ebb8058))
-* **norm:** close review findings — migration lock leak, atomic apply, grouped-read warning ([a122b1a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a122b1a6b6b674a8930aeae726238350f962ebec))
 
 
 ### Documentation

--- a/packages/oql/CHANGELOG.md
+++ b/packages/oql/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Documentation
 
 * **oql:** fix broken join + HASH-args examples (structural) ([74f746c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/74f746c0183cc9619c3d4bca7f52370eef8bb99e))
-* **oql:** fix broken join + HASH-args examples (structural) ([dc3b6ae](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/dc3b6ae25086b957571da9d33ed196487c21abdf))
 
 ## [1.0.0-dev6.6](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/oql-v1.0.0-dev6.5...oql-v1.0.0-dev6.6) (2026-07-28)
 
@@ -21,9 +20,7 @@
 ### Documentation
 
 * **oql:** fix broken join + HASH-args examples (structural) ([74f746c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/74f746c0183cc9619c3d4bca7f52370eef8bb99e))
-* **oql:** fix broken join + HASH-args examples (structural) ([dc3b6ae](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/dc3b6ae25086b957571da9d33ed196487c21abdf))
 * **oql:** fix broken query examples (referenced columns not in column list) ([3e7e1f4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3e7e1f4129cbacf255577d0faf931d965b9fa026))
-* **oql:** fix broken query examples (referenced columns not in column list) ([521430a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/521430ab8498a67802f995e9d07dd2f51636a1a0))
 
 ## [1.0.0-dev6.6](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/oql-v1.0.0-dev6.5...oql-v1.0.0-dev6.6) (2026-07-28)
 
@@ -31,7 +28,6 @@
 ### Documentation
 
 * **oql:** fix broken query examples (referenced columns not in column list) ([3e7e1f4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3e7e1f4129cbacf255577d0faf931d965b9fa026))
-* **oql:** fix broken query examples (referenced columns not in column list) ([521430a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/521430ab8498a67802f995e9d07dd2f51636a1a0))
 
 ## [1.0.0-dev6.5](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/oql-v1.0.0-dev6.4...oql-v1.0.0-dev6.5) (2026-07-25)
 
@@ -39,9 +35,7 @@
 ### Bug Fixes
 
 * **oql:** resolve round-3 review findings ([7d8cb7b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7d8cb7b4d360d2dfb2f6b08ec64cadb2fa18995e))
-* **oql:** resolve round-3 review findings ([77fd8a8](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/77fd8a876091dfc69ee7fe61e0376ee1ae0ecbf6))
 * **oql:** resolve round-4 review findings ([49ddec9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/49ddec9d0246bfe7564d00523e1326dbc282fc65))
-* **oql:** resolve round-4 review findings ([abf3945](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/abf394576770e1bbb01c99a87462b846759307d5))
 
 ## [1.0.0-dev6.4](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/oql-v1.0.0-dev6.3...oql-v1.0.0-dev6.4) (2026-07-23)
 
@@ -49,9 +43,7 @@
 ### Bug Fixes
 
 * **oql:** close re-review findings — Mongo COUNT(col) & Maria comment escaping ([7850c89](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7850c89f1258d01ec5970acb960c2b7d16e28bb5))
-* **oql:** close re-review findings — Mongo COUNT(col) & Maria comment escaping ([d6ea9a2](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d6ea9a296a307d37e5c1cf917a6a6fd7a5906048))
 * **oql:** close review findings — offset-only SQL, Mongo joins/dates/LIKE, param keying ([3f1a155](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3f1a155e2b8369bf7b21555eddc6f593b6e8b872))
-* **oql:** close review findings — offset-only SQL, Mongo joins/dates/LIKE, param keying ([860b0d8](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/860b0d8821419edfa7fecab793d1f6d086184c74))
 
 ## [1.0.0-dev6.3](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/oql-v1.0.0-dev6.2...oql-v1.0.0-dev6.3) (2026-07-14)
 

--- a/packages/pact/CHANGELOG.md
+++ b/packages/pact/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **pact:** import compat via subpaths instead of the root barrel ([f9a71e7](https://github.com/TundraSoft/TundraLibs/commit/f9a71e76c1dcb87c7e0b6a997f0165a67858accf))
-* **pact:** import compat via subpaths instead of the root barrel ([50b9009](https://github.com/TundraSoft/TundraLibs/commit/50b90095895ae97ba6dd11e069fa2fd80a284a43))
 
 ## [0.4.3](https://github.com/TundraSoft/TundraLibs/compare/pact-v0.4.2...pact-v0.4.3) (2026-08-12)
 
@@ -14,7 +13,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [0.4.2](https://github.com/TundraSoft/TundraLibs/compare/pact-v0.4.1...pact-v0.4.2) (2026-08-09)
 
@@ -29,7 +27,6 @@
 ### Documentation
 
 * **pact:** add Observability section ([b5372fd](https://github.com/TundraSoft/TundraLibs/commit/b5372fd6666526928c02ba45ec6e6edf153fd2d0))
-* **pact:** add Observability section ([2d7bbd0](https://github.com/TundraSoft/TundraLibs/commit/2d7bbd04caa3e1282deb56bf4810c471aa6813f0))
 
 ## [0.4.0](https://github.com/TundraSoft/TundraLibs/compare/pact-v0.3.3...pact-v0.4.0) (2026-08-09)
 
@@ -44,7 +41,6 @@
 ### Documentation
 
 * **pact:** correct the sync event's fires-when description ([58800b5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/58800b5d86280752591f4d132f3dec60889dc002))
-* **pact:** correct the sync event's fires-when description ([53c9945](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/53c99450db2d09c8eb6c2e36acb5e865b1c456eb))
 
 ## [0.3.2](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/pact-v0.3.1...pact-v0.3.2) (2026-07-27)
 
@@ -52,13 +48,11 @@
 ### Bug Fixes
 
 * **pact:** enforce RFC 7518 per-algorithm HMAC secret minimums (HS384&gt;=48B, HS512&gt;=64B) ([04c02e6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/04c02e6617e2c45d122f8a3664709cb4e22b8728))
-* **pact:** enforce RFC 7518 per-algorithm HMAC secret minimums (HS384&gt;=48B, HS512&gt;=64B) ([aedd5c3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/aedd5c30e904169ef01ebbb9bb664c15d93eabd6))
 
 
 ### Documentation
 
 * **pact:** document per-algorithm HMAC secret minimums (companion to [#208](https://github.com/TundraSoft/TundraLibs-1.0.0/issues/208)) ([3d0c3be](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3d0c3be83f125b0e8337a009a402b9491a694b29))
-* **pact:** document per-algorithm HMAC secret minimums (companion to [#208](https://github.com/TundraSoft/TundraLibs-1.0.0/issues/208)) ([23cc5c3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/23cc5c320d7c83227e3b4a38d2040c04bf7397a9))
 
 ## [0.3.1](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/pact-v0.3.0...pact-v0.3.1) (2026-07-25)
 
@@ -66,11 +60,8 @@
 ### Bug Fixes
 
 * **pact:** resolve round-3 review findings ([24fd7b1](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/24fd7b1f36a3ac82f320eb2b3a8c04494be29d73))
-* **pact:** resolve round-3 review findings ([c28e00c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c28e00c00a791386f8e5e8dd5cb087ce395ed5f3))
 * **pact:** resolve round-4 review findings ([ca10d7a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/ca10d7a456c8c4ed07b3662864ce72fc985e8e3f))
-* **pact:** resolve round-4 review findings ([d5f2222](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d5f222200b0e860d4dc6b17a47eb12d6d333329d))
 * **pact:** resolve round-6 review findings ([3e5f263](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3e5f263d06dc7a1156acb8d578bd998c98ab2c03))
-* **pact:** resolve round-6 review findings ([e2eb833](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e2eb833555ba4ef973517542d8ccbe920c5ebdf2))
 
 
 ### Documentation
@@ -83,13 +74,11 @@
 ### Features
 
 * **pact:** verify OIDC id_token signatures via JWKS ([65cf623](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/65cf6235eb5e929b057702d7965f6f6b307e1d29))
-* **pact:** verify OIDC id_token signatures via JWKS ([30d90b7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/30d90b7945ba640501b6de13264ec582ee6ac190))
 
 
 ### Bug Fixes
 
 * **pact:** close re-review findings — prototype-safe Permissions map ([e44159c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e44159c0506c3e6e13cd557324b4d4bca5852163))
-* **pact:** close re-review findings — prototype-safe Permissions map ([f64dcc1](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/f64dcc17159aae307456301b092d0397a08a862a))
 * **pact:** close review findings — isolate success-event listeners, null-proto grants, OAuthClient rename ([5b6aeb9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5b6aeb9ce99c774aba5a5f2521d326eea187318a))
 * **pact:** close review findings — success-event isolation, null-proto grants, OAuthClient rename ([8f98dcc](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8f98dcc4fbf211d30b24412f493e62ebdf8b603b))
 
@@ -97,7 +86,6 @@
 ### Refactoring
 
 * **pact:** delegate id_token verification to crypt ([c070395](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/c0703952b8607b3da89cfd2b3fc59fdddbf7633f))
-* **pact:** delegate id_token verification to crypt ([23b712a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/23b712ab2f6aafc60c6ba9e87c68a7acca36c457))
 
 
 ### Documentation

--- a/packages/radrouter/CHANGELOG.md
+++ b/packages/radrouter/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Documentation
 
 * **radrouter:** link the tracer middleware recipe ([263917c](https://github.com/TundraSoft/TundraLibs/commit/263917c0bfd96a1cd7ade9ebb91ca959ed989c43))
-* **radrouter:** link the tracer middleware recipe ([b9b208d](https://github.com/TundraSoft/TundraLibs/commit/b9b208d87fc9f089eadf62ec8360e2bd4e27f804))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/radrouter-v1.0.0-dev5...radrouter-v1.0.0) (2026-08-01)
 
@@ -21,7 +20,6 @@
 ### Documentation
 
 * **radrouter:** fix wrong capital sharp-S folding claim ([1ce7dda](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1ce7dda6c260aba9ac406be935fcc6a44e557145))
-* **radrouter:** fix wrong capital sharp-S folding claim ([5622924](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5622924d83b7649ff8d106a50d5174cb183ce7fa))
 
 ## [1.0.0-dev4](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/radrouter-v1.0.0-dev3...radrouter-v1.0.0-dev4) (2026-07-25)
 
@@ -29,9 +27,7 @@
 ### Bug Fixes
 
 * **radrouter:** resolve round-3 review findings ([613f5aa](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/613f5aa33ab57f26f977099eaddae2707772580c))
-* **radrouter:** resolve round-3 review findings ([99dbc82](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/99dbc823e1711f309197f3a0f6e697e0b7d0268a))
 * **radrouter:** resolve round-5 review findings ([e1ff223](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e1ff2230ac7e9d81d3c6663c154dd8d501f3da1c))
-* **radrouter:** resolve round-5 review findings ([8c42af5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8c42af5ef439e94432bd9934f935540f3d753648))
 
 ## [1.0.0-dev3](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/radrouter-v1.0.0-dev2...radrouter-v1.0.0-dev3) (2026-07-23)
 
@@ -39,9 +35,7 @@
 ### Bug Fixes
 
 * **radrouter:** close re-review findings — length-preserving case-fold, example comment, conflict/clear coverage ([6b5aae5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/6b5aae5d6a8816b1a44c68809629c563916a484d))
-* **radrouter:** close re-review findings — length-preserving case-fold, example comment, conflict/clear coverage ([9cbdc7b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/9cbdc7bce62f8f72a71315f7c51cbdff91c4c8e1))
 * **radrouter:** close review findings — greedy-suffix terminality, empty-path rejection, doc drift ([940520c](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/940520c7a0564454500256c219a8ff2fdf73b0f4))
-* **radrouter:** close review findings — greedy-suffix terminality, empty-path rejection, doc drift ([48a8558](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/48a8558a8511ad05a89f216f01fad344a1320da9))
 
 ## [1.0.0-dev2](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/radrouter-v1.0.0-dev1...radrouter-v1.0.0-dev2) (2026-07-14)
 

--- a/packages/restler/CHANGELOG.md
+++ b/packages/restler/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.1.0](https://github.com/TundraSoft/TundraLibs/compare/restler-v1.0.1...restler-v1.1.0) (2026-08-09)
 
@@ -27,7 +26,6 @@
 ### Documentation
 
 * **restler:** add Observability section ([a5b4325](https://github.com/TundraSoft/TundraLibs/commit/a5b43251f05ad617167547420627d2cb6c1551e9))
-* **restler:** add Observability section ([69e42e3](https://github.com/TundraSoft/TundraLibs/commit/69e42e392e77a3ecdb2e6017760d9f27283d99ab))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/restler-v1.0.0-dev7...restler-v1.0.0) (2026-08-01)
 
@@ -49,9 +47,7 @@
 ### Bug Fixes
 
 * **restler:** resolve round-3 review findings ([0a95ed5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0a95ed52d8d25c4b98e6f153b8bba333aee0c54e))
-* **restler:** resolve round-3 review findings ([6b75e25](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/6b75e25a51c59cac3eccae9157349228a9625b1b))
 * **restler:** resolve round-4 review findings ([fed081f](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fed081fec8a47e6d0a65dd117c7c61f1621e1f39))
-* **restler:** resolve round-4 review findings ([6539e6e](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/6539e6e0b97780b8755870cf0aa384c4a83adcb6))
 * **restler:** resolve round-5 review findings ([59360ad](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/59360ad9715ac295357de4b65e0dd1608045b778))
 * **restler:** scrub request URL from wrapped fetch error cause chain ([8e495b6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8e495b6e143ceec4f7f4a3a65373dbd6f2f74494))
 
@@ -61,11 +57,8 @@
 ### Bug Fixes
 
 * **restler:** close re-review findings — redact request payload, UTF-8 BASIC auth ([7461081](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/746108183d0fd2398c3f39df7c44d2374306f3e5))
-* **restler:** close re-review findings — redact request payload, UTF-8 BASIC auth ([d035a15](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/d035a15ec2763f446d19c9a64409f63878dd649f))
 * **restler:** close review findings — credential redaction, validation parity, dep skew ([7f967a9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7f967a95d9e44bb6f1ddb0f3f7cc00db2760813c))
-* **restler:** close review findings — credential redaction, validation parity, dep skew ([113f88f](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/113f88f0df99aa418e5059441447c58bf6ed2b4f))
 * **restler:** release timeout timer on completion; validate endpoint version/contentType ([3d57c7a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3d57c7aac39df253f7cb491b402c493958103067))
-* **restler:** release timeout timer on completion; validate endpoint version/contentType ([0edfd31](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0edfd312606ac1bcd3cb6a841d6be28771742655))
 
 ## [1.0.0-dev1](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/restler-v1.0.0-dev0...restler-v1.0.0-dev1) (2026-07-14)
 

--- a/packages/rpc/CHANGELOG.md
+++ b/packages/rpc/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Documentation
 
 * **rpc:** link the tracer middleware recipe ([1e4db7c](https://github.com/TundraSoft/TundraLibs/commit/1e4db7c88e0a26ad9b2196315bd8505019102ca0))
-* **rpc:** link the tracer middleware recipe ([01fef1b](https://github.com/TundraSoft/TundraLibs/commit/01fef1b3551c08ab645f4f257f39a28bf4547d8a))
 
 ## [1.0.0](https://github.com/TundraSoft/TundraLibs/compare/rpc-v1.0.0-dev6...rpc-v1.0.0) (2026-08-01)
 
@@ -21,7 +20,6 @@
 ### Bug Fixes
 
 * **rpc:** correlate BAD_FORMAT error frames to the offending request id ([26439af](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/26439af1bd2fdc712a245efa4b7d08b9c01036e1))
-* **rpc:** correlate BAD_FORMAT error frames to the offending request id ([9677691](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/96776915d83451f06e68a25488e195b374fbbbbf))
 
 ## [1.0.0-dev5](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/rpc-v1.0.0-dev4...rpc-v1.0.0-dev5) (2026-07-27)
 
@@ -29,7 +27,6 @@
 ### Bug Fixes
 
 * **rpc:** publish() normalizes undefined payload to null so the frame isn't rejected ([1dbae36](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1dbae36648d2b6b719bbf4fc905a7608144098df))
-* **rpc:** publish() normalizes undefined payload to null so the frame isn't rejected ([2b94bd4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2b94bd44a7ee084ce4e8a1da22d1e9ce9959b5c3))
 
 ## [1.0.0-dev4](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/rpc-v1.0.0-dev3...rpc-v1.0.0-dev4) (2026-07-25)
 
@@ -37,11 +34,8 @@
 ### Bug Fixes
 
 * **rpc:** resolve round-3 review findings ([09740f0](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/09740f01985ee0886d6a731f75e21a1f1190ef8a))
-* **rpc:** resolve round-3 review findings ([38ab91b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/38ab91bbabbb81e8fa39ebd05be70f8d8ca747d2))
 * **rpc:** resolve round-4 review findings ([44ee873](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/44ee8736c073339d1dc8853f4bf13a94d90a7bb3))
-* **rpc:** resolve round-4 review findings ([060ae6a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/060ae6a119ee2bda8af32f15532465323a501d5f))
 * **rpc:** resolve round-5 review findings ([b2b41a9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b2b41a90155d0a67f5c521455f3efe5b303da9d4))
-* **rpc:** resolve round-5 review findings ([2ca62e9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2ca62e920db49b1b5ccb4bb9c94dd99846c0d53b))
 
 
 ### Documentation
@@ -55,7 +49,6 @@
 
 * **rpc:** close re-review findings — re-check connection after authorize await ([f673ac3](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/f673ac3a6cbb3c5198cab0bebba12f93c1fc987e))
 * **rpc:** close review findings — extension seams, error-path bugs, BaseError ([fcf6012](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fcf601249b6b43e026e8cd854f0f5875f207623e))
-* **rpc:** close review findings — extension seams, error-path bugs, BaseError ([b7f12c4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/b7f12c450687a6672743407f23718577e16c3c36))
 * **rpc:** re-check connection after authorize await + close re-review doc/convention findings ([70c1cbe](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/70c1cbef2eca2fcb5af55b05a099e15261e7ca64))
 * **rpc:** satisfy JSR slow-types after seam promotion ([9444354](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/9444354e9d4d7fafc9fbf4221305a76006186273))
 

--- a/packages/slogger/CHANGELOG.md
+++ b/packages/slogger/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **slogger:** import compat via subpaths instead of the root barrel ([3456aeb](https://github.com/TundraSoft/TundraLibs/commit/3456aeb2f9caa49439f957340a661bf0434a5732))
-* **slogger:** import compat via subpaths instead of the root barrel ([09929a4](https://github.com/TundraSoft/TundraLibs/commit/09929a4b6abc1a416787997aaea3d31b5f5cfa46))
 
 ## [1.1.3](https://github.com/TundraSoft/TundraLibs/compare/slogger-v1.1.2...slogger-v1.1.3) (2026-08-12)
 
@@ -14,7 +13,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.1.2](https://github.com/TundraSoft/TundraLibs/compare/slogger-v1.1.1...slogger-v1.1.2) (2026-08-09)
 
@@ -22,7 +20,6 @@
 ### Documentation
 
 * **slogger:** adopt tracer.logContext in correlation guide ([562b3e7](https://github.com/TundraSoft/TundraLibs/commit/562b3e7fa3995fa97cd638f052ff6f2f6b320472))
-* **slogger:** adopt tracer.logContext in correlation guide ([0e6aad4](https://github.com/TundraSoft/TundraLibs/commit/0e6aad4529bb57da11c4b09b47a3128a9988187c))
 
 ## [1.1.1](https://github.com/TundraSoft/TundraLibs/compare/slogger-v1.1.0...slogger-v1.1.1) (2026-08-09)
 
@@ -61,7 +58,6 @@
 ### Documentation
 
 * **slogger:** fix broken README/handler examples + sampling option name ([54dcd1b](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/54dcd1b4e5a81dececfba79dddc8f04ebf868d5d))
-* **slogger:** fix broken README/handler examples + sampling option name ([1ea7506](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1ea75062aae1b23ae7f751fde1d7a5f396c93bd1))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/slogger-v1.0.0-dev9...slogger-v1.0.0-dev10) (2026-07-27)
 
@@ -69,7 +65,6 @@
 ### Documentation
 
 * **slogger:** createSlogger docs describe reference-identity config comparison ([7ff128d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7ff128d5f83eb40a0e664d7785aafb408d1a1c8c))
-* **slogger:** createSlogger docs describe reference-identity config comparison ([cf5f5ae](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/cf5f5aec70acfcb36b6926d264eb10bc3e3bed3f))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/slogger-v1.0.0-dev8...slogger-v1.0.0-dev9) (2026-07-25)
 
@@ -77,15 +72,10 @@
 ### Bug Fixes
 
 * **slogger:** resolve round-3 review findings ([a0e96f7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a0e96f7e7ced9a53d9e7eef01f37d1ceeab211c0))
-* **slogger:** resolve round-3 review findings ([7a60bf7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/7a60bf716ffbe236fc92b20cc5baad8d7ea00ff3))
 * **slogger:** resolve round-4 review findings ([61ff1ad](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/61ff1ad1af555e9a91a04ef97e81e6bfc71c7d26))
-* **slogger:** resolve round-4 review findings ([2e84a0d](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2e84a0d636cce331da63b34464aeaa34e036b4c3))
 * **slogger:** resolve round-5 masking findings ([2b9d767](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/2b9d767460ef45341e580604be04f164e4e77982))
-* **slogger:** resolve round-5 masking findings ([e6ac051](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e6ac0511346dceac0cdd20101904b553ca50d810))
 * **slogger:** resolve round-6 review findings ([f677b27](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/f677b27546fc2ef930e65bde91dab8910c31c9f9))
-* **slogger:** resolve round-6 review findings ([616e7e4](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/616e7e41224e4c93fac5de81f7f94848a13677e3))
 * **slogger:** resolve round-7 review findings ([caaafa6](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/caaafa67c4b3354405dcedb6f67d48b765a79147))
-* **slogger:** resolve round-7 review findings ([bf13ef1](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/bf13ef14ea7c7e8dd24f682332f257da25885ee3))
 
 ## [1.0.0-dev8](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/slogger-v1.0.0-dev7...slogger-v1.0.0-dev8) (2026-07-23)
 
@@ -93,9 +83,7 @@
 ### Bug Fixes
 
 * **slogger:** close re-review findings — partial-write loops, masking non-scalars, FileHandler double-open ([31fed3a](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/31fed3a41e85f690ac96a9c2b4e1ea639ff15103))
-* **slogger:** close re-review findings — partial-write loops, masking non-scalars, FileHandler double-open ([fe7b578](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fe7b5788e7e468303d3dc84fc1aca410fa182333))
 * **slogger:** close review findings — finalize isolation, typed errors, masking + HTTP buffer fixes ([4a4a60e](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4a4a60e313a5d04ae58ffb38cd3bcf3d0d65eeff))
-* **slogger:** close review findings — finalize isolation, typed errors, masking + HTTP buffer fixes ([1fea220](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1fea220d2208a65ec2f65006b58d1d5a024130d8))
 
 
 ### Documentation

--- a/packages/tracer/CHANGELOG.md
+++ b/packages/tracer/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [0.5.0](https://github.com/TundraSoft/TundraLibs/compare/tracer-v0.4.1...tracer-v0.5.0) (2026-08-09)
 
@@ -34,7 +33,6 @@
 ### Features
 
 * **tracer:** ship the composition-root adapters — wrap and logContext ([35214b9](https://github.com/TundraSoft/TundraLibs/commit/35214b91cc1f30a56813ce7b2c4701ed39a48147))
-* **tracer:** ship the composition-root adapters — wrap and logContext ([bc212e9](https://github.com/TundraSoft/TundraLibs/commit/bc212e9df56893008593d6b57c8cfc3f61946d00))
 
 ## [0.3.1](https://github.com/TundraSoft/TundraLibs/compare/tracer-v0.3.0...tracer-v0.3.1) (2026-08-09)
 
@@ -54,7 +52,6 @@
 ### Features
 
 * **tracer:** add OTLP exporter, batch processor and semantic conventions ([8b5c0da](https://github.com/TundraSoft/TundraLibs/commit/8b5c0da08b956fe354fa2db975ddfbd4e5164e8f))
-* **tracer:** add OTLP exporter, batch processor and semantic conventions ([cf8bab6](https://github.com/TundraSoft/TundraLibs/commit/cf8bab627b6b1b4d04c61b35df79a7b5a42f8bc1))
 
 
 ### Refactoring
@@ -67,7 +64,6 @@
 * **tracer:** add the event-based drivers recipe ([d911245](https://github.com/TundraSoft/TundraLibs/commit/d9112454b65765362c46980dd185c02719c48a0c))
 * **tracer:** add the how-it-works guides, and a real-collector conformance test ([8b14e60](https://github.com/TundraSoft/TundraLibs/commit/8b14e609a4abf5a931a97cddc1b41e08351412b6))
 * **tracer:** align the log-correlation example keys with otelLogFormatter ([564077d](https://github.com/TundraSoft/TundraLibs/commit/564077dd237fb444f28edc7e58be32d14104d9fc))
-* **tracer:** align the log-correlation example keys with otelLogFormatter ([8574578](https://github.com/TundraSoft/TundraLibs/commit/85745787e533d9051dbef70d3fe012ffc6112d0e))
 * **tracer:** make the recipes wiki-visible ([941195f](https://github.com/TundraSoft/TundraLibs/commit/941195ffb47d56a7c392b957cc1f825c039873a1))
 
 ## [0.2.0](https://github.com/TundraSoft/TundraLibs/compare/tracer-v0.1.0...tracer-v0.2.0) (2026-08-09)

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **utils:** import compat via subpaths instead of the root barrel ([1ffae78](https://github.com/TundraSoft/TundraLibs/commit/1ffae78425c9a6ede1cb8ba5900f0531f858f835))
-* **utils:** import compat via subpaths instead of the root barrel ([e2c1645](https://github.com/TundraSoft/TundraLibs/commit/e2c164589c960ca8d4cc9b6524d35a95f02d783e))
 
 ## [1.0.2](https://github.com/TundraSoft/TundraLibs/compare/utils-v1.0.1...utils-v1.0.2) (2026-08-12)
 
@@ -14,7 +13,6 @@
 ### Bug Fixes
 
 * **utils:** harden Events and Options; adopt across the suite ([b32ffc4](https://github.com/TundraSoft/TundraLibs/commit/b32ffc4e9f9a4971070fd1a928141678d7cd4fce))
-* **utils:** harden Events and Options; adopt across the suite ([23d744c](https://github.com/TundraSoft/TundraLibs/commit/23d744c2025efd9735eec85627bcac04eb01ef3d))
 
 ## [1.0.1](https://github.com/TundraSoft/TundraLibs/compare/utils-v1.0.0...utils-v1.0.1) (2026-08-09)
 
@@ -24,7 +22,6 @@
 * **utils:** bound syslog field lengths to finish the ReDoS fix ([7e47c5a](https://github.com/TundraSoft/TundraLibs/commit/7e47c5a84bfbcba12a4465b14e01f39fba4fa9ea))
 * **utils:** make the RFC3164 fields structurally disjoint ([3be4389](https://github.com/TundraSoft/TundraLibs/commit/3be438943f7c4e6b55f965ed43cff2d92a7e1524))
 * **utils:** remove polynomial-ReDoS backtracking from syslog and variableReplacer ([5909647](https://github.com/TundraSoft/TundraLibs/commit/59096470e9c825ec8ebb964954f5a10e57a3cf36))
-* **utils:** remove polynomial-ReDoS backtracking from syslog and variableReplacer ([3dc89bb](https://github.com/TundraSoft/TundraLibs/commit/3dc89bbcb40d107b88d20d429f00f9a8a2e0e247))
 
 
 ### Documentation
@@ -44,7 +41,6 @@
 ### Documentation
 
 * **utils:** fix templatize + syslog documentation to match real behavior/API ([1602f08](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/1602f08aabdda5361b9cd12785d4b18f5ee98133))
-* **utils:** fix templatize + syslog documentation to match real behavior/API ([e18ec22](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/e18ec22a33bcdc3c50a7537301d7e87602bab028))
 
 ## [1.0.0-dev10](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/utils-v1.0.0-dev9...utils-v1.0.0-dev10) (2026-07-27)
 
@@ -52,7 +48,6 @@
 ### Bug Fixes
 
 * **utils:** parse year-first RFC3164 syslog timestamps with the correct year ([21684d5](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/21684d579d52490ae3a77f771a31f8133219f217))
-* **utils:** parse year-first RFC3164 syslog timestamps with the correct year ([40c14c7](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/40c14c714ff03609e0616ad27ff3cc78d282615d))
 
 ## [1.0.0-dev9](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/utils-v1.0.0-dev8...utils-v1.0.0-dev9) (2026-07-25)
 
@@ -60,11 +55,8 @@
 ### Bug Fixes
 
 * **utils:** resolve round-3 review findings ([5029388](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/5029388d84075c924c9f815a15a49fc31288c179))
-* **utils:** resolve round-3 review findings ([464ffa9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/464ffa98a3f4b70974ff408034f53bb1265e31de))
 * **utils:** resolve round-4 review findings ([71193c2](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/71193c28477cfbab882d743818ef9f946ac55d0e))
-* **utils:** resolve round-4 review findings ([a925b74](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/a925b747aa5e7d79cbdd40b8e33071092df3d826))
 * **utils:** resolve round-6 review findings ([3e728ef](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/3e728efde967beca3c72ef3e62fbe237aaad6a36))
-* **utils:** resolve round-6 review findings ([fa5ae93](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/fa5ae93b5c8e2dd5956ade7deba9e7d0133d78b1))
 
 ## [1.0.0-dev8](https://github.com/TundraSoft/TundraLibs-1.0.0/compare/utils-v1.0.0-dev7...utils-v1.0.0-dev8) (2026-07-23)
 
@@ -72,11 +64,9 @@
 ### Bug Fixes
 
 * **utils:** asObject() returns a defensive copy for read-only PrivateObject ([ff05ef9](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/ff05ef91528669d248b899b8eec6b0a77ab29862))
-* **utils:** asObject() returns a defensive copy for read-only PrivateObject ([cac9a37](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/cac9a375e5ba360955d0ba8a714aa9fa2e4b4e5d))
 * **utils:** async memoize/@Once honor the Promise contract on cached calls ([4d2eefd](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/4d2eefde6ed8cfc3453f92d7793bab8b8f081f67))
 * **utils:** close re-review findings — async memoize/@Once honor Promise contract ([9c71bfd](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/9c71bfd3748e29f4125bc3921836d83df6d479ee))
 * **utils:** close review findings — decorator exports, SSRF ranges, validation-bypass leaks ([8b87f04](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/8b87f04dd4c2a9d9643bee36496bff9db17fc318))
-* **utils:** close review findings — decorator exports, SSRF ranges, validation-bypass leaks ([0daf2fc](https://github.com/TundraSoft/TundraLibs-1.0.0/commit/0daf2fca21499f51beaa4671b4831ff389e5cd1f))
 
 
 ### Documentation


### PR DESCRIPTION
Cleanup after the release incident (#206) plus two convention codifications.

**Changelogs (19 packages):**
- Remove the two foreign `**id:** republish as 1.0.3` entries from drivers 1.0.3 — attributed there by the empty-commit bug documented in #206.
- Collapse doubled entries (same change cited with branch AND merge SHA) — produced by merge-commit merges; the repo is squash-only now, so these cannot recur.

**CONVENTIONS.md:**
- New: *Large type surfaces may group into subfolders* — full-namespace-chain identifiers (`RapidApplicationEvents`), leaf file names (`application/Events.ts`), single `types/mod.ts` barrel.
- New: *Imports go through folder barrels* — every folder carries `mod.ts`; cross-folder imports use it, siblings import directly, one import statement per module, type-only back-edges for cycle safety.

No source changes; `chore:` type — no release expected. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)