### PR TITLE
fix(tracer): build the active-span context on first use, not at import

### DIFF
--- a/packages/tracer/Tracer.ts
+++ b/packages/tracer/Tracer.ts
@@ -216,6 +216,11 @@ export class Tracer extends Options<TracerOptions> {
    * @param optionsOrFn - {@link SpanOptions}, or `fn` when there are none.
    * @param maybeFn - `fn`, when options were supplied.
    * @returns Whatever `fn` returns.
+   * @throws {TypeError} When the runtime provides no `AsyncLocalStorage`
+   *   (`node:async_hooks`) — e.g. a browser. Making a span active needs an
+   *   async-context scope, so it fails loudly rather than silently running
+   *   `fn` with no active span. {@link Tracer.startSpan} has no such
+   *   requirement.
    */
   public startActiveSpan<R>(name: string, fn: (span: Span) => R): R;
   public startActiveSpan<R>(
@@ -279,6 +284,9 @@ export class Tracer extends Options<TracerOptions> {
    * booleans, and arrays of those) are dropped rather than exported malformed.
    * Satisfies the witness contract by construction: `fn` is invoked exactly
    * once, its result returned unchanged, its errors recorded and re-thrown.
+   *
+   * @throws {TypeError} When the runtime provides no `AsyncLocalStorage` —
+   *   see {@link Tracer.startActiveSpan}.
    */
   public readonly wrap = <T>(
     info: { name: string; attributes?: Record<string, unknown> },
@@ -308,6 +316,9 @@ export class Tracer extends Options<TracerOptions> {
    * ```
    *
    * Same contract and attribute sanitisation as {@link Tracer.wrap}.
+   *
+   * @throws {TypeError} When the runtime provides no `AsyncLocalStorage` —
+   *   see {@link Tracer.startActiveSpan}.
    */
   public readonly wrapClient = <T>(
     info: { name: string; attributes?: Record<string, unknown> },

--- a/packages/tracer/activeSpan.test.ts
+++ b/packages/tracer/activeSpan.test.ts
@@ -1,0 +1,184 @@
+import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
+import { type Context, createContext } from '@tundralibs/ambient';
+import { activeSpan, buildActiveSpan } from './activeSpan.ts';
+import { FLAG_SAMPLED, MemoryExporter, Span, SpanKind, Tracer } from './mod.ts';
+
+/** A standalone {@link Span}, built without a {@link Tracer}. */
+const spanNamed = (name: string, spanId = '1'.repeat(16)): Span =>
+  new Span({
+    name,
+    context: {
+      traceId: 'a'.repeat(32),
+      spanId,
+      traceFlags: FLAG_SAMPLED,
+    },
+    kind: SpanKind.INTERNAL,
+    startTime: new Date(),
+    resource: {},
+    recording: true,
+    onEnd: () => {},
+  });
+
+describe('tracer.activeSpan', () => {
+  it('is empty outside any run scope', () => {
+    asserts.assertEquals(activeSpan.get(), undefined);
+    asserts.assertEquals(activeSpan.active(), false);
+  });
+
+  it('getOr falls back outside any run scope', () => {
+    const fallback = spanNamed('fallback');
+    asserts.assertStrictEquals(activeSpan.getOr(fallback), fallback);
+  });
+
+  it('exposes the span inside run', () => {
+    const span = spanNamed('root');
+    activeSpan.run(span, () => {
+      asserts.assertStrictEquals(activeSpan.get(), span);
+      asserts.assertStrictEquals(activeSpan.getOr(spanNamed('other')), span);
+      asserts.assertEquals(activeSpan.active(), true);
+    });
+    asserts.assertEquals(activeSpan.get(), undefined);
+  });
+
+  it('survives await', async () => {
+    const span = spanNamed('async');
+    await activeSpan.run(span, async () => {
+      await new Promise((r) => setTimeout(r, 1));
+      asserts.assertStrictEquals(activeSpan.get(), span);
+    });
+  });
+
+  it('nests — the inner scope wins, the outer is restored', () => {
+    const outer = spanNamed('outer', '1'.repeat(16));
+    const inner = spanNamed('inner', '2'.repeat(16));
+    activeSpan.run(outer, () => {
+      activeSpan.run(inner, () => {
+        asserts.assertStrictEquals(activeSpan.get(), inner);
+      });
+      asserts.assertStrictEquals(activeSpan.get(), outer);
+    });
+  });
+
+  it('isolates concurrent flows', async () => {
+    const seen: Array<string | undefined> = [];
+    const flow = (name: string, delay: number) =>
+      activeSpan.run(spanNamed(name), async () => {
+        await new Promise((r) => setTimeout(r, delay));
+        seen.push(activeSpan.get()?.name);
+      });
+    await Promise.all([flow('f1', 5), flow('f2', 1)]);
+    asserts.assertArrayIncludes(seen, ['f1', 'f2']);
+  });
+
+  describe('one shared store, built on first use', () => {
+    // The store is created lazily, so what has to be proven is that every
+    // entry point still lands on the SAME instance — a second store would not
+    // observe the first's writes, and spans would silently stop nesting.
+
+    it('a Tracer reads the span this module put in scope', () => {
+      const tracer = new Tracer({ serviceName: 'shared' });
+      const span = spanNamed('from-store');
+      activeSpan.run(span, () => {
+        // `tracer.active()` is a different entry into the same store.
+        asserts.assertStrictEquals(tracer.active(), span);
+        asserts.assertEquals(tracer.logContext(), {
+          traceId: span.context.traceId,
+          spanId: span.context.spanId,
+        });
+      });
+    });
+
+    it('this module reads the span a Tracer put in scope', () => {
+      const tracer = new Tracer({ serviceName: 'shared' });
+      tracer.startActiveSpan('work', (span) => {
+        asserts.assertStrictEquals(activeSpan.get(), span);
+        asserts.assertEquals(activeSpan.active(), true);
+      });
+      asserts.assertEquals(activeSpan.get(), undefined);
+    });
+
+    it('spans still nest across an await, at depth', async () => {
+      const exporter = new MemoryExporter();
+      const tracer = new Tracer({ serviceName: 'nesting', exporter });
+      await tracer.startActiveSpan('outer', async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        // Started five frames deep and after an await — it must still find
+        // `outer` through the shared store.
+        await tracer.startActiveSpan('inner', async () => {
+          await new Promise((r) => setTimeout(r, 1));
+        });
+      });
+      const outer = exporter.find('outer')!;
+      const inner = exporter.find('inner')!;
+      asserts.assertEquals(inner.parentSpanId, outer.context.spanId);
+      asserts.assertEquals(inner.context.traceId, outer.context.traceId);
+      asserts.assertEquals(outer.parentSpanId, undefined);
+    });
+  });
+});
+
+describe('tracer.activeSpan (runtime without AsyncLocalStorage)', () => {
+  /**
+   * Stands in for a browser: the store can never be built. `createContext`
+   * raises exactly this on such a runtime, so the surface is exercised against
+   * the failure it actually degrades around.
+   */
+  const noAsyncLocalStorage = new TypeError(
+    "@tundralibs/ambient requires 'AsyncLocalStorage' (node:async_hooks), " +
+      'which this runtime does not provide.',
+  );
+  const degraded = buildActiveSpan((): never => {
+    throw noAsyncLocalStorage;
+  });
+
+  it('get() returns undefined instead of throwing', () => {
+    asserts.assertEquals(degraded.get(), undefined);
+  });
+
+  it('getOr() returns the fallback instead of throwing', () => {
+    const fallback = spanNamed('fallback');
+    asserts.assertStrictEquals(degraded.getOr(fallback), fallback);
+  });
+
+  it('active() reports false instead of throwing', () => {
+    asserts.assertEquals(degraded.active(), false);
+  });
+
+  it('run() propagates the store error unchanged', () => {
+    const thrown = asserts.assertThrows(
+      () => degraded.run(spanNamed('never'), () => 'never'),
+      TypeError,
+      'AsyncLocalStorage',
+    );
+    asserts.assertStrictEquals(thrown, noAsyncLocalStorage);
+  });
+
+  it('run() does not run the callback when it throws', () => {
+    let ran = false;
+    asserts.assertThrows(() =>
+      degraded.run(spanNamed('never'), () => {
+        ran = true;
+      })
+    );
+    // Failing loudly is the point: silently running `fn` with no active span
+    // would produce orphaned root spans instead of a nested trace.
+    asserts.assertEquals(ran, false);
+  });
+
+  it('works normally again once the resolver supplies a store', () => {
+    // The seam is honoured in the working direction too, so the degradation
+    // above is genuinely driven by store availability and not by the seam
+    // itself being broken.
+    const store: Context<Span> = createContext<Span>();
+    const working = buildActiveSpan(() => store);
+    const span = spanNamed('w1');
+    working.run(span, () => {
+      asserts.assertStrictEquals(working.get(), span);
+      asserts.assertStrictEquals(working.getOr(spanNamed('other')), span);
+      asserts.assertEquals(working.active(), true);
+    });
+    asserts.assertEquals(working.get(), undefined);
+    asserts.assertEquals(working.active(), false);
+  });
+});

--- a/packages/tracer/activeSpan.ts
+++ b/packages/tracer/activeSpan.ts
@@ -15,13 +15,97 @@
  * @module
  */
 
-import { createContext } from '@tundralibs/ambient';
+import { type Context, createContext } from '@tundralibs/ambient';
 import type { Span } from './Span.ts';
+
+/** The single process-wide store, once built. See {@link requireStore}. */
+let store: Context<Span> | undefined;
+
+/**
+ * The store backing the active {@link Span}, built on first use and memoized
+ * thereafter. Construction is deferred rather than done at module scope purely
+ * so that *importing* `@tundralibs/tracer` is side-effect-free on runtimes
+ * without `AsyncLocalStorage` (a browser bundle); on every supported runtime
+ * the store is still a single process-wide instance shared by all callers, so
+ * spans nest across module boundaries exactly as before.
+ *
+ * @returns The one shared {@link Context}.
+ * @throws {TypeError} When the runtime provides no `AsyncLocalStorage`
+ *   (`node:async_hooks`) — raised by `createContext`.
+ */
+function requireStore(): Context<Span> {
+  return (store ??= createContext<Span>());
+}
+
+/**
+ * Build the active-span {@link Context} surface over `resolveStore` — the
+ * supplier of the backing store, which throws where the runtime cannot provide
+ * one.
+ *
+ * Exported (but not re-exported from the package root, so not public API) only
+ * so the ALS-less degradation path — unreachable on any supported runtime — is
+ * unit-testable via the `resolveStore` seam, mirroring `buildAmbient` in
+ * `@tundralibs/ambient`.
+ *
+ * @internal
+ * @param resolveStore - Supplies the shared {@link Context}; throws where none
+ *   can exist.
+ * @returns A {@link Context} bound to `resolveStore`.
+ */
+export function buildActiveSpan(
+  resolveStore: () => Context<Span>,
+): Context<Span> {
+  /**
+   * The store, or `undefined` where none can exist. The read-only members go
+   * through this so they keep their documented never-throws contract
+   * everywhere: no store means no active span, which is exactly the "called
+   * outside any span scope" case they already handle. `resolveStore` throws
+   * only for that one reason, so there is no other failure being swallowed
+   * here.
+   */
+  const readStore = (): Context<Span> | undefined => {
+    try {
+      return resolveStore();
+    } catch {
+      return undefined;
+    }
+  };
+
+  return {
+    run<R>(span: Span, fn: () => R): R {
+      return resolveStore().run(span, fn);
+    },
+
+    get(): Span | undefined {
+      return readStore()?.get();
+    },
+
+    getOr(fallback: Span): Span {
+      // Delegated rather than `?? fallback`-ed so the store keeps ownership of
+      // the `undefined`-vs-nullish distinction it documents.
+      const active = readStore();
+      if (active === undefined) return fallback;
+      return active.getOr(fallback);
+    },
+
+    active(): boolean {
+      return readStore()?.active() ?? false;
+    },
+  };
+}
 
 /**
  * The currently active {@link Span}, or `undefined` outside any span scope.
  * Prefer `tracer.active()` — this is the underlying store.
+ *
+ * The backing `AsyncLocalStorage` is built on first use, not at import, so the
+ * package imports cleanly on runtimes that have none (browsers). There, the
+ * read-only members degrade quietly — `get()` yields `undefined`, `getOr()` the
+ * fallback, `active()` `false`, all indistinguishable from being called outside
+ * a span — while `run()` throws, because establishing a scope is the one thing
+ * that cannot be faked.
+ *
+ * @throws {TypeError} From `run()` only, when the runtime provides no
+ *   `AsyncLocalStorage` (`node:async_hooks`) — e.g. a browser.
  */
-export const activeSpan: ReturnType<typeof createContext<Span>> = createContext<
-  Span
->();
+export const activeSpan: Context<Span> = buildActiveSpan(requireStore);

--- a/packages/tracer/docs/Tracer-Concepts.md
+++ b/packages/tracer/docs/Tracer-Concepts.md
@@ -92,6 +92,27 @@ Tracer keeps the active span in its **own** context store, separate from
 `ambient`'s shared `RequestContext`. Span lifecycle is tracer's concern; the
 request bag is the application's.
 
+### Runtimes without `AsyncLocalStorage`
+
+That store is built on **first use**, not at import, so importing
+`@tundralibs/tracer` succeeds everywhere — including a browser bundle, where
+`node:async_hooks` does not exist. What changes there is only what genuinely
+depends on a scope:
+
+- `tracer.active()` returns `undefined`, and `tracer.logContext()` /
+  `tracer.propagation()` return `{}` — exactly what they return outside any
+  span, so callers need no branch.
+- `startActiveSpan` (and the `wrap` / `wrapClient` witnesses built on it)
+  throws a `TypeError`. Establishing a scope is the one thing that cannot
+  degrade quietly: silently running the callback with no active span would
+  turn a nested trace into orphaned roots.
+- `startSpan`, `span.end()`, exporters and `inject` / `extract` need no
+  context at all, so manual span lifecycles and propagation keep working.
+
+On every supported runtime — Deno, Bun, Node >= 22 and Cloudflare Workers
+under `nodejs_compat` — the store is a single process-wide instance shared by
+every caller, so nesting behaves identically to a store built at import time.
+
 ## startSpan vs startActiveSpan
 
 |                       | `startSpan`             | `startActiveSpan`                |


### PR DESCRIPTION
## The defect

`packages/tracer/activeSpan.ts` called `createContext()` at **module scope**,
and `mod.ts` re-exports the result. On any runtime without `AsyncLocalStorage`
that line runs while the barrel is being evaluated, so **importing the package
threw**:

```
TypeError: @tundralibs/ambient requires 'AsyncLocalStorage' (node:async_hooks),
which this runtime does not provide. Supported runtimes: Deno, Bun, and Node.js >= 22.
```

Reproduced against the published `tracer@0.5.1` in a real Vite browser build —
`await import('@tundralibs/tracer')` failed outright. Not the tracing: the
import. That took the whole package out of reach of a browser bundle, including
everything that never needed async context (`startSpan`, `span.end()`,
exporters, `inject` / `extract`).

## The fix

Same bug class ambient 0.2.3 fixed, and this **mirrors that solution** rather
than inventing a second pattern for the same problem:

- the store is built on first use and memoized — `store ??= createContext()`;
- the accessor surface is built over a `resolveStore` supplier seam
  (`buildActiveSpan`, the analogue of ambient's `buildAmbient`), so the
  ALS-less paths are unit-testable without stubbing globals. Stubbing
  `process.getBuiltinModule` and re-importing does **not** work — a
  cache-busted module still resolves the already-cached dependency, so the stub
  silently tests nothing.

`buildActiveSpan` is exported from `activeSpan.ts` but deliberately **not**
re-exported from `mod.ts`, so it is not public API — again as ambient does.

It was the only module-scope ALS construction in the package: nothing else in
tracer's import graph touches `node:async_hooks`, `Deno.*` or `process.*` at
module scope (the other module-scope initialisers are a `crypto.getRandomValues`
id generator, two `Sampler` arrows and Guardian schemas, all browser-safe).

## Contract preserved

| | With `AsyncLocalStorage` (Deno / Bun / Node / Workers) | Without (browser) |
| --- | --- | --- |
| `import '@tundralibs/tracer'` | works | **now works** (threw before) |
| `activeSpan.get()` / `getOr()` / `active()` | unchanged | `undefined` / fallback / `false` — identical to being called outside any span |
| `activeSpan.run()`, `startActiveSpan`, `wrap`, `wrapClient` | unchanged | the existing ambient `TypeError`, at **call** time |
| `startSpan`, exporters, `inject` / `extract` | unchanged | work — they never needed a scope |
| store identity | one process-wide instance shared by every entry point, as before | n/a |

Establishing a scope is the one operation that cannot degrade quietly: running
`fn` with no active span would turn a nested trace into orphaned roots, so it
fails loudly instead. No public API, export name, or type change — `activeSpan`
is still exported from `mod.ts` with the same `Context<Span>` shape.

## Verification

**The goal, before vs after** — `deno bundle --platform=browser -o … packages/tracer/mod.ts`,
loaded with `process.getBuiltinModule` removed (and again with the entire
`process` global deleted):

```
# before
1. MODULE LOAD: FAILED -> @tundralibs/ambient requires 'AsyncLocalStorage' …

# after
1. MODULE LOAD: ok
2. activeSpan.get() -> undefined / active() -> false / getOr('fb') -> fb
3. activeSpan.run() -> TypeError: @tundralibs/ambient requires 'AsyncLocalStorage' …
4. new Tracer(...) -> ok, active() -> undefined, logContext() -> {}, propagation() -> {}
5. tracer.startActiveSpan() -> TypeError
   startSpan/end -> exported "manual"; inject -> 00-8e776d…-3ec23dc…-01
```

- **Tests green on all three CI runtimes**: `deno test` (12 files, 160 steps),
  `bun test` (141 pass / 5 skip), `node --import tsx --test` (141 pass).
- **`deno check`** clean on `mod.ts` and every subpath in `deno.json` exports
  (`./errors`, `./exporters`, `./exporters/otlp`, `./types`); repo-wide
  `deno task check`, `deno fmt --check`, `deno lint` and `deno publish --dry-run`
  (slow-types gate) all clean.
- **Shared-context semantics proven on a normal runtime** — the memoization is
  exactly where this could silently break, so `activeSpan.test.ts` asserts
  nesting (inner wins, outer restored), survival across `await`, concurrent
  isolation, and that **two separate entries share one store**: a `Tracer` reads
  the span this module put in scope and vice versa, and spans started after an
  `await` still parent correctly.
- **New ALS-less branches are covered by real tests** (`activeSpan.ts` at
  100% branch / function / line under `deno coverage`). No threshold lowered,
  no ignore comments added.

Docs: `docs/Tracer-Concepts.md` gains a short "Runtimes without
`AsyncLocalStorage`" section stating what degrades and what throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
