### PR TITLE
refactor(slogger): break the Slogger/LogManager import cycle

### DIFF
--- a/packages/slogger/LogManager.ts
+++ b/packages/slogger/LogManager.ts
@@ -4,60 +4,27 @@
  */
 
 import { Singleton } from '@tundralibs/utils';
-import {
-  AbstractHandler,
-  type HandlerOptions,
-} from './handlers/AbstractHandler.ts';
-import {
-  BlackholeHandler,
-  ConsoleHandler,
-  FileHandler,
-  HTTPHandler,
-  MemoryHandler,
-  StreamHandler,
-  SyslogHandler,
-  TCPHandler,
-} from './handlers/mod.ts';
-import type { SloggerFormatter, SlogObject } from './types/mod.ts';
-import {
-  jsonFormatter,
-  prettyJsonFormatter,
-} from './formatters/jsonFormatter.ts';
-import { logfmtFormatter } from './formatters/logfmt.ts';
-import { otelLogFormatter } from './formatters/otel.ts';
-import {
-  compactFormat,
-  detailedFormat,
-  keyValueFormat,
-  minimalistFormat,
-  simpleFormatter,
-  standardFormat,
-} from './formatters/string.ts';
-import { HandlerConfig, Slogger, SloggerOptions } from './Slogger.ts';
+import type { AbstractHandler, HandlerOptions } from './handlers/mod.ts';
+import type { SloggerFormatter } from './types/mod.ts';
+import { type HandlerConfig, Slogger, type SloggerOptions } from './Slogger.ts';
+import { registry } from './Registry.ts';
 import { SloggerConfigError } from './errors/mod.ts';
 /**
  * LogManager Singleton
  *
  * Manages all available handlers and formatters in the Slogger system.
  * Provides factory methods to initialize handlers and access formatters.
+ *
+ * The handler/formatter half of this surface is stored in the shared
+ * {@link registry} leaf module rather than on this class, so `Slogger`
+ * can resolve `type` / `formatter` strings without importing back into
+ * this module. Every method below forwards to that one instance — a
+ * formatter added here is immediately visible to every `Slogger`. The
+ * logger cache (`_loggers`) stays here because it constructs `Slogger`
+ * instances, which the registry deliberately knows nothing about.
  */
 @Singleton
 class Manager {
-  /** Map of registered handler constructors */
-  protected _handlers: Map<
-    string,
-    new (
-      name: string,
-      options: HandlerOptions & Record<string, unknown>,
-    ) => AbstractHandler
-  > = new Map();
-
-  /** Map of registered formatters */
-  protected _formatters: Map<
-    string,
-    SloggerFormatter
-  > = new Map();
-
   protected _loggers: Map<string, Slogger> = new Map();
 
   /**
@@ -65,42 +32,6 @@ class Manager {
    * {@link createSlogger} to detect conflicting re-creation.
    */
   private __loggerConfigs: Map<string, SloggerOptions> = new Map();
-
-  constructor() {
-    // Register built-in handlers
-    this.__registerDefaultHandlers();
-    // Register built-in formatters
-    this.__registerDefaultFormatters();
-  }
-
-  /**
-   * Registers all built-in handler types
-   */
-  private __registerDefaultHandlers(): void {
-    this.addHandler('FileHandler', FileHandler);
-    this.addHandler('ConsoleHandler', ConsoleHandler);
-    this.addHandler('HTTPHandler', HTTPHandler);
-    this.addHandler('SyslogHandler', SyslogHandler);
-    this.addHandler('TCPHandler', TCPHandler);
-    this.addHandler('StreamHandler', StreamHandler);
-    this.addHandler('MemoryHandler', MemoryHandler);
-    this.addHandler('BlackholeHandler', BlackholeHandler);
-  }
-
-  /**
-   * Registers all built-in formatters
-   */
-  private __registerDefaultFormatters(): void {
-    this.addFormatter('json', jsonFormatter);
-    this.addFormatter('prettyJson', prettyJsonFormatter);
-    this.addFormatter('standard', standardFormat);
-    this.addFormatter('detailed', detailedFormat);
-    this.addFormatter('compact', compactFormat);
-    this.addFormatter('minimalist', minimalistFormat);
-    this.addFormatter('keyValue', keyValueFormat);
-    this.addFormatter('logfmt', logfmtFormatter());
-    this.addFormatter('otelLog', otelLogFormatter());
-  }
 
   /**
    * Adds a handler constructor to the registry
@@ -122,36 +53,7 @@ class Manager {
       options: T,
     ) => AbstractHandler,
   ): void {
-    // Validate name
-    if (!name || typeof name !== 'string' || name.trim() === '') {
-      throw new SloggerConfigError('Handler name must be a non-empty string', {
-        key: 'name',
-      });
-    }
-
-    // Check for duplicates
-    if (this._handlers.has(name)) {
-      throw new SloggerConfigError(`Handler '${name}' is already registered`, {
-        key: 'name',
-      });
-    }
-
-    // Validate constructor
-    if (typeof handlerConstructor !== 'function') {
-      throw new SloggerConfigError(
-        'Handler constructor must be a valid class constructor',
-        { key: 'handlerConstructor' },
-      );
-    }
-
-    // Register the handler
-    this._handlers.set(
-      name,
-      handlerConstructor as new (
-        name: string,
-        options: HandlerOptions & Record<string, unknown>,
-      ) => AbstractHandler,
-    );
+    registry.addHandler(name, handlerConstructor);
   }
 
   /**
@@ -164,57 +66,7 @@ class Manager {
    *   function returning a string.
    */
   public addFormatter(name: string, formatter: SloggerFormatter): void {
-    // Validate name
-    if (!name || typeof name !== 'string' || name.trim() === '') {
-      throw new SloggerConfigError(
-        'Formatter name must be a non-empty string',
-        { key: 'name' },
-      );
-    }
-
-    // Check for duplicates
-    if (this._formatters.has(name)) {
-      throw new SloggerConfigError(
-        `Formatter '${name}' is already registered`,
-        { key: 'name' },
-      );
-    }
-
-    // Validate formatter
-    if (typeof formatter !== 'function') {
-      throw new SloggerConfigError('Formatter must be a valid function', {
-        key: 'formatter',
-      });
-    }
-
-    // Validate formatter output with a test log
-    try {
-      const testLog = {
-        id: '1',
-        appName: 'test',
-        hostname: 'test',
-        level: 1,
-        date: new Date(),
-        timestamp: Date.now(),
-        isoDate: new Date().toISOString(),
-        levelName: 'WARNING',
-        context: {},
-        message: 'test',
-      } as SlogObject;
-
-      const result = formatter(testLog);
-      if (typeof result !== 'string') {
-        throw new TypeError('Formatter must return a string');
-      }
-    } catch (e) {
-      throw new SloggerConfigError(
-        `Invalid formatter: ${e instanceof Error ? e.message : String(e)}`,
-        { key: 'formatter' },
-        e instanceof Error ? e : undefined,
-      );
-    }
-
-    this._formatters.set(name, formatter);
+    registry.addFormatter(name, formatter);
   }
 
   /**
@@ -227,24 +79,7 @@ class Manager {
    *   string or a formatter with `name` already exists.
    */
   public createFormatter(name: string, template: string): SloggerFormatter {
-    // Validate template
-    if (!template || typeof template !== 'string') {
-      throw new SloggerConfigError('Template must be a non-empty string', {
-        key: 'template',
-      });
-    }
-
-    // Check for duplicates
-    if (this._formatters.has(name)) {
-      throw new SloggerConfigError(
-        `Formatter '${name}' is already registered`,
-        { key: 'name' },
-      );
-    }
-
-    const formatter = simpleFormatter(template);
-    this.addFormatter(name, formatter);
-    return formatter;
+    return registry.createFormatter(name, template);
   }
 
   /**
@@ -254,7 +89,7 @@ class Manager {
    * @returns The formatter function or undefined if not found
    */
   public getFormatter(name: string): SloggerFormatter | undefined {
-    return this._formatters.get(name);
+    return registry.getFormatter(name);
   }
 
   /**
@@ -263,7 +98,7 @@ class Manager {
    * @returns Array of formatter names
    */
   public getFormatterNames(): string[] {
-    return Array.from(this._formatters.keys());
+    return registry.getFormatterNames();
   }
 
   /**
@@ -272,7 +107,7 @@ class Manager {
    * @returns Array of handler type names
    */
   public getHandlerTypes(): string[] {
-    return Array.from(this._handlers.keys());
+    return registry.getHandlerTypes();
   }
 
   /**
@@ -291,36 +126,7 @@ class Manager {
     name: string,
     options: Omit<HandlerConfig, 'name' | 'type'>,
   ): AbstractHandler {
-    const handlerConstructor = this._handlers.get(type);
-    if (!handlerConstructor) {
-      throw new SloggerConfigError(`Handler type '${type}' not found`, {
-        key: 'type',
-      });
-    }
-
-    // If formatter is specified by name, resolve it
-    if (options.formatter && typeof options.formatter === 'string') {
-      const formatterName = options.formatter;
-      const formatter = this.getFormatter(formatterName);
-      if (!formatter) {
-        throw new SloggerConfigError(`Formatter '${formatterName}' not found`, {
-          key: 'formatter',
-        });
-      }
-      options.formatter = formatter;
-    }
-
-    const handler = new handlerConstructor(name, options as HandlerOptions);
-    // Kick off async initialization (e.g. FileHandler opening its file)
-    // eagerly, but never leave the promise unhandled: an init failure
-    // (bad directory, permission denied) would otherwise surface as an
-    // uncaught rejection that terminates the process. `handle()` and
-    // `finalize()` await the same cached promise, so early records wait
-    // for setup instead of racing ahead and being dropped, and the
-    // error is re-surfaced there (swallowed by Slogger.log(), or raised
-    // by Slogger.finalize()) rather than crashing.
-    handler.ensureInitialized().catch(() => {});
-    return handler;
+    return registry.createHandler(type, name, options);
   }
 
   /**

--- a/packages/slogger/Registry.test.ts
+++ b/packages/slogger/Registry.test.ts
@@ -1,0 +1,165 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { SyslogSeverities } from '@tundralibs/utils';
+import { registry } from './Registry.ts';
+import { LogManager } from './LogManager.ts';
+import { Slogger } from './Slogger.ts';
+import { LogManager as LogManagerFromRoot } from './mod.ts';
+import { AbstractHandler, type HandlerOptions } from './handlers/mod.ts';
+import type { SlogObject } from './types/mod.ts';
+
+/** Records every formatted line so a test can prove it ran. */
+class ProbeHandler extends AbstractHandler {
+  public readonly mode = 'probe';
+  public lines: string[] = [];
+
+  constructor(name: string, options: HandlerOptions) {
+    super(name, options);
+  }
+
+  protected _handle(message: string): void {
+    this.lines.push(message);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// One registry, three doors
+// -----------------------------------------------------------------------------
+// `Slogger.ts` and `LogManager.ts` used to import each other; the handler /
+// formatter registry now lives in the `Registry.ts` leaf that both import
+// instead. That refactor's one plausible regression is a SPLIT registry —
+// two `Registry` instances, so a formatter registered through `LogManager`
+// is invisible to a `Slogger` resolving `formatter: 'name'`, and vice versa.
+// Every test below crosses the seam: it writes through one import path and
+// reads through a different one.
+// -----------------------------------------------------------------------------
+
+describe('slogger.registry', () => {
+  it('LogManager writes land in the shared registry leaf', () => {
+    const formatter = (log: SlogObject): string => `via-manager:${log.message}`;
+    LogManager.addFormatter('registryProbeViaManager', formatter);
+
+    // Written through LogManager, read through the leaf module directly.
+    asserts.assertStrictEquals(
+      registry.getFormatter('registryProbeViaManager'),
+      formatter,
+      'a formatter added via LogManager must land in the shared registry',
+    );
+    asserts.assert(
+      registry.getFormatterNames().includes('registryProbeViaManager'),
+    );
+  });
+
+  it('registry writes are visible through LogManager', () => {
+    const formatter = (log: SlogObject): string => `via-leaf:${log.message}`;
+    registry.addFormatter('registryProbeViaLeaf', formatter);
+
+    // Written through the leaf module, read through the public LogManager.
+    asserts.assertStrictEquals(
+      LogManager.getFormatter('registryProbeViaLeaf'),
+      formatter,
+      'a formatter added via the registry must be visible on LogManager',
+    );
+    asserts.assert(
+      LogManager.getFormatterNames().includes('registryProbeViaLeaf'),
+    );
+  });
+
+  it('the built-ins are registered exactly once', () => {
+    // A second Registry instance would either duplicate the built-in names
+    // or give LogManager and the leaf divergent lists.
+    asserts.assertEquals(
+      LogManager.getHandlerTypes(),
+      registry.getHandlerTypes(),
+    );
+    asserts.assertEquals(
+      LogManager.getFormatterNames(),
+      registry.getFormatterNames(),
+    );
+
+    const handlerTypes = registry.getHandlerTypes();
+    asserts.assertEquals(
+      new Set(handlerTypes).size,
+      handlerTypes.length,
+      'built-in handlers must not be registered twice',
+    );
+    const formatterNames = registry.getFormatterNames();
+    asserts.assertEquals(
+      new Set(formatterNames).size,
+      formatterNames.length,
+      'built-in formatters must not be registered twice',
+    );
+    asserts.assert(handlerTypes.includes('ConsoleHandler'));
+    asserts.assert(formatterNames.includes('json'));
+  });
+
+  it('the root mod.ts export is the same LogManager instance', () => {
+    asserts.assertStrictEquals(LogManagerFromRoot, LogManager);
+  });
+
+  it('a Slogger resolves handler types registered via LogManager', async () => {
+    // The end-to-end seam crossing: register through LogManager, then let a
+    // plain `new Slogger(...)` resolve BOTH the handler type and the
+    // formatter by name. Slogger never imports LogManager — if the two saw
+    // different registries this construction would throw
+    // "Handler type 'RegistryProbeHandler' not found".
+    LogManager.addHandler('RegistryProbeHandler', ProbeHandler);
+    const formatter = (log: SlogObject): string => `probe|${log.message}`;
+    LogManager.addFormatter('registryProbeFormat', formatter);
+
+    const log = new Slogger({
+      appName: 'RegistryProbeApp',
+      level: SyslogSeverities.DEBUG,
+      handlers: [{
+        name: 'probe',
+        type: 'RegistryProbeHandler',
+        level: SyslogSeverities.DEBUG,
+        formatter: 'registryProbeFormat',
+      }],
+    });
+
+    try {
+      log.info('hello');
+      // Give the handler's async `handle()` a turn to run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const handler = LogManager.createHandler(
+        'RegistryProbeHandler',
+        'probe-direct',
+        { level: SyslogSeverities.DEBUG, formatter: 'registryProbeFormat' },
+      ) as ProbeHandler;
+      asserts.assertStrictEquals(
+        handler.formatter,
+        formatter,
+        'LogManager.createHandler must resolve the same formatter reference',
+      );
+      await handler.finalize();
+    } finally {
+      await log.finalize();
+    }
+  });
+
+  it('a Slogger sees a formatter added after the logger type was registered', () => {
+    // Registration order must not matter: the registry is one live map, not
+    // a snapshot copied into either module at import time.
+    const formatter = (log: SlogObject): string => `late|${log.message}`;
+    registry.addFormatter('registryProbeLateFormat', formatter);
+
+    const log = new Slogger({
+      appName: 'RegistryProbeLateApp',
+      level: SyslogSeverities.DEBUG,
+      handlers: [{
+        name: 'probe-late',
+        type: 'RegistryProbeHandler',
+        level: SyslogSeverities.DEBUG,
+        formatter: 'registryProbeLateFormat',
+      }],
+    });
+
+    asserts.assertStrictEquals(
+      LogManager.getFormatter('registryProbeLateFormat'),
+      formatter,
+    );
+    return log.finalize();
+  });
+});

--- a/packages/slogger/Registry.ts
+++ b/packages/slogger/Registry.ts
@@ -1,0 +1,352 @@
+/**
+ * @fileoverview The handler/formatter registry that sits **underneath**
+ * both {@link Slogger} and `LogManager`.
+ *
+ * This module is a deliberate leaf: it imports handlers, formatters,
+ * types, and errors, and imports nothing that imports it back. `Slogger`
+ * needs the registry to resolve `type` / `formatter` strings in its
+ * handler configs; `LogManager` needs it to expose `addHandler` /
+ * `addFormatter` / … to consumers *and* needs `Slogger` as a value to
+ * construct cached loggers. Before this module existed those two needs
+ * met in a `Slogger.ts` ⇄ `LogManager.ts` value-import cycle.
+ *
+ * That cycle was legal ESM and worked natively, but it is fragile under
+ * bundlers: one top-level `await` anywhere in a consumer's module graph
+ * makes esbuild (wrangler) and Rollup (Vite) lower *every* module
+ * initializer in that graph to an async function, at which point a
+ * two-way import edge deadlocks — `await init_Slogger()` awaits
+ * `await init_LogManager()` which awaits `init_Slogger()`. Routing both
+ * through this leaf turns the cycle into two one-way edges, so the
+ * package stays importable no matter what a consumer's graph contains.
+ *
+ * The exported {@link registry} binding is a module-scope singleton:
+ * every importer within the package — `Slogger.ts`, `LogManager.ts` —
+ * shares the one instance, so a handler or formatter registered through
+ * `LogManager` is visible to every `Slogger` that resolves a config by
+ * name.
+ *
+ * @module
+ */
+
+import {
+  AbstractHandler,
+  BlackholeHandler,
+  ConsoleHandler,
+  FileHandler,
+  type HandlerOptions,
+  HTTPHandler,
+  MemoryHandler,
+  StreamHandler,
+  SyslogHandler,
+  TCPHandler,
+} from './handlers/mod.ts';
+import {
+  compactFormat,
+  detailedFormat,
+  jsonFormatter,
+  keyValueFormat,
+  logfmtFormatter,
+  minimalistFormat,
+  otelLogFormatter,
+  prettyJsonFormatter,
+  simpleFormatter,
+  standardFormat,
+} from './formatters/mod.ts';
+import type { SloggerFormatter, SlogObject } from './types/mod.ts';
+import { SloggerConfigError } from './errors/mod.ts';
+// Type-only back-edge: erased at compile time, so it cannot create a
+// runtime cycle back into `Slogger.ts`. See the module note above.
+import type { HandlerConfig } from './Slogger.ts';
+
+/**
+ * Registry of handler constructors and formatters, plus the factory that
+ * turns a declarative handler config into a live {@link AbstractHandler}.
+ *
+ * Not exported — the package shares the single {@link registry} instance
+ * created at the bottom of this module. `LogManager` re-exposes this
+ * surface verbatim as the consumer-facing API.
+ */
+class Registry {
+  /** Map of registered handler constructors */
+  protected _handlers: Map<
+    string,
+    new (
+      name: string,
+      options: HandlerOptions & Record<string, unknown>,
+    ) => AbstractHandler
+  > = new Map();
+
+  /** Map of registered formatters */
+  protected _formatters: Map<
+    string,
+    SloggerFormatter
+  > = new Map();
+
+  constructor() {
+    // Register built-in handlers
+    this.__registerDefaultHandlers();
+    // Register built-in formatters
+    this.__registerDefaultFormatters();
+  }
+
+  /**
+   * Registers all built-in handler types
+   */
+  private __registerDefaultHandlers(): void {
+    this.addHandler('FileHandler', FileHandler);
+    this.addHandler('ConsoleHandler', ConsoleHandler);
+    this.addHandler('HTTPHandler', HTTPHandler);
+    this.addHandler('SyslogHandler', SyslogHandler);
+    this.addHandler('TCPHandler', TCPHandler);
+    this.addHandler('StreamHandler', StreamHandler);
+    this.addHandler('MemoryHandler', MemoryHandler);
+    this.addHandler('BlackholeHandler', BlackholeHandler);
+  }
+
+  /**
+   * Registers all built-in formatters
+   */
+  private __registerDefaultFormatters(): void {
+    this.addFormatter('json', jsonFormatter);
+    this.addFormatter('prettyJson', prettyJsonFormatter);
+    this.addFormatter('standard', standardFormat);
+    this.addFormatter('detailed', detailedFormat);
+    this.addFormatter('compact', compactFormat);
+    this.addFormatter('minimalist', minimalistFormat);
+    this.addFormatter('keyValue', keyValueFormat);
+    this.addFormatter('logfmt', logfmtFormatter());
+    this.addFormatter('otelLog', otelLogFormatter());
+  }
+
+  /**
+   * Adds a handler constructor to the registry
+   *
+   * @param name - Unique identifier for the handler type
+   * @param handlerConstructor - Constructor for the handler type
+   * @throws {SloggerConfigError} When `name` is invalid, the handler
+   *   type is already registered, or `handlerConstructor` is not a
+   *   constructor.
+   */
+  public addHandler<
+    T extends HandlerOptions & Record<string, unknown> =
+      & HandlerOptions
+      & Record<string, unknown>,
+  >(
+    name: string,
+    handlerConstructor: new (
+      name: string,
+      options: T,
+    ) => AbstractHandler,
+  ): void {
+    // Validate name
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      throw new SloggerConfigError('Handler name must be a non-empty string', {
+        key: 'name',
+      });
+    }
+
+    // Check for duplicates
+    if (this._handlers.has(name)) {
+      throw new SloggerConfigError(`Handler '${name}' is already registered`, {
+        key: 'name',
+      });
+    }
+
+    // Validate constructor
+    if (typeof handlerConstructor !== 'function') {
+      throw new SloggerConfigError(
+        'Handler constructor must be a valid class constructor',
+        { key: 'handlerConstructor' },
+      );
+    }
+
+    // Register the handler
+    this._handlers.set(
+      name,
+      handlerConstructor as new (
+        name: string,
+        options: HandlerOptions & Record<string, unknown>,
+      ) => AbstractHandler,
+    );
+  }
+
+  /**
+   * Adds a formatter to the registry
+   *
+   * @param name - Unique identifier for the formatter
+   * @param formatter - The formatter function
+   * @throws {SloggerConfigError} When `name` is invalid, the
+   *   formatter is already registered, or `formatter` is not a
+   *   function returning a string.
+   */
+  public addFormatter(name: string, formatter: SloggerFormatter): void {
+    // Validate name
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      throw new SloggerConfigError(
+        'Formatter name must be a non-empty string',
+        { key: 'name' },
+      );
+    }
+
+    // Check for duplicates
+    if (this._formatters.has(name)) {
+      throw new SloggerConfigError(
+        `Formatter '${name}' is already registered`,
+        { key: 'name' },
+      );
+    }
+
+    // Validate formatter
+    if (typeof formatter !== 'function') {
+      throw new SloggerConfigError('Formatter must be a valid function', {
+        key: 'formatter',
+      });
+    }
+
+    // Validate formatter output with a test log
+    try {
+      const testLog = {
+        id: '1',
+        appName: 'test',
+        hostname: 'test',
+        level: 1,
+        date: new Date(),
+        timestamp: Date.now(),
+        isoDate: new Date().toISOString(),
+        levelName: 'WARNING',
+        context: {},
+        message: 'test',
+      } as SlogObject;
+
+      const result = formatter(testLog);
+      if (typeof result !== 'string') {
+        throw new TypeError('Formatter must return a string');
+      }
+    } catch (e) {
+      throw new SloggerConfigError(
+        `Invalid formatter: ${e instanceof Error ? e.message : String(e)}`,
+        { key: 'formatter' },
+        e instanceof Error ? e : undefined,
+      );
+    }
+
+    this._formatters.set(name, formatter);
+  }
+
+  /**
+   * Creates a custom formatter using the {@link simpleFormatter} factory
+   *
+   * @param name - Unique identifier for the formatter
+   * @param template - Template string for the formatter
+   * @returns The created formatter function
+   * @throws {SloggerConfigError} When `template` is not a non-empty
+   *   string or a formatter with `name` already exists.
+   */
+  public createFormatter(name: string, template: string): SloggerFormatter {
+    // Validate template
+    if (!template || typeof template !== 'string') {
+      throw new SloggerConfigError('Template must be a non-empty string', {
+        key: 'template',
+      });
+    }
+
+    // Check for duplicates
+    if (this._formatters.has(name)) {
+      throw new SloggerConfigError(
+        `Formatter '${name}' is already registered`,
+        { key: 'name' },
+      );
+    }
+
+    const formatter = simpleFormatter(template);
+    this.addFormatter(name, formatter);
+    return formatter;
+  }
+
+  /**
+   * Gets a formatter by name
+   *
+   * @param name - Name of the formatter to retrieve
+   * @returns The formatter function or undefined if not found
+   */
+  public getFormatter(name: string): SloggerFormatter | undefined {
+    return this._formatters.get(name);
+  }
+
+  /**
+   * Gets all registered formatter names
+   *
+   * @returns Array of formatter names
+   */
+  public getFormatterNames(): string[] {
+    return Array.from(this._formatters.keys());
+  }
+
+  /**
+   * Gets all registered handler type names
+   *
+   * @returns Array of handler type names
+   */
+  public getHandlerTypes(): string[] {
+    return Array.from(this._handlers.keys());
+  }
+
+  /**
+   * Creates and initializes a handler of the specified type
+   *
+   * @param type - Type of handler to create (e.g., 'console', 'file')
+   * @param name - Unique name for this handler instance
+   * @param options - Configuration options for the handler
+   * @returns Initialized handler instance
+   * @throws {SloggerConfigError} When the handler `type` or a
+   *   formatter referenced by name is not registered (or when the
+   *   handler constructor rejects the options).
+   */
+  public createHandler(
+    type: string,
+    name: string,
+    options: Omit<HandlerConfig, 'name' | 'type'>,
+  ): AbstractHandler {
+    const handlerConstructor = this._handlers.get(type);
+    if (!handlerConstructor) {
+      throw new SloggerConfigError(`Handler type '${type}' not found`, {
+        key: 'type',
+      });
+    }
+
+    // If formatter is specified by name, resolve it
+    if (options.formatter && typeof options.formatter === 'string') {
+      const formatterName = options.formatter;
+      const formatter = this.getFormatter(formatterName);
+      if (!formatter) {
+        throw new SloggerConfigError(`Formatter '${formatterName}' not found`, {
+          key: 'formatter',
+        });
+      }
+      options.formatter = formatter;
+    }
+
+    const handler = new handlerConstructor(name, options as HandlerOptions);
+    // Kick off async initialization (e.g. FileHandler opening its file)
+    // eagerly, but never leave the promise unhandled: an init failure
+    // (bad directory, permission denied) would otherwise surface as an
+    // uncaught rejection that terminates the process. `handle()` and
+    // `finalize()` await the same cached promise, so early records wait
+    // for setup instead of racing ahead and being dropped, and the
+    // error is re-surfaced there (swallowed by Slogger.log(), or raised
+    // by Slogger.finalize()) rather than crashing.
+    handler.ensureInitialized().catch(() => {});
+    return handler;
+  }
+}
+
+/**
+ * The one registry shared by the whole package.
+ *
+ * A module-scope binding is the singleton: `Slogger.ts` and
+ * `LogManager.ts` both import *this* value, so `LogManager.addFormatter`
+ * and a `Slogger` resolving `formatter: 'name'` read and write the same
+ * two maps. Creating a second {@link Registry} anywhere would silently
+ * split handler/formatter lookup between the two.
+ */
+export const registry: Registry = new Registry();

--- a/packages/slogger/Slogger.ts
+++ b/packages/slogger/Slogger.ts
@@ -13,7 +13,7 @@ import { hostname } from '@tundralibs/compat/net';
 import { onExit } from '@tundralibs/compat/runtime';
 import { AbstractHandler, type HandlerOptions } from './handlers/mod.ts';
 import type { SloggerFormatter, SlogObject } from './types/mod.ts';
-import { LogManager } from './LogManager.ts';
+import { registry } from './Registry.ts';
 import { SamplingOptions } from './handlers/AbstractHandler.ts';
 import {
   SloggerConfigError,
@@ -97,7 +97,7 @@ export type SloggerOptions = {
    *
    * Called lazily — only for records that pass the level/handler filters, so
    * muted lines never invoke it. Like formatters, the provider is compared by
-   * **reference identity** for {@link LogManager} caching: hoist it to a
+   * **reference identity** for `LogManager` caching: hoist it to a
    * stable `const`, don't pass a fresh arrow on each `createSlogger` call.
    */
   contextProvider?: () => LogContext;
@@ -241,7 +241,7 @@ export class Slogger {
           // Resolve formatter if provided as string
           if (options.formatter) {
             if (typeof options.formatter === 'string') {
-              const formatter = LogManager.getFormatter(options.formatter);
+              const formatter = registry.getFormatter(options.formatter);
               if (!formatter) {
                 throw new SloggerConfigError(
                   `Formatter '${options.formatter}' not found`,
@@ -263,7 +263,7 @@ export class Slogger {
           }
 
           // Create and register the handler
-          const handler = LogManager.createHandler(
+          const handler = registry.createHandler(
             type,
             name,
             options as HandlerOptions,


### PR DESCRIPTION
## What

Breaks the circular import between `packages/slogger/Slogger.ts` and
`packages/slogger/LogManager.ts` by extracting the handler/formatter
registry into a new leaf module, `packages/slogger/Registry.ts`.

```
before:  Slogger.ts  <-->  LogManager.ts        (1 value-import cycle)
after:   Slogger.ts   -->  Registry.ts  <--  LogManager.ts   (0 cycles)
```

**No public API change.** `mod.ts` is untouched, `LogManager` is still
exported from `LogManager.ts` with an identical method surface, and every
exported type is unchanged. `deno publish --dry-run` is clean.

## The extraction

`Registry` now owns the two maps and the registry logic, moved verbatim:
`addHandler`, `addFormatter`, `createFormatter`, `getFormatter`,
`getFormatterNames`, `getHandlerTypes`, `createHandler`, plus the built-in
handler/formatter registrations that used to run in `Manager`'s constructor.
Error messages and their `context` keys are byte-identical, so every existing
assertion still matches.

`Manager` keeps exactly the half that genuinely needs `Slogger` as a value —
the logger cache (`_loggers`, `createSlogger`, `getLogger`, `__sameConfig`) —
and forwards the registry half to the shared instance. Its only remaining
back-edge to `Slogger.ts` is `import type { HandlerConfig }`, which is erased
at compile time and cannot create a runtime cycle (the pattern CONVENTIONS.md
blesses under "Cycle care"). Its `AbstractHandler` / `HandlerOptions` imports
became `import type` for the same reason, and its two separate imports from
`./handlers/` collapsed into one barrel import per the import conventions.

`Slogger.ts` changes are three lines: the import, and the two call sites
(`LogManager.getFormatter` → `registry.getFormatter`,
`LogManager.createHandler` → `registry.createHandler`).

The removed `_handlers` / `_formatters` fields were `protected` on a class
(`Manager`) that is not exported, so nothing outside the package could reach
them.

## The shared-singleton guarantee

The registry is a module-scope binding — `export const registry: Registry =
new Registry()` — so every importer in the package shares one instance and one
pair of maps.

**Delegation, not inheritance, is what makes this hold.** A `Manager extends
Registry` would have given `LogManager` its own maps and silently split
lookup: a formatter added via `LogManager.addFormatter` would have been
invisible to a `Slogger` resolving `formatter: 'name'`. That is the one
regression this refactor could plausibly introduce, so it gets its own test
file.

`Registry.test.ts` crosses the seam in every direction — writing through one
import path and reading through another:

- formatter added via `LogManager` → read back via the `Registry.ts` leaf
- formatter added via the leaf → read back via `LogManager`
- `LogManager` and the leaf report identical, duplicate-free built-in lists
- `LogManager` from `./mod.ts` is the same object as from `./LogManager.ts`
- end-to-end: a handler type + formatter registered via `LogManager`, then
  resolved by name inside a plain `new Slogger({ handlers: [...] })` —
  `Slogger` never imports `LogManager`, so a split registry would throw
  `Handler type 'RegistryProbeHandler' not found`
- registration order doesn't matter (the registry is one live map, not a
  snapshot copied at import time)

**Negative control:** with `LogManager` temporarily pointed at a second
`new Registry()`, 5 of the 6 steps fail (the sixth is the `mod.ts` identity
check, which correctly doesn't touch the registry). Reverted before commit.

## Why now — hardening, not a live bug fix

Circular ESM imports are legal and work natively; this cycle was not causing a
failure today. But **one top-level `await` anywhere in a consumer's module
graph** makes esbuild (wrangler) and Rollup (Vite) lower *every* module
initializer in that graph to an async function, and a two-way import edge then
deadlocks: `await init_Slogger()` awaits `await init_LogManager()` which awaits
`init_Slogger()` — no error, just a hang.

slogger did exactly this: it hung forever on import in wrangler and Vite
consumer builds until `@tundralibs/compat` 1.1.2 removed the offending TLA
(see the "No top-level await" block in `packages/compat/mod.test.ts`, which
names this cycle by name). The hang is gone today, but only because compat
stays TLA-free. Removing the cycle makes slogger robust regardless of what any
consumer's graph contains.

## Verification

| Check | Result |
| --- | --- |
| Value-import cycles in `packages/slogger` | **1 → 0** (throwaway AST-ish walker over `import`/`export … from`, skipping `import type`; sanity-checked against guardian, where it correctly finds 5) |
| `deno test packages/slogger/` | 23 files, 353 steps, 0 failed |
| `bun test packages/slogger/` | 302 pass, 3 skip, 0 fail (19 files) |
| `node --import tsx --test 'packages/slogger/**/*.test.ts'` | 302 pass, 0 fail |
| `deno check` on `mod.ts` + all 4 subpath exports | clean |
| `deno task check` (whole workspace) | clean |
| `deno bundle --platform=browser -o … packages/slogger/mod.ts` | 183 modules, 241.62KB, success |
| `deno publish --dry-run` | success |
| `deno fmt --check` / `deno lint` | clean |
| tracer + ambient + compat suites (slogger's dependents) | 47 files, 1191 steps, 0 failed |

No `any`, no lint-ignore comments, no coverage suppressions. All new code in
`Registry.ts` is exercised by the existing `LogManager.test.ts` (which now
reaches it through the delegating methods) plus the new `Registry.test.ts`.

**DO NOT MERGE** — leaving the merge to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
