### PR TITLE
refactor(rpc): move the pub/sub conformance harness off the public barrels

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -27,14 +27,15 @@ via `server.handlers()` or run standalone via `server.listen()`.
 
 ## Modules
 
-| Module           | Description                                                                            | Documentation                                 |
-| ---------------- | -------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `Server`         | Command router + channels + middleware                                                 | This page                                     |
-| Wire protocol    | JSON envelope frames, `decodeFrame` / `encodeFrame`                                    | [docs/Rpc-Protocol](docs/Rpc-Protocol.md)     |
-| Middleware       | Koa-style middleware patterns and recipes                                              | [docs/Rpc-Middleware](docs/Rpc-Middleware.md) |
-| Pub/Sub adapters | Adapter contract, capability flags, in-memory + Redis sketch, conformance test harness | [docs/Rpc-PubSub](docs/Rpc-PubSub.md)         |
-| Extending        | Subclass overrides — pattern subscribe, frame inspection                               | [docs/Rpc-Extending](docs/Rpc-Extending.md)   |
-| `./pubsub`       | `PubSubAdapter` base + `MemoryPubSubAdapter`                                           | [docs/Rpc-PubSub](docs/Rpc-PubSub.md)         |
+| Module           | Description                                                                            | Documentation                                              |
+| ---------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `Server`         | Command router + channels + middleware                                                 | This page                                                  |
+| Wire protocol    | JSON envelope frames, `decodeFrame` / `encodeFrame`                                    | [docs/Rpc-Protocol](docs/Rpc-Protocol.md)                  |
+| Middleware       | Koa-style middleware patterns and recipes                                              | [docs/Rpc-Middleware](docs/Rpc-Middleware.md)              |
+| Pub/Sub adapters | Adapter contract, capability flags, in-memory + Redis sketch, conformance test harness | [docs/Rpc-PubSub](docs/Rpc-PubSub.md)                      |
+| Extending        | Subclass overrides — pattern subscribe, frame inspection                               | [docs/Rpc-Extending](docs/Rpc-Extending.md)                |
+| `./pubsub`       | `PubSubAdapter` base + `MemoryPubSubAdapter`                                           | [docs/Rpc-PubSub](docs/Rpc-PubSub.md)                      |
+| `./conformance`  | `runAdapterConformance` — adapter contract test harness (test files only)              | [docs/Rpc-PubSub](docs/Rpc-PubSub.md#testing-your-adapter) |
 
 ## Installation
 
@@ -61,6 +62,14 @@ npx jsr add @tundralibs/rpc
 ```typescript
 import { Server } from '@tundralibs/rpc';
 import { MemoryPubSubAdapter } from '@tundralibs/rpc/pubsub';
+```
+
+The adapter conformance harness ships on its own sub-path, and belongs
+in test files only — it imports a test framework, which browser and
+edge-worker bundlers cannot resolve:
+
+```typescript
+import { runAdapterConformance } from '@tundralibs/rpc/conformance';
 ```
 
 ## Wire protocol

--- a/packages/rpc/deno.json
+++ b/packages/rpc/deno.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./mod.ts",
     "./pubsub": "./pubsub/mod.ts",
+    "./conformance": "./pubsub/conformance.ts",
     "./types": "./types/mod.ts",
     "./errors": "./errors/mod.ts"
   },

--- a/packages/rpc/docs/Rpc-PubSub.md
+++ b/packages/rpc/docs/Rpc-PubSub.md
@@ -308,9 +308,13 @@ with the package, not just prose. Any adapter — including the bundled
 `MemoryPubSubAdapter` — can run the harness against itself and inherit
 the same assertions.
 
+It lives behind its own `@tundralibs/rpc/conformance` sub-path, and is
+deliberately **not** re-exported from `@tundralibs/rpc` or
+`@tundralibs/rpc/pubsub` — see [Why its own sub-path](#why-its-own-sub-path).
+
 ```ts
 import { describe } from '@tundralibs/compat/test';
-import { runAdapterConformance } from '@tundralibs/rpc';
+import { runAdapterConformance } from '@tundralibs/rpc/conformance';
 import { MyRedisAdapter } from './MyRedisAdapter.ts';
 
 describe('MyRedisAdapter', () => {
@@ -381,9 +385,24 @@ part of the universal contract (synchronous delivery, throw-on-
 subscribe-after-close). Contract drift in the harness breaks
 Memory's CI alongside any custom adapter's.
 
-> **Implementation**: [`pubsub/conformance.ts`](../pubsub/conformance.ts).
-> Re-exported at the top level (`@tundralibs/rpc`) so adapter authors
-> don't need to know about the `pubsub/` subpath.
+### Why its own sub-path
+
+The harness imports `@tundralibs/compat/test`, which resolves
+`bun:test` / `node:test` to whichever test framework the host runtime
+provides. Those specifiers do not exist for browser- and edge-targeting
+bundlers: with the harness re-exported from `@tundralibs/rpc`, a
+Cloudflare Workers build fails outright with
+`Could not resolve "bun:test"` — even for an app that only imports
+`Client`. Parking it on `@tundralibs/rpc/conformance` keeps every
+runtime barrel free of that edge, so `@tundralibs/rpc` and
+`@tundralibs/rpc/pubsub` bundle cleanly for Workers, Deno Deploy, and
+the browser with no `alias` shims.
+
+The rule that follows: `runAdapterConformance` is imported from test
+files only, and neither `mod.ts` nor `pubsub/mod.ts` may re-export it.
+
+> **Implementation**: [`pubsub/conformance.ts`](../pubsub/conformance.ts),
+> published as `@tundralibs/rpc/conformance`.
 
 ## When to Reach for Cross-Process
 

--- a/packages/rpc/mod.ts
+++ b/packages/rpc/mod.ts
@@ -6,7 +6,11 @@
  * types, the wire-protocol codec, and the default in-memory pub/sub
  * adapter. Cross-process broadcast adapters (Redis, etc.) are out of
  * scope here; plug your own implementation of {@link PubSubAdapter}
- * into `new Server({ pubsub: ... })`.
+ * into `new Server({ pubsub: ... })`. To verify such an adapter
+ * against the contract, import `runAdapterConformance` from the
+ * `@tundralibs/rpc/conformance` sub-path — it is kept off this barrel
+ * because it pulls in a test framework, which browser and edge-worker
+ * bundlers cannot resolve.
  *
  * `Server` and `Client` share a single wire protocol and a parallel
  * middleware mental model (`use` on Server, `useSend` / `useReceive`
@@ -71,11 +75,8 @@ export {
 
 export {
   type AdapterCapabilities,
-  type AdapterFactory,
-  type ConformanceOptions,
   MemoryPubSubAdapter,
   PubSubAdapter,
-  runAdapterConformance,
   type Subscription,
 } from './pubsub/mod.ts';
 

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./mod.ts",
     "./pubsub": "./pubsub/mod.ts",
+    "./conformance": "./pubsub/conformance.ts",
     "./types": "./types/mod.ts",
     "./errors": "./errors/mod.ts"
   },

--- a/packages/rpc/pubsub/conformance.ts
+++ b/packages/rpc/pubsub/conformance.ts
@@ -7,10 +7,10 @@
  * this suite against itself and observe the same assertions
  * `MemoryPubSubAdapter` is held to.
  *
- * Usage:
+ * Usage — note the dedicated `/conformance` sub-path:
  *
  * ```ts
- * import { runAdapterConformance } from '@tundralibs/rpc/pubsub';
+ * import { runAdapterConformance } from '@tundralibs/rpc/conformance';
  * import { describe } from '@tundralibs/compat/test';
  * import { MyRedisAdapter } from './MyRedisAdapter.ts';
  *
@@ -27,6 +27,14 @@
  * `crossProcess` broadcast, which requires a separate adapter
  * instance on another process. Run an out-of-process integration
  * test in addition to this suite for those.
+ *
+ * Reachable **only** through the `/conformance` sub-path — never from
+ * `@tundralibs/rpc` or `@tundralibs/rpc/pubsub`. This module
+ * statically imports `@tundralibs/compat/test`, which resolves
+ * `bun:test` / `node:test`; those specifiers are unresolvable to
+ * browser and edge-worker bundlers (Cloudflare Workers' esbuild fails
+ * the build outright). Isolating the harness here keeps the runtime
+ * barrels bundler-safe — import it from test files only.
  *
  * @module
  */

--- a/packages/rpc/pubsub/mod.ts
+++ b/packages/rpc/pubsub/mod.ts
@@ -1,6 +1,13 @@
 /**
  * @fileoverview Pub/Sub adapter exports.
  *
+ * Runtime-safe: nothing reachable from this barrel imports a test
+ * framework. The conformance harness deliberately lives behind its
+ * own `@tundralibs/rpc/conformance` sub-path — it imports
+ * `@tundralibs/compat/test`, which resolves `bun:test` / `node:test`
+ * at runtime and hard-fails bundlers that target browsers or edge
+ * workers. Never re-export it from here or from the root barrel.
+ *
  * @module
  */
 
@@ -11,9 +18,3 @@ export {
 } from './Adapter.ts';
 
 export { MemoryPubSubAdapter } from './MemoryPubSubAdapter.ts';
-
-export {
-  type AdapterFactory,
-  type ConformanceOptions,
-  runAdapterConformance,
-} from './conformance.ts';


### PR DESCRIPTION
## The bug

Importing `@tundralibs/rpc` at all — or `@tundralibs/rpc/pubsub` for
just the adapters — pulls a **test framework** into the consumer's
bundle graph. Browser and edge-worker bundlers cannot resolve
`bun:test` / `node:test`, so the build does not degrade: it **fails**.

The exact chain, on published rpc 1.0.1:

```
mod.ts:63              export { …, runAdapterConformance } from './pubsub/mod.ts'
  → pubsub/mod.ts:7    export { runAdapterConformance } from './conformance.ts'
    → pubsub/conformance.ts:34
                       import { afterEach, beforeEach, it } from '@tundralibs/compat/test'
      → compat/test.ts import('bun:test') / import('node:test')
        → wrangler/esbuild:  ✗ [ERROR] Could not resolve "bun:test"
```

This was verified empirically in a real `wrangler` build: a consumer
importing 14 other `@tundralibs/*` packages builds fine, and fails the
moment `@tundralibs/rpc` is added — even when the app only touches
`Client`. Downstream apps are currently carrying a wrangler `alias`
stub purely to work around this one package. rpc is the **last**
package in the suite still doing it; every other one was narrowed in
the recent barrel-hygiene wave (#190–#203).

## The fix

`runAdapterConformance` is a legitimate public feature — it lets
adapter authors verify their own `PubSubAdapter` against the contract
`MemoryPubSubAdapter` is held to. The problem was only its *location*:
it sat on the two barrels ordinary consumers import.

It now has its own sub-path, wired into both manifests:

```jsonc
// packages/rpc/deno.json AND packages/rpc/package.json
"exports": {
  ".":            "./mod.ts",
  "./pubsub":     "./pubsub/mod.ts",
  "./conformance": "./pubsub/conformance.ts",   // ← new
  "./types":      "./types/mod.ts",
  "./errors":     "./errors/mod.ts"
}
```

- Removed from `mod.ts`: `runAdapterConformance`, `AdapterFactory`,
  `ConformanceOptions`.
- Removed from `pubsub/mod.ts`: the same three.
- `pubsub/conformance.ts` itself **does not move** — so
  `MemoryPubSubAdapter.test.ts` keeps its sibling `./conformance.ts`
  import and the harness stays dogfooded on every CI run.
- The types travel with the function; they are only useful alongside
  it, and keeping them on the root barrel would leave two import paths
  for one feature.
- Both barrels grew a `@fileoverview` note recording *why* the harness
  must never come back, so this does not silently regress.

## ⚠️ Migration (BREAKING for one import path)

```diff
-import { runAdapterConformance } from '@tundralibs/rpc';
-import { runAdapterConformance } from '@tundralibs/rpc/pubsub';
+import { runAdapterConformance } from '@tundralibs/rpc/conformance';
```

Same for `AdapterFactory` / `ConformanceOptions` if you import those.
Nothing else changes — no signature, no behaviour. Affected code is
adapter authors' **test files**; runtime code was never able to call
this meaningfully.

## Reviewer decision: breaking marker vs. deprecated re-export

**This commit deliberately does NOT carry a `!` marker**, so
release-please will cut rpc **1.0.2** (patch). rpc is at 1.x and
`bump-minor-pre-major` is inert past 1.0.0, so `fix(rpc)!:` would force
**2.0.0** — a major for a test-only helper. Precedent for `!` exists
(`refactor(tracer)!: move the OTLP exporter under exporters/`) but
tracer was 0.x at the time, where `!` bumps minor.

Three options; **I recommend (A)**, but the version consequence is
yours to make, not mine to slip in:

| | Option | Effect |
|---|---|---|
| **A** ✅ | Ship as-is (clean removal, no `!`) | rpc 1.0.2. Bug fully fixed on both barrels. Anyone on the old import path gets a build error with an obvious fix. |
| **B** | Amend to `fix(rpc)!:` before merge | rpc 2.0.0. Semver-honest, but a major release whose entire surface delta is one test helper's import path. |
| **C** | Keep a deprecated re-export on `./pubsub` | **Does not fix the bug.** Any re-export from `pubsub/mod.ts` keeps the `compat/test` edge alive, so `@tundralibs/rpc/pubsub` still fails Workers builds — and `mod.ts` re-exports `pubsub/mod.ts`, so the root barrel would need auditing too. It converts a hard error into a half-fix. |

Reasoning for (A): the whole point is that *no* consumer-facing path
reaches `compat/test`, which (C) forfeits. Between (A) and (B), the
real-world break is a one-line import change in test files, versus a
major-version bump every consumer must action. If you disagree, amend
the subject to `fix(rpc)!:` before merging — no code change needed.

## Verification

**1. The point — `deno bundle --platform=browser`, then `grep -c`:**

| Entrypoint | `bun:test` | `node:test` | Size |
|---|---|---|---|
| `packages/rpc/mod.ts` | **1 → 0** | **1 → 0** | 268.44KB → 215.82KB |
| `packages/rpc/pubsub/mod.ts` | **1 → 0** | **1 → 0** | 56.89KB → 1.40KB |
| `packages/rpc/errors/mod.ts` | 0 → 0 | — | unchanged |
| `packages/rpc/pubsub/conformance.ts` | 1 → **1** | — | harness intact behind its own sub-path, as intended |

**2. Harness still works** — `packages/rpc/pubsub/MemoryPubSubAdapter.test.ts`
exercises `runAdapterConformance` (10 contract clauses + capability
gate). Green on all three runtimes.

**3. Full rpc suite, all three CI runtimes:**

- `deno test --allow-all packages/rpc` → **5 passed (132 steps), 0 failed**
- `bun test packages/rpc` → **117 pass, 0 fail**
- `node --import tsx --test 'packages/rpc/**/*.test.ts'` → **117 pass, 0 fail**

**4. `deno check` clean** on `mod.ts` and every sub-path in
`deno.json` exports (`./pubsub`, `./conformance`, `./types`,
`./errors`).

**5. `deno publish --dry-run`** from `packages/rpc` → `Success`, no
slow-type warnings.

**6. Sub-path resolution smoke-tested** on all three runtimes — a probe
importing `@tundralibs/rpc/conformance`, `@tundralibs/rpc/pubsub` and
`@tundralibs/rpc` side by side resolves under Deno (workspace),
Bun and Node (package.json exports). Probe was temporary and is not
committed.

**7. `deno fmt` / `deno lint` clean; `deno task workspace:sync:check`
reports 19 packages in sync** — export maps are hand-maintained per
package, not generated, so no release-please files were touched.

Docs updated: `README.md` (module table + import section),
`docs/Rpc-PubSub.md` (usage snippet + a new "Why its own sub-path"
section replacing the old "re-exported at the top level" note), and the
`conformance.ts` module JSDoc `@example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
