### PR TITLE
feat(norm): register engines lazily so Norm works on edge runtimes

### DIFF
--- a/packages/norm/Norm.test.ts
+++ b/packages/norm/Norm.test.ts
@@ -24,6 +24,9 @@ import {
   type Session,
   use,
 } from './mod.ts';
+// `runtimeOf` is the migration seam, not part of the public barrel — the
+// test reaches it directly to read the resolved executor's capabilities.
+import { runtimeOf } from './Norm.ts';
 
 type Row = Record<string, unknown>;
 
@@ -217,6 +220,74 @@ describe('norm.Norm (config + lifecycle + tx edges)', () => {
         database: 'd',
       } as never,
     });
+  });
+
+  it('database config: the fetch-only edge dialects construct engines lazily', () => {
+    // neon / turso / d1 are registered by the root barrel exactly like the
+    // four original dialects — no import beyond `@tundralibs/norm`, no
+    // connection attempted at construction.
+    const neon = new Norm({
+      database: {
+        dialect: 'neon',
+        host: 'ep-x.eu-central-1.aws.neon.tech',
+        token: 'tok',
+      },
+    });
+    const turso = new Norm({
+      database: {
+        dialect: 'turso',
+        url: 'https://db-org.turso.io',
+        authToken: 'tok',
+      },
+    });
+    const d1 = new Norm({
+      database: {
+        dialect: 'd1',
+        accountId: 'acct',
+        databaseId: 'db',
+        apiToken: 'tok',
+      },
+    });
+    // Each resolved to a SQL executor (not the Mongo one) and reports the
+    // dialect family its translator emits: Neon speaks Postgres, Turso and
+    // D1 speak SQLite — no oql change was needed for any of them.
+    for (
+      const [norm, dialect] of [
+        [neon, 'postgres'],
+        [turso, 'sqlite'],
+        [d1, 'sqlite'],
+      ] as const
+    ) {
+      const caps =
+        runtimeOf(norm.use(Schema('S', { Users }))).executor.capabilities;
+      asserts.assertEquals(caps.dialect, dialect);
+      // One-shot HTTP: nothing survives a call, so no transactions.
+      asserts.assertEquals(caps.transactions, false);
+    }
+  });
+
+  it('mongo is detected without an instanceof check on the driver class', () => {
+    // `wrap()` keys on the engine's own `Engine` label so `Norm.ts` needs
+    // no value import of MongoEngine. A SQL engine must not be routed to
+    // the Mongo executor, and vice versa.
+    const mongo = new Norm({
+      database: {
+        dialect: 'mongo',
+        uri: 'mongodb://localhost:27017',
+        database: 'd',
+      } as never,
+    });
+    const sqlite = new Norm({ database: { dialect: 'sqlite', path: dir } });
+    asserts.assertEquals(
+      runtimeOf(mongo.use(Schema('S', { Users }))).executor.capabilities
+        .dialect,
+      'mongo',
+    );
+    asserts.assertEquals(
+      runtimeOf(sqlite.use(Schema('S', { Users }))).executor.capabilities
+        .dialect,
+      'sqlite',
+    );
   });
 
   it('NormDb: entities getter, lifecycle proxies', async () => {

--- a/packages/norm/Norm.ts
+++ b/packages/norm/Norm.ts
@@ -28,19 +28,28 @@
  * @since 1.0.0
  */
 
-import {
-  type EngineQueryResult,
-  type EngineTransactionOptions,
-  MariaEngine,
-  type MariaEngineOptions,
+// EVERY `@tundralibs/drivers` import in this file is TYPE-ONLY, and must
+// stay that way: a value import of an engine class here lands in the
+// runtime graph of every norm consumer, which is exactly what stopped
+// norm bundling for edge runtimes (the native SQLite adapter's
+// `bun:sqlite` / `@db/sqlite` specifiers). Engines are constructed
+// through the `engines/` registry instead.
+import type {
+  EngineQueryResult,
+  EngineTransactionOptions,
+} from '@tundralibs/drivers/types';
+import type { D1EngineOptions } from '@tundralibs/drivers/d1';
+import type { MariaEngineOptions } from '@tundralibs/drivers/maria';
+import type {
   MongoEngine,
-  type MongoEngineOptions,
-  PostgresEngine,
-  type PostgresEngineOptions,
-  SQLiteEngine,
-  type SQLiteEngineOptions,
-} from '@tundralibs/drivers';
+  MongoEngineOptions,
+} from '@tundralibs/drivers/mongo';
+import type { NeonHttpEngineOptions } from '@tundralibs/drivers/neon';
+import type { PostgresEngineOptions } from '@tundralibs/drivers/postgres';
+import type { SQLiteEngineOptions } from '@tundralibs/drivers/sqlite';
+import type { TursoEngineOptions } from '@tundralibs/drivers/turso';
 import { type EventOptionKeys, Options } from '@tundralibs/utils';
+import { resolveEngineFactory } from './engines/mod.ts';
 import {
   type AnyDefinition,
   type ComposedSchema,
@@ -86,7 +95,15 @@ import {
 } from './scope.ts';
 import { coerceCount, makeResult, type NormResult, ulid } from './result.ts';
 
-/** Engine construction config, discriminated by dialect. */
+/**
+ * Engine construction config, discriminated by dialect.
+ *
+ * `neon` (Postgres over HTTP), `turso` and `d1` (SQLite over HTTP) are
+ * the fetch-only engines — the ones that work on an edge runtime. The
+ * dialect's engine module must be registered before construction; the
+ * root `@tundralibs/norm` barrel registers all seven, while
+ * `@tundralibs/norm/core` registers none (see `engines/registry.ts`).
+ */
 export type DatabaseConfig =
   | (
     & { dialect: 'postgres' }
@@ -94,7 +111,10 @@ export type DatabaseConfig =
   )
   | ({ dialect: 'maria' } & MariaEngineOptions)
   | ({ dialect: 'sqlite' } & SQLiteEngineOptions)
-  | ({ dialect: 'mongo' } & MongoEngineOptions);
+  | ({ dialect: 'mongo' } & MongoEngineOptions)
+  | ({ dialect: 'neon' } & NeonHttpEngineOptions)
+  | ({ dialect: 'turso' } & TursoEngineOptions)
+  | ({ dialect: 'd1' } & D1EngineOptions);
 
 /** Constructor options. Exactly one of `engine` / `database`. */
 export type NormConfig = {
@@ -234,7 +254,7 @@ export class Norm extends Options<NormConfig, NormEvents> {
         void this._emit('slowQuery', id, r.id, r.time, r.transactionId),
     );
     // transactionTimeout is a SQL-only engine event (Mongo has no tx).
-    if (!(engine instanceof MongoEngine)) {
+    if (!isMongoEngine(engine)) {
       engine.on(
         'transactionTimeout',
         (_id: string, txId: string) =>
@@ -718,9 +738,7 @@ export class NormDb<R, Scope extends string = never> {
   }
 }
 
-/**
- * Pick the executor: caller-supplied `engine`, or constructed from
- * `database` via the matching dialect driver.
+/** Instance-name counter for engines Norm constructs itself.
  *
  * @internal
  */
@@ -732,12 +750,38 @@ type ResolvedEngine = {
   engine: AnySQLEngine | MongoEngine;
 };
 
+/**
+ * Is this the Mongo engine? Checked on the engine's own `Engine` label
+ * rather than `instanceof MongoEngine`, because the class reference would
+ * be a VALUE import of `@tundralibs/drivers/mongo` — dragging the Mongo
+ * driver into every consumer's bundle for a branch that only needs to
+ * know "SQL or not". Every driver engine sets `Engine`; a bare object
+ * used as a test double has none and is treated as SQL, exactly as the
+ * `instanceof` check treated it.
+ */
+function isMongoEngine(
+  engine: AnySQLEngine | MongoEngine,
+): engine is MongoEngine {
+  return (engine as { Engine?: string })?.Engine === 'MONGO';
+}
+
 function wrap(engine: AnySQLEngine | MongoEngine): ResolvedEngine {
-  return engine instanceof MongoEngine
+  return isMongoEngine(engine)
     ? { executor: mongoExecutor(engine), engine }
     : { executor: sqlExecutor(engine), engine };
 }
 
+/**
+ * Pick the executor: caller-supplied `engine`, or one built from
+ * `database` by the dialect's registered factory.
+ *
+ * @throws {NormError} `INVALID_ENGINE_CONFIG` when both `engine` and
+ *   `database` are given, when neither is, or when `database.dialect` is
+ *   not a known dialect.
+ * @throws {NormError} `ENGINE_NOT_REGISTERED` when the dialect is known
+ *   but its `@tundralibs/norm/engines/<dialect>` module has not been
+ *   imported.
+ */
 function resolveEngine(cfg: NormConfig): ResolvedEngine {
   if (cfg.engine !== undefined && cfg.database !== undefined) {
     throw new NormError(
@@ -757,34 +801,11 @@ function resolveEngine(cfg: NormConfig): ResolvedEngine {
     );
   }
   const name = `norm-${++normEngineCounter}`;
-  const db = cfg.database;
-  switch (db.dialect) {
-    case 'postgres': {
-      const { dialect: _d, ...rest } = db;
-      return wrap(new PostgresEngine(name, rest));
-    }
-    case 'maria': {
-      const { dialect: _d, ...rest } = db;
-      return wrap(new MariaEngine(name, rest));
-    }
-    case 'sqlite': {
-      const { dialect: _d, ...rest } = db;
-      return wrap(new SQLiteEngine(name, rest));
-    }
-    case 'mongo': {
-      const { dialect: _d, ...rest } = db;
-      return wrap(new MongoEngine(name, rest));
-    }
-    default: {
-      const exhaustive: never = db;
-      throw new NormError(
-        `new Norm({ database }): unknown dialect '${
-          (exhaustive as { dialect: string }).dialect
-        }'`,
-        { code: 'INVALID_ENGINE_CONFIG' },
-      );
-    }
-  }
+  const { dialect, ...rest } = cfg.database;
+  // Registry lookup, not a `switch` over imported engine classes — see
+  // `engines/registry.ts` for why the classes cannot live in this file.
+  const factory = resolveEngineFactory(dialect);
+  return wrap(factory(name, rest as Record<string, unknown>));
 }
 
 // ---------------------------------------------------------------------

--- a/packages/norm/README.md
+++ b/packages/norm/README.md
@@ -3,7 +3,8 @@
 A typed, cross-runtime ORM built on [OQL](../oql/README.md) and
 [@tundralibs/drivers](../drivers/README.md) — one schema declaration
 drives your types, validation, migrations, and **at-rest column
-encryption**, across PostgreSQL, MariaDB/MySQL, SQLite, and MongoDB.
+encryption**, across PostgreSQL, MariaDB/MySQL, SQLite, and MongoDB —
+and, on edge runtimes, Neon, Turso, and Cloudflare D1 over HTTP.
 
 ![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
 ![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
@@ -25,18 +26,62 @@ NORM derives:
   is unchanged), filter encrypted columns transparently through digest
   siblings, and mask sensitive values on read.
 
-The same typed code runs against four engines — three SQL dialects and
-a document store — and is exercised end-to-end against all four by the
-live test suite.
+The same typed code runs against seven engines — four self-hosted
+(`postgres`, `maria`, `sqlite`, `mongo`) and three fetch-only ones for
+edge/serverless runtimes (`neon`, `turso`, `d1`). The four self-hosted
+dialects are exercised end-to-end by the live test suite.
 
 ## Modules
 
-| Module                          | Import                        | Description                                                          |
-| ------------------------------- | ----------------------------- | -------------------------------------------------------------------- |
-| Root                            | `@tundralibs/norm`            | `Norm`, `NormDb`, repos, `Column`, `Entity`, `Schema`, `use`.        |
-| [Definition](definition/mod.ts) | `@tundralibs/norm/definition` | Builders, entity/schema types, doc + snapshot emitters.              |
-| [Migrations](migrations/mod.ts) | `@tundralibs/norm/migrations` | The `Migrator` — snapshot / plan / apply / rollback.                 |
-| [Asserts](asserts/mod.ts)       | `@tundralibs/norm/asserts`    | Validate hand-built definitions with the same rules `Entity()` uses. |
+| Module                          | Import                               | Description                                                                                                |
+| ------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Root                            | `@tundralibs/norm`                   | `Norm`, `NormDb`, repos, `Column`, `Entity`, `Schema`, `use` — plus every dialect.                         |
+| [Core](core.ts)                 | `@tundralibs/norm/core`              | The same surface with NO dialect registered — the edge/serverless entry point.                             |
+| [Definition](definition/mod.ts) | `@tundralibs/norm/definition`        | Builders, entity/schema types, doc + snapshot emitters.                                                    |
+| [Migrations](migrations/mod.ts) | `@tundralibs/norm/migrations`        | The `Migrator` — snapshot / plan / apply / rollback.                                                       |
+| [Asserts](asserts/mod.ts)       | `@tundralibs/norm/asserts`           | Validate hand-built definitions with the same rules `Entity()` uses.                                       |
+| [Engines](engines/mod.ts)       | `@tundralibs/norm/engines`           | `registerEngine` / `resolveEngineFactory` — the dialect registry.                                          |
+| Engine (one per dialect)        | `@tundralibs/norm/engines/<dialect>` | Side-effect module registering one dialect: `postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`, `d1`. |
+
+### Running on the edge
+
+`@tundralibs/norm` (the root barrel) registers all seven dialects, so
+any `database` config works with no extra import. The cost is that every
+driver — including the **native** SQLite adapter — is in the bundle, and
+its `bun:sqlite` / `@db/sqlite` specifiers cannot be resolved by an edge
+bundler.
+
+On Cloudflare Workers, Vercel Edge, or Vite, import `@tundralibs/norm/core`
+(identical exports, zero dialects registered) plus the one engine module
+you need:
+
+```typescript
+import '@tundralibs/norm/engines/d1'; // or /neon, or /turso
+import { Column, Entity, Norm, Schema } from '@tundralibs/norm/core';
+
+const norm = new Norm({
+  database: {
+    dialect: 'd1',
+    accountId: env.CF_ACCOUNT_ID,
+    databaseId: env.D1_DATABASE_ID,
+    apiToken: env.CF_API_TOKEN,
+  },
+});
+```
+
+A dialect whose module was never imported throws a `NormError`
+(`ENGINE_NOT_REGISTERED`) at construction, naming the import to add.
+That matters most for `sqlite`: Cloudflare's `unenv` polyfill _resolves_
+`node:sqlite` and even exposes `DatabaseSync`, but constructing one
+throws `Illegal constructor` on workerd — so without the registry a
+native-SQLite build would sail through CI and fail in production. Native
+SQLite cannot work on Workers at all; `d1` and `turso` (both SQLite over
+HTTP) are the supported paths, and `neon` is the Postgres one.
+
+The edge engines are one-shot HTTP: no pooling and no transactions, which
+`executor.capabilities` reports honestly. They reuse the same OQL
+translators as their self-hosted counterparts (`neon` → Postgres,
+`turso` / `d1` → SQLite), so the SQL norm generates is unchanged.
 
 ## Installation
 

--- a/packages/norm/core.test.ts
+++ b/packages/norm/core.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The two entry points. `@tundralibs/norm` (root barrel) and
+ * `@tundralibs/norm/core` must expose the SAME surface — the only
+ * difference is that the root barrel also imports the seven
+ * `engines/<dialect>` side-effect modules. That is what makes the split
+ * non-breaking: an existing consumer's import keeps every export AND
+ * every dialect.
+ */
+
+import { describe, it } from '@tundralibs/compat/test';
+import * as asserts from '@std/asserts';
+import * as core from './core.ts';
+import * as barrel from './mod.ts';
+
+describe('norm.core (edge entry point)', () => {
+  it('exports the same surface as the root barrel', () => {
+    const coreKeys = Object.keys(core).sort();
+    const barrelKeys = Object.keys(barrel).sort();
+    asserts.assertEquals(barrelKeys, coreKeys);
+    asserts.assertEquals(coreKeys.length > 40, true);
+  });
+
+  it('exports the SAME Norm class object, not a copy', () => {
+    asserts.assertStrictEquals(core.Norm, barrel.Norm);
+    asserts.assertStrictEquals(core.NormDb, barrel.NormDb);
+    asserts.assertStrictEquals(core.NormError, barrel.NormError);
+  });
+
+  it('re-exports the registry so a consumer can register its own engine', () => {
+    asserts.assertEquals(typeof core.registerEngine, 'function');
+    asserts.assertEquals(typeof core.resolveEngineFactory, 'function');
+  });
+
+  it('constructs an edge Norm from core + one engine module', async () => {
+    // Exactly what a Workers consumer writes: the core entry point plus
+    // the single dialect it uses. No other driver is in the graph.
+    await import('./engines/d1.ts');
+    const norm = new core.Norm({
+      database: {
+        dialect: 'd1',
+        accountId: 'acct',
+        databaseId: 'db',
+        apiToken: 'tok',
+      },
+    });
+    asserts.assertEquals(norm instanceof barrel.Norm, true);
+    // The engine really was built by the D1 factory: SQLite dialect, and
+    // one-shot REST means no transactions.
+    const db = norm.use(core.Schema('S', {
+      Users: core.Entity('users', { id: core.Column.integer() }, {
+        pk: ['id'],
+      }),
+    }));
+    await asserts.assertRejects(
+      () => db.transaction(() => Promise.resolve(1)),
+      core.NormUnsupportedError,
+    );
+  });
+});

--- a/packages/norm/core.ts
+++ b/packages/norm/core.ts
@@ -1,0 +1,161 @@
+/**
+ * `@tundralibs/norm/core` — norm's ENTIRE surface (definition layer +
+ * runtime), with NO engine registered.
+ *
+ * Identical to the root `@tundralibs/norm` barrel except for one thing:
+ * the root barrel also imports all seven `engines/<dialect>` modules, so
+ * `new Norm({ database: { dialect } })` works out of the box for every
+ * dialect — and, as a consequence, every driver (including the native
+ * SQLite adapter and its `bun:sqlite` / `@db/sqlite` specifiers) is in
+ * the bundle. That is fine on a server and fatal on an edge runtime.
+ *
+ * Import from here on Cloudflare Workers / Vercel Edge / Vite, and add
+ * only the engine you actually use:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/d1';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({ database: { dialect: 'd1', accountId, databaseId, apiToken } });
+ * ```
+ *
+ * A dialect whose module was not imported fails at construction with a
+ * `NormError` (`ENGINE_NOT_REGISTERED`) naming the import to add.
+ *
+ * @module
+ */
+
+// ─── Runtime ─────────────────────────────────────────────────────────
+export { type DatabaseConfig, Norm, type NormConfig, NormDb } from './Norm.ts';
+export {
+  type NormDialect,
+  type NormEngineFactory,
+  registerEngine,
+  resolveEngineFactory,
+} from './engines/mod.ts';
+export { coerceCount, type NormResult, ulid } from './result.ts';
+export {
+  rotateKey,
+  type RotateKeyEntityReport,
+  type RotateKeyOptions,
+  type RotateKeyProgress,
+  type RotateKeyReport,
+} from './rotate.ts';
+export type { NormScope, ScopeInput, ScopeValue } from './scope.ts';
+export {
+  type FindOptions,
+  QueryAccessor,
+  ReadRepo,
+  Repo,
+  type RepoFor,
+} from './Repo.ts';
+export {
+  type AnySQLEngine,
+  bindTx,
+  type Executor,
+  type ExecutorCapabilities,
+  type ExecutorQuery,
+  mongoExecutor,
+  type NormDMLQuery,
+  type Session,
+  sqlExecutor,
+} from './executor.ts';
+export {
+  type CompiledEntity,
+  compileRuntime,
+  type NormCrypto,
+  type NormEmit,
+  type NormEvents,
+  type ReverseMap,
+  type ReverseRelation,
+  type Runtime,
+  type Witness,
+  type WitnessInfo,
+} from './compile.ts';
+export {
+  buildCellGuardian,
+  buildWriteGuardians,
+  validateRows,
+  type WriteGuardians,
+} from './guardians.ts';
+export {
+  canonicalizePlain,
+  type CryptoOverrides,
+  decodePlain,
+  DEFAULT_ENCRYPT_ALGORITHM,
+  DEFAULT_HASH_ALGORITHM,
+  type EncryptAlgorithm,
+  type HashAlgorithm,
+  pbkdf2Verify,
+  SIBLING_HASH_ALGORITHM,
+} from './crypto.ts';
+export {
+  type AdvisoryLockErrorMeta,
+  type CryptoErrorMeta,
+  type DefinitionIssue,
+  NormAdvisoryLockError,
+  NormCryptoError,
+  NormDefinitionError,
+  NormError,
+  type NormErrorCode,
+  NormHookError,
+  NormQueryError,
+  NormUnsupportedError,
+  NormValidationError,
+  type QueryErrorMeta,
+  type ValidationIssue,
+} from './errors/mod.ts';
+
+// ─── Definition layer ────────────────────────────────────────────────
+
+export {
+  type AnyColumnBuilder,
+  type AnyDefinition,
+  Column,
+  ColumnBuilder,
+  type ColumnSnapshot,
+  type ColumnSpec,
+  type ComposedSchema,
+  DateColumnBuilder,
+  type DefaultInput,
+  type DefaultRowOf,
+  DIGEST_LENGTHS,
+  type DigestAlgorithm,
+  DigestColumnBuilder,
+  type EmittedForeignKey,
+  EncryptedColumnBuilder,
+  Entity,
+  type EntityQueryOptions,
+  type EntitySnapshot,
+  type EntityTableOptions,
+  type EntityViewOptions,
+  type ExpressionDefault,
+  type FilterOf,
+  type FilterShapeOf,
+  type ForeignKeyDef,
+  HashedColumnBuilder,
+  type InsertOf,
+  MaskColumnBuilder,
+  NumberColumnBuilder,
+  type PrimaryKeyOf,
+  type ProjectedRowOf,
+  type ProjectionInput,
+  type QueryDefinition,
+  type ReadHooks,
+  type ReadRowOf,
+  type RowOf,
+  Schema,
+  type SchemaDefinition,
+  type SchemaValue,
+  type Snapshot,
+  snapshot,
+  StringColumnBuilder,
+  type TableDefinition,
+  type TableHooks,
+  toMarkdown,
+  toMermaidERD,
+  toPlantUML,
+  type UpdateOf,
+  use,
+  type ViewDefinition,
+} from './definition/mod.ts';

--- a/packages/norm/deno.json
+++ b/packages/norm/deno.json
@@ -5,10 +5,19 @@
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",
+    "./core": "./core.ts",
     "./errors": "./errors/mod.ts",
     "./definition": "./definition/mod.ts",
     "./migrations": "./migrations/mod.ts",
-    "./asserts": "./asserts/mod.ts"
+    "./asserts": "./asserts/mod.ts",
+    "./engines": "./engines/mod.ts",
+    "./engines/postgres": "./engines/postgres.ts",
+    "./engines/maria": "./engines/maria.ts",
+    "./engines/sqlite": "./engines/sqlite.ts",
+    "./engines/mongo": "./engines/mongo.ts",
+    "./engines/neon": "./engines/neon.ts",
+    "./engines/turso": "./engines/turso.ts",
+    "./engines/d1": "./engines/d1.ts"
   },
   "imports": {}
 }

--- a/packages/norm/docs/NORM-Guide.md
+++ b/packages/norm/docs/NORM-Guide.md
@@ -53,6 +53,14 @@ const norm = new Norm({
 });
 ```
 
+`dialect` is one of `postgres`, `maria`, `sqlite`, `mongo` (self-hosted)
+or `neon`, `turso`, `d1` (fetch-only, for edge/serverless runtimes). The
+root `@tundralibs/norm` barrel registers all seven. On an edge runtime,
+import `@tundralibs/norm/core` — the same surface with nothing registered
+— plus the single `@tundralibs/norm/engines/<dialect>` module you need, so
+no native driver ever enters the bundle. See the package README for the
+full rationale.
+
 ## 2. Model the schema
 
 Keep one entity per file and one folder per schema — the folder is the

--- a/packages/norm/engines/d1.ts
+++ b/packages/norm/engines/d1.ts
@@ -1,0 +1,36 @@
+/**
+ * @module
+ *
+ * Registers the `d1` dialect — SQLite over Cloudflare D1's REST API.
+ * Import for its side effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/d1';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({
+ *   database: {
+ *     dialect: 'd1',
+ *     accountId: env.CF_ACCOUNT_ID,
+ *     databaseId: env.D1_DATABASE_ID,
+ *     apiToken: env.CF_API_TOKEN,
+ *   },
+ * });
+ * ```
+ *
+ * Edge-safe: `fetch()` only, no native SQLite binding. The engine reuses
+ * the SQLite OQL translator, so norm's SQL generation is identical to the
+ * `sqlite` dialect; only the transport differs (one-shot REST, so no
+ * pooling and no transactions).
+ *
+ * @since 1.2.0
+ */
+
+import { D1Engine } from '@tundralibs/drivers/d1';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'd1',
+  (name: string, options: ConstructorParameters<typeof D1Engine>[1]) =>
+    new D1Engine(name, options),
+);

--- a/packages/norm/engines/maria.ts
+++ b/packages/norm/engines/maria.ts
@@ -1,0 +1,28 @@
+/**
+ * @module
+ *
+ * Registers the `maria` dialect (MariaDB / MySQL). Import for its side
+ * effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/maria';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({ database: { dialect: 'maria', host, database, username } });
+ * ```
+ *
+ * The root `@tundralibs/norm` barrel already imports this module.
+ *
+ * Pulls the MariaDB TCP wire stack — NOT edge-safe.
+ *
+ * @since 1.2.0
+ */
+
+import { MariaEngine } from '@tundralibs/drivers/maria';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'maria',
+  (name: string, options: ConstructorParameters<typeof MariaEngine>[1]) =>
+    new MariaEngine(name, options),
+);

--- a/packages/norm/engines/mod.ts
+++ b/packages/norm/engines/mod.ts
@@ -1,0 +1,16 @@
+/**
+ * @module
+ *
+ * Barrel for the engine registry. Importing this module registers
+ * NOTHING — the per-dialect side-effect modules
+ * (`@tundralibs/norm/engines/postgres`, `.../d1`, …) do that.
+ *
+ * @since 1.2.0
+ */
+
+export {
+  type NormDialect,
+  type NormEngineFactory,
+  registerEngine,
+  resolveEngineFactory,
+} from './registry.ts';

--- a/packages/norm/engines/mongo.ts
+++ b/packages/norm/engines/mongo.ts
@@ -1,0 +1,27 @@
+/**
+ * @module
+ *
+ * Registers the `mongo` dialect. Import for its side effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/mongo';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({ database: { dialect: 'mongo', host, database } });
+ * ```
+ *
+ * The root `@tundralibs/norm` barrel already imports this module.
+ *
+ * Pulls the MongoDB driver and its TCP transport — NOT edge-safe.
+ *
+ * @since 1.2.0
+ */
+
+import { MongoEngine } from '@tundralibs/drivers/mongo';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'mongo',
+  (name: string, options: ConstructorParameters<typeof MongoEngine>[1]) =>
+    new MongoEngine(name, options),
+);

--- a/packages/norm/engines/neon.ts
+++ b/packages/norm/engines/neon.ts
@@ -1,0 +1,32 @@
+/**
+ * @module
+ *
+ * Registers the `neon` dialect — Postgres over Neon's HTTP query API.
+ * Import for its side effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/neon';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({
+ *   database: { dialect: 'neon', host: env.NEON_HOST, connectionString: env.NEON_URL },
+ * });
+ * ```
+ *
+ * Edge-safe: `fetch()` only, no TCP, no native binding. The engine reuses
+ * the Postgres OQL translator, so norm's SQL generation is identical to
+ * the `postgres` dialect; only the transport differs (one-shot HTTP, so
+ * no pooling and no transactions — `executor.capabilities` reports that
+ * honestly).
+ *
+ * @since 1.2.0
+ */
+
+import { NeonHttpEngine } from '@tundralibs/drivers/neon';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'neon',
+  (name: string, options: ConstructorParameters<typeof NeonHttpEngine>[1]) =>
+    new NeonHttpEngine(name, options),
+);

--- a/packages/norm/engines/postgres.ts
+++ b/packages/norm/engines/postgres.ts
@@ -1,0 +1,27 @@
+/**
+ * @module
+ *
+ * Registers the `postgres` dialect. Import for its side effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/postgres';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({ database: { dialect: 'postgres', host, database, username } });
+ * ```
+ *
+ * The root `@tundralibs/norm` barrel already imports this module.
+ *
+ * Pulls the Postgres TCP wire stack — NOT edge-safe; use `neon` there.
+ *
+ * @since 1.2.0
+ */
+
+import { PostgresEngine } from '@tundralibs/drivers/postgres';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'postgres',
+  (name: string, options: ConstructorParameters<typeof PostgresEngine>[1]) =>
+    new PostgresEngine(name, options),
+);

--- a/packages/norm/engines/registry.test.ts
+++ b/packages/norm/engines/registry.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Engine registry: registration, lookup, and the two failure modes
+ * (`unknown dialect` vs `known dialect, module never imported`). Plus the
+ * invariant the whole registry exists for — nothing in `core.ts`'s
+ * RUNTIME import graph reaches a native database binding.
+ */
+
+import { describe, it } from '@tundralibs/compat/test';
+import * as asserts from '@std/asserts';
+import { NormError } from '../errors/mod.ts';
+import {
+  type NormDialect,
+  registerEngine,
+  resolveEngineFactory,
+} from './registry.ts';
+
+const ALL_DIALECTS: readonly NormDialect[] = [
+  'postgres',
+  'maria',
+  'sqlite',
+  'mongo',
+  'neon',
+  'turso',
+  'd1',
+];
+
+/**
+ * A registry instance nothing else has touched. Test files share module
+ * state inside one runner process, and any file that imports the root
+ * barrel registers all seven dialects — so the "not registered" paths are
+ * exercised on a fresh module instance, obtained with a cache-busting
+ * query string. `../errors/mod.ts` is imported WITHOUT the query, so the
+ * fresh copy throws the same `NormError` class.
+ */
+function freshRegistry(): Promise<typeof import('./registry.ts')> {
+  const nonce = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return import(`./registry.ts?case=${nonce}`) as Promise<
+    typeof import('./registry.ts')
+  >;
+}
+
+/** Minimal stand-in with the one member the registry's factory
+ * constraint requires. */
+const fakeEngine = (label: string) => ({ Engine: label });
+
+describe('norm.engines.registry', () => {
+  it('a known dialect with no engine module imported throws an actionable NormError', async () => {
+    const { resolveEngineFactory: resolve } = await freshRegistry();
+    const err = asserts.assertThrows(
+      () => resolve('d1'),
+      NormError,
+    ) as NormError;
+    asserts.assertEquals(err.code, 'ENGINE_NOT_REGISTERED');
+    // The message must name the exact import that fixes it — this is the
+    // whole point of failing loudly instead of resolving a driver that
+    // cannot run on the target runtime.
+    asserts.assertStringIncludes(err.message, `'d1'`);
+    asserts.assertStringIncludes(
+      err.message,
+      '@tundralibs/norm/engines/d1',
+    );
+    asserts.assertStringIncludes(err.message, '@tundralibs/norm');
+    asserts.assertEquals(
+      (err.context as { dialect?: string }).dialect,
+      'd1',
+    );
+  });
+
+  it('every dialect reports its own engine module in the error', async () => {
+    const { resolveEngineFactory: resolve } = await freshRegistry();
+    for (const dialect of ALL_DIALECTS) {
+      const err = asserts.assertThrows(
+        () => resolve(dialect),
+        NormError,
+      ) as NormError;
+      asserts.assertEquals(err.code, 'ENGINE_NOT_REGISTERED');
+      asserts.assertStringIncludes(
+        err.message,
+        `@tundralibs/norm/engines/${dialect}`,
+      );
+    }
+  });
+
+  it('a dialect that does not exist at all keeps the original message', async () => {
+    const { resolveEngineFactory: resolve } = await freshRegistry();
+    const err = asserts.assertThrows(
+      () => resolve('oracle'),
+      NormError,
+    ) as NormError;
+    asserts.assertEquals(err.code, 'INVALID_ENGINE_CONFIG');
+    asserts.assertStringIncludes(err.message, `unknown dialect 'oracle'`);
+  });
+
+  it('a registered factory is returned and receives name + options', async () => {
+    const { registerEngine: register, resolveEngineFactory: resolve } =
+      await freshRegistry();
+    const seen: Array<[string, unknown]> = [];
+    register('turso', (name: string, options: { url: string }) => {
+      seen.push([name, options]);
+      return fakeEngine('TURSO');
+    });
+    const factory = resolve('turso');
+    const engine = factory('norm-7', { url: 'libsql://x' });
+    asserts.assertEquals(seen, [['norm-7', { url: 'libsql://x' }]]);
+    asserts.assertEquals(
+      (engine as unknown as { Engine: string }).Engine,
+      'TURSO',
+    );
+    // Registering one dialect must not register any other.
+    asserts.assertThrows(() => resolve('neon'), NormError);
+  });
+
+  it('re-registering a dialect replaces the previous factory', async () => {
+    const { registerEngine: register, resolveEngineFactory: resolve } =
+      await freshRegistry();
+    register('neon', () => fakeEngine('FIRST'));
+    register('neon', () => fakeEngine('SECOND'));
+    const engine = resolve('neon')('norm-1', {});
+    asserts.assertEquals(
+      (engine as unknown as { Engine: string }).Engine,
+      'SECOND',
+    );
+  });
+
+  it('the root barrel registers all seven dialects', async () => {
+    // The shared (statically imported) registry — importing the root
+    // barrel is exactly what an existing consumer does.
+    await import('../mod.ts');
+    for (const dialect of ALL_DIALECTS) {
+      asserts.assertEquals(
+        typeof resolveEngineFactory(dialect),
+        'function',
+        `${dialect} should be registered by the root barrel`,
+      );
+    }
+  });
+
+  it('registerEngine is exported for callers registering their own engine', () => {
+    asserts.assertEquals(typeof registerEngine, 'function');
+  });
+});
+
+describe({
+  name: 'norm.engines.registry - core.ts import graph',
+  // `deno info` is the graph oracle; Bun/Node have no equivalent.
+  deno: true,
+  bun: false,
+  node: false,
+  fn: () => {
+    it('core.ts reaches no native database binding at runtime', async () => {
+      const entry = new URL('../core.ts', import.meta.url).href;
+      const { stdout, code } = await new Deno.Command('deno', {
+        args: ['info', '--json', entry],
+        stdout: 'piped',
+        stderr: 'piped',
+      }).output();
+      asserts.assertEquals(code, 0, '`deno info --json core.ts` failed');
+      const info = JSON.parse(new TextDecoder().decode(stdout)) as {
+        roots: string[];
+        modules: Array<
+          {
+            specifier: string;
+            dependencies?: Array<{ code?: { specifier?: string } }>;
+          }
+        >;
+      };
+      // Walk CODE edges only: `import type` edges are erased by the TS ->
+      // JS compile and never reach a bundler, which is exactly why
+      // `Norm.ts` may keep type-only imports of the engine option types.
+      const bySpec = new Map(info.modules.map((m) => [m.specifier, m]));
+      const reachable = new Set<string>([info.roots[0]!]);
+      const queue = [info.roots[0]!];
+      while (queue.length) {
+        for (const dep of bySpec.get(queue.shift()!)?.dependencies ?? []) {
+          const next = dep.code?.specifier;
+          if (!next || reachable.has(next)) continue;
+          reachable.add(next);
+          queue.push(next);
+        }
+      }
+      const forbidden = [...reachable].filter((spec) =>
+        /^bun:sqlite$/.test(spec) ||
+        /@db\/sqlite/.test(spec) || /\bsqlite_deno\b/.test(spec) ||
+        /better-sqlite3/.test(spec) ||
+        /(^|\/)mariadb(@|\/|$)/.test(spec) ||
+        /(^|\/)mongodb(@|\/|$)/.test(spec)
+      );
+      asserts.assertEquals(
+        forbidden,
+        [],
+        `@tundralibs/norm/core must not pull a database driver into the ` +
+          `runtime graph — a value import crept back into the barrel`,
+      );
+      // Sanity: the walk actually visited the package.
+      asserts.assertEquals(reachable.size > 10, true);
+    });
+  },
+});

--- a/packages/norm/engines/registry.ts
+++ b/packages/norm/engines/registry.ts
@@ -1,0 +1,135 @@
+/**
+ * @module
+ *
+ * The dialect → engine-factory registry behind `new Norm({ database })`.
+ *
+ * `Norm.ts` used to `import { PostgresEngine, MariaEngine, SQLiteEngine,
+ * MongoEngine }` and switch on `database.dialect`. Those four value
+ * imports put every driver — including the NATIVE SQLite adapter, which
+ * loads `bun:sqlite` / `@db/sqlite` / `better-sqlite3` — in the runtime
+ * graph of anyone who imported norm at all, so bundling norm for an edge
+ * runtime (Cloudflare Workers, Vite) failed to resolve those specifiers
+ * before a single line ran.
+ *
+ * Now the switch is a `Map` lookup and each dialect's engine class lives
+ * in its own side-effect module (`engines/<dialect>.ts`) that registers a
+ * factory when — and only when — it is imported. The root `mod.ts` imports
+ * all seven, so every existing consumer is unaffected;
+ * `@tundralibs/norm/core` imports none, so an edge consumer pulls in
+ * exactly the engine it asked for.
+ *
+ * @since 1.2.0
+ */
+
+import { NormError } from '../errors/mod.ts';
+import type { AnySQLEngine } from '../executor.ts';
+import type { MongoEngine } from '@tundralibs/drivers/mongo';
+
+/**
+ * Every dialect `new Norm({ database })` understands. Mirrors the
+ * `dialect` discriminant of `DatabaseConfig` in `Norm.ts`; a dialect
+ * listed here still has to be REGISTERED (by importing its
+ * `engines/<dialect>.ts` module) before it can be constructed.
+ *
+ * `neon` (Postgres over HTTP), `turso` and `d1` (SQLite over HTTP) are
+ * the fetch-only engines — the only ones that work on an edge runtime.
+ */
+export type NormDialect =
+  | 'postgres'
+  | 'maria'
+  | 'sqlite'
+  | 'mongo'
+  | 'neon'
+  | 'turso'
+  | 'd1';
+
+/**
+ * Builds a driver engine from the `database` config minus its `dialect`
+ * key. Registered per dialect by the `engines/<dialect>.ts` modules; the
+ * options are re-typed to the concrete engine's option type there.
+ */
+export type NormEngineFactory = (
+  name: string,
+  options: Record<string, unknown>,
+) => AnySQLEngine | MongoEngine;
+
+/** Module-private — the only mutable state in the registry. */
+const ENGINE_FACTORIES: Map<string, NormEngineFactory> = new Map();
+
+/** Import specifier that registers each dialect, quoted in the error. */
+const ENGINE_MODULES: Readonly<Record<NormDialect, string>> = {
+  postgres: '@tundralibs/norm/engines/postgres',
+  maria: '@tundralibs/norm/engines/maria',
+  sqlite: '@tundralibs/norm/engines/sqlite',
+  mongo: '@tundralibs/norm/engines/mongo',
+  neon: '@tundralibs/norm/engines/neon',
+  turso: '@tundralibs/norm/engines/turso',
+  d1: '@tundralibs/norm/engines/d1',
+};
+
+/**
+ * Register the engine constructor for `dialect`. Called for its side
+ * effect by each `engines/<dialect>.ts` module; re-registering a dialect
+ * replaces the previous factory (importing a module twice is a no-op —
+ * module evaluation is cached).
+ *
+ * Both type parameters are inferred from `factory`, so a registration
+ * module names the concrete engine's own option type and never casts:
+ * `O` from its options parameter, `E` from the engine it returns.
+ *
+ * `E` is constrained on the `Engine` label every driver engine carries
+ * rather than on `AnySQLEngine | MongoEngine`, because the pool-free HTTP
+ * engines (`NeonHttpEngine`, `TursoEngine`, `D1Engine`) narrow the
+ * protected `_processOption` generic to their own options type and so are
+ * not structurally assignable to any single instantiation of their own
+ * base class. They ARE the right shape at runtime — norm drives them
+ * through the same public surface as every other engine — so the
+ * dialect-erasing cast below is where that gap is absorbed, once, instead
+ * of in each edge registration module.
+ *
+ * @param dialect - The {@link NormDialect} this factory builds.
+ * @param factory - Builds the engine from a Norm-generated instance name
+ *   and the `database` config with `dialect` stripped.
+ */
+export function registerEngine<O, E extends { readonly Engine: string }>(
+  dialect: NormDialect,
+  factory: (name: string, options: O) => E,
+): void {
+  // The stored signature is dialect-erased; the call site in `Norm.ts`
+  // hands over the `DatabaseConfig` branch that matches `dialect`, which
+  // IS `O` by construction of the discriminated union.
+  ENGINE_FACTORIES.set(dialect, factory as unknown as NormEngineFactory);
+}
+
+/**
+ * Look up the factory for `dialect`.
+ *
+ * @param dialect - The `database.dialect` value, unvalidated.
+ * @returns The registered {@link NormEngineFactory}.
+ * @throws {NormError} `INVALID_ENGINE_CONFIG` when `dialect` is not one
+ *   of the {@link NormDialect} values at all.
+ * @throws {NormError} `ENGINE_NOT_REGISTERED` when `dialect` is valid but
+ *   its engine module has not been imported — naming the exact import to
+ *   add. This is what turns an edge build's silent, deploy-time failure
+ *   ("`node:sqlite` polyfilled but `new DatabaseSync()` throws `Illegal
+ *   constructor`") into an actionable error at construction.
+ */
+export function resolveEngineFactory(dialect: string): NormEngineFactory {
+  const factory = ENGINE_FACTORIES.get(dialect);
+  if (factory !== undefined) return factory;
+  const known = Object.hasOwn(ENGINE_MODULES, dialect);
+  if (!known) {
+    throw new NormError(
+      `new Norm({ database }): unknown dialect '${dialect}'`,
+      { code: 'INVALID_ENGINE_CONFIG' },
+    );
+  }
+  throw new NormError(
+    `new Norm({ database }): dialect '${dialect}' has no registered ` +
+      `engine — import '${
+        ENGINE_MODULES[dialect as NormDialect]
+      }' (or the root '@tundralibs/norm' barrel, which registers every ` +
+      `dialect) before constructing Norm.`,
+    { code: 'ENGINE_NOT_REGISTERED', dialect },
+  );
+}

--- a/packages/norm/engines/sqlite.ts
+++ b/packages/norm/engines/sqlite.ts
@@ -1,0 +1,35 @@
+/**
+ * @module
+ *
+ * Registers the `sqlite` dialect (native, file-backed). Import for its
+ * side effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/sqlite';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({ database: { dialect: 'sqlite', path: './data' } });
+ * ```
+ *
+ * The root `@tundralibs/norm` barrel already imports this module.
+ *
+ * Pulls a NATIVE SQLite binding (`bun:sqlite`, `@db/sqlite`,
+ * `better-sqlite3`, `node:sqlite`) — this is the module that made norm
+ * unbundleable for edge runtimes before the registry existed, and it is
+ * still the one you must not import there. Cloudflare's `unenv` polyfill
+ * resolves `node:sqlite` and even exposes `DatabaseSync`, but
+ * constructing one throws `Illegal constructor` on workerd, so a native
+ * SQLite build would fail in production rather than at build time. On the
+ * edge use `d1` or `turso` (both SQLite over HTTP) instead.
+ *
+ * @since 1.2.0
+ */
+
+import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'sqlite',
+  (name: string, options: ConstructorParameters<typeof SQLiteEngine>[1]) =>
+    new SQLiteEngine(name, options),
+);

--- a/packages/norm/engines/turso.ts
+++ b/packages/norm/engines/turso.ts
@@ -1,0 +1,31 @@
+/**
+ * @module
+ *
+ * Registers the `turso` dialect — SQLite over Turso / libSQL's Hrana-v3
+ * HTTP API. Import for its side effect:
+ *
+ * ```ts
+ * import '@tundralibs/norm/engines/turso';
+ * import { Norm } from '@tundralibs/norm/core';
+ *
+ * const norm = new Norm({
+ *   database: { dialect: 'turso', url: env.TURSO_URL, token: env.TURSO_TOKEN },
+ * });
+ * ```
+ *
+ * Edge-safe: `fetch()` only, no native SQLite binding. The engine reuses
+ * the SQLite OQL translator, so norm's SQL generation is identical to the
+ * `sqlite` dialect; only the transport differs (one-shot HTTP, so no
+ * pooling and no transactions).
+ *
+ * @since 1.2.0
+ */
+
+import { TursoEngine } from '@tundralibs/drivers/turso';
+import { registerEngine } from './registry.ts';
+
+registerEngine(
+  'turso',
+  (name: string, options: ConstructorParameters<typeof TursoEngine>[1]) =>
+    new TursoEngine(name, options),
+);

--- a/packages/norm/errors/NormErrorCodes.ts
+++ b/packages/norm/errors/NormErrorCodes.ts
@@ -50,6 +50,10 @@ export type NormErrorCode =
   | 'INVALID_HANDLE'
   /** `new Norm({...})` engine/database configuration is invalid. */
   | 'INVALID_ENGINE_CONFIG'
+  /** `new Norm({ database })` named a known dialect whose engine module
+   * has not been imported — import `@tundralibs/norm/engines/<dialect>`,
+   * or the root `@tundralibs/norm` barrel which registers all of them. */
+  | 'ENGINE_NOT_REGISTERED'
   // ── Definition / registry ({@link NormDefinitionError}) ────────────
   /** Two registry keys map to the same database object, or a key is
    * provided by more than one composed schema. */

--- a/packages/norm/executor.ts
+++ b/packages/norm/executor.ts
@@ -22,15 +22,25 @@ import type {
   EngineQueryResult,
   EngineTransactionOptions,
   MongoEngine,
-  SQLEngine,
+  SQLConnectionEngine,
   TransactionScope,
 } from '@tundralibs/drivers';
 import type { Query } from '@tundralibs/oql/types';
 import { NormAdvisoryLockError, NormUnsupportedError } from './errors/mod.ts';
 
-/** Any SQL engine, dialect-erased. */
+/**
+ * Any SQL engine, dialect-erased.
+ *
+ * Rooted at `SQLConnectionEngine` — the pool-free base — rather than the
+ * pooled `SQLEngine`, so the fetch-only edge engines (`NeonHttpEngine`,
+ * `TursoEngine`, `D1Engine`, which own a single stateless HTTP client
+ * instead of a connection pool) are accepted here too. The pooled engines
+ * still satisfy it (`SQLEngine extends SQLConnectionEngine`), and the
+ * base declares the whole public surface this seam uses — the pool is an
+ * implementation detail of the subclass, never read through this type.
+ */
 // deno-lint-ignore no-explicit-any
-export type AnySQLEngine = SQLEngine<any, any, any>;
+export type AnySQLEngine = SQLConnectionEngine<any, any, any>;
 
 /** The DML query types `db.query()` accepts. */
 export type NormDMLQuery =

--- a/packages/norm/mod.ts
+++ b/packages/norm/mod.ts
@@ -9,134 +9,27 @@
  * await db.repo('Users').insert({ email: 'a@b.c', ... });
  * ```
  *
+ * This barrel is the batteries-included entry point: it registers every
+ * dialect (`postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`,
+ * `d1`), so any `database` config works with no extra import — and every
+ * driver, native SQLite binding included, is therefore in the bundle.
+ *
+ * On an edge runtime import {@link module:core} (`@tundralibs/norm/core`)
+ * plus the one `@tundralibs/norm/engines/<dialect>` module you need; the
+ * export surface is otherwise identical.
+ *
  * @module
  */
 
-// ─── Runtime ─────────────────────────────────────────────────────────
-export { type DatabaseConfig, Norm, type NormConfig, NormDb } from './Norm.ts';
-export { coerceCount, type NormResult, ulid } from './result.ts';
-export {
-  rotateKey,
-  type RotateKeyEntityReport,
-  type RotateKeyOptions,
-  type RotateKeyProgress,
-  type RotateKeyReport,
-} from './rotate.ts';
-export type { NormScope, ScopeInput, ScopeValue } from './scope.ts';
-export {
-  type FindOptions,
-  QueryAccessor,
-  ReadRepo,
-  Repo,
-  type RepoFor,
-} from './Repo.ts';
-export {
-  type AnySQLEngine,
-  bindTx,
-  type Executor,
-  type ExecutorCapabilities,
-  type ExecutorQuery,
-  mongoExecutor,
-  type NormDMLQuery,
-  type Session,
-  sqlExecutor,
-} from './executor.ts';
-export {
-  type CompiledEntity,
-  compileRuntime,
-  type NormCrypto,
-  type NormEmit,
-  type NormEvents,
-  type ReverseMap,
-  type ReverseRelation,
-  type Runtime,
-  type Witness,
-  type WitnessInfo,
-} from './compile.ts';
-export {
-  buildCellGuardian,
-  buildWriteGuardians,
-  validateRows,
-  type WriteGuardians,
-} from './guardians.ts';
-export {
-  canonicalizePlain,
-  type CryptoOverrides,
-  decodePlain,
-  DEFAULT_ENCRYPT_ALGORITHM,
-  DEFAULT_HASH_ALGORITHM,
-  type EncryptAlgorithm,
-  type HashAlgorithm,
-  pbkdf2Verify,
-  SIBLING_HASH_ALGORITHM,
-} from './crypto.ts';
-export {
-  type AdvisoryLockErrorMeta,
-  type CryptoErrorMeta,
-  type DefinitionIssue,
-  NormAdvisoryLockError,
-  NormCryptoError,
-  NormDefinitionError,
-  NormError,
-  type NormErrorCode,
-  NormHookError,
-  NormQueryError,
-  NormUnsupportedError,
-  NormValidationError,
-  type QueryErrorMeta,
-  type ValidationIssue,
-} from './errors/mod.ts';
+// Side-effect imports: each registers one dialect's engine factory (see
+// `engines/registry.ts`). They come first so a dialect is registered
+// before any consumer code can construct a Norm.
+import './engines/postgres.ts';
+import './engines/maria.ts';
+import './engines/sqlite.ts';
+import './engines/mongo.ts';
+import './engines/neon.ts';
+import './engines/turso.ts';
+import './engines/d1.ts';
 
-// ─── Definition layer ────────────────────────────────────────────────
-
-export {
-  type AnyColumnBuilder,
-  type AnyDefinition,
-  Column,
-  ColumnBuilder,
-  type ColumnSnapshot,
-  type ColumnSpec,
-  type ComposedSchema,
-  DateColumnBuilder,
-  type DefaultInput,
-  type DefaultRowOf,
-  DIGEST_LENGTHS,
-  type DigestAlgorithm,
-  DigestColumnBuilder,
-  type EmittedForeignKey,
-  EncryptedColumnBuilder,
-  Entity,
-  type EntityQueryOptions,
-  type EntitySnapshot,
-  type EntityTableOptions,
-  type EntityViewOptions,
-  type ExpressionDefault,
-  type FilterOf,
-  type FilterShapeOf,
-  type ForeignKeyDef,
-  HashedColumnBuilder,
-  type InsertOf,
-  MaskColumnBuilder,
-  NumberColumnBuilder,
-  type PrimaryKeyOf,
-  type ProjectedRowOf,
-  type ProjectionInput,
-  type QueryDefinition,
-  type ReadHooks,
-  type ReadRowOf,
-  type RowOf,
-  Schema,
-  type SchemaDefinition,
-  type SchemaValue,
-  type Snapshot,
-  snapshot,
-  StringColumnBuilder,
-  type TableDefinition,
-  type TableHooks,
-  toMarkdown,
-  toMermaidERD,
-  toPlantUML,
-  type UpdateOf,
-  use,
-  type ViewDefinition,
-} from './definition/mod.ts';
+export * from './core.ts';

--- a/packages/norm/package.json
+++ b/packages/norm/package.json
@@ -5,10 +5,19 @@
   "type": "module",
   "exports": {
     ".": "./mod.ts",
+    "./core": "./core.ts",
     "./errors": "./errors/mod.ts",
     "./definition": "./definition/mod.ts",
     "./migrations": "./migrations/mod.ts",
-    "./asserts": "./asserts/mod.ts"
+    "./asserts": "./asserts/mod.ts",
+    "./engines": "./engines/mod.ts",
+    "./engines/postgres": "./engines/postgres.ts",
+    "./engines/maria": "./engines/maria.ts",
+    "./engines/sqlite": "./engines/sqlite.ts",
+    "./engines/mongo": "./engines/mongo.ts",
+    "./engines/neon": "./engines/neon.ts",
+    "./engines/turso": "./engines/turso.ts",
+    "./engines/d1": "./engines/d1.ts"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## The defect

`packages/norm/Norm.ts` value-imported four engine classes from the
`@tundralibs/drivers` **root barrel**:

```ts
import { MariaEngine, MongoEngine, PostgresEngine, SQLiteEngine } from '@tundralibs/drivers';
```

They were used in exactly one place — the `switch (db.dialect)` inside
`resolveEngine()`. That single import put the **native** SQLite adapter in the
runtime graph of every consumer that imported norm at all, so norm could not be
bundled for an edge runtime:

- `wrangler deploy --dry-run` → `Could not resolve "bun:sqlite"`, `Could not resolve "$sqlite_deno"`
- Vite → `Rolldown failed to resolve import "$sqlite_deno"`

Nothing on norm's query path needs a filesystem — only `migrations/Migrator.ts`
and `migrations/FileLock.ts` touch `compat/file`, and those live behind their own
subpath. The static engine import was the whole gap.

## The registry

`packages/norm/engines/registry.ts` holds a module-private
`Map<string, NormEngineFactory>` with `registerEngine(dialect, factory)` and
`resolveEngineFactory(dialect)`. `Norm.ts`'s switch becomes a lookup:

```ts
const { dialect, ...rest } = cfg.database;
const factory = resolveEngineFactory(dialect);
return wrap(factory(name, rest as Record<string, unknown>));
```

Each dialect gets a side-effect module — `engines/{postgres,maria,sqlite,mongo,neon,turso,d1}.ts`
— that imports its engine class from the drivers **subpath**, never the barrel
(load-bearing: `@tundralibs/drivers` would drag SQLite straight back in), and
registers a factory. `registerEngine` infers both the options type and the
engine type from the factory, so no registration module casts.

Two other value imports had to go with it: `Norm.ts` used
`engine instanceof MongoEngine` twice. That is now a `Engine === 'MONGO'` label
check (`isMongoEngine`), which behaves identically for real engines and for the
bare-object test doubles the old check also treated as SQL.

`normEngineCounter` naming, the `engine:` path, and the both-supplied /
neither-supplied errors are untouched. An unknown dialect still throws
`unknown dialect 'oracle'` with `INVALID_ENGINE_CONFIG`; the new
`ENGINE_NOT_REGISTERED` code covers only a *known* dialect whose module was
never imported.

## Two entry points — why this is not breaking

- **`mod.ts`** (`@tundralibs/norm`) imports all seven registration modules and
  re-exports `core.ts`. Every existing
  `new Norm({ database: { dialect: 'postgres', … } })` keeps working with zero
  changes, and gains three dialects.
- **`core.ts`** (`@tundralibs/norm/core`, new) is the identical export surface
  with **nothing** registered. Edge consumers import it plus the one engine
  module they need.

`core.test.ts` asserts the two barrels export the same keys and the same class
objects, so the surfaces cannot drift.

I did **not** add a convenience `engines/edge.ts` registering neon+turso+d1.
On an edge runtime bundle size is the currency and an app talks to exactly one
database; that module would pull three HTTP clients into every edge bundle to
save one import line, while the root barrel already covers "give me everything".

## Three new dialects

`DatabaseConfig` grows `neon` (`NeonHttpEngineOptions`), `turso`
(`TursoEngineOptions`) and `d1` (`D1EngineOptions`). Those option types come in
as `import type` from the drivers subpaths — erased at compile time, so they add
no runtime edge. **Every** `@tundralibs/drivers` import in `Norm.ts` is now
type-only, and a comment at the top says so.

No oql change was needed, and I verified rather than assumed it: the edge
engines reuse the existing translators (`NeonHttpEngine` → `PostgresTranslator`,
`TursoEngine` / `D1Engine` → `SQLiteTranslator`), so `executor.capabilities.dialect`
resolves to `postgres` / `sqlite` / `sqlite` and the generated SQL is unchanged.
There is a test pinning exactly that.

`executor.ts`'s `AnySQLEngine` is re-rooted from `SQLEngine` to the pool-free
`SQLConnectionEngine` base. `SQLEngine extends SQLConnectionEngine`, and the
base declares the entire public surface this seam uses, so no public member is
lost and every existing engine still satisfies it — norm never touches the pool.

## The workerd proof

A throwaway wrangler project (`compatibility_date = "2026-08-04"`,
`nodejs_compat`, **no aliases, no stubs**), importing `@tundralibs/norm/core` +
`@tundralibs/norm/engines/d1`:

```
$ wrangler deploy --dry-run
Total Upload: 1198.71 KiB / gzip: 249.77 KiB
--dry-run: exiting now.
```

`wrangler dev` on real workerd, one fetch:

```json
{"ok":true,"normIsConstructed":true,"entities":["Users"],"repoHasFind":true,
 "sqliteError":"new Norm({ database }): dialect 'sqlite' has no registered engine — import '@tundralibs/norm/engines/sqlite' (or the root '@tundralibs/norm' barrel, which registers every dialect) before constructing Norm.",
 "unenv":"resolved, DatabaseSync=function; construct threw: Illegal constructor"}
```

The **root barrel still fails the same build**, which is expected and correct:

```
✘ Could not resolve "$sqlite_deno"   packages/drivers/engines/sqlite/adapter.ts:112
✘ Could not resolve "bun:sqlite"     packages/drivers/engines/sqlite/adapter.ts:154
```

## Why the loud error matters

The `unenv` line above is the reason the registry throws instead of falling
back. On workerd `node:sqlite` **resolves** through Cloudflare's unenv polyfill
and even exposes `DatabaseSync` as a function — but `new DatabaseSync(':memory:')`
throws `Illegal constructor`. A `dialect: 'sqlite'` on an edge build would
therefore pass CI and fail cryptically in production. With the registry it fails
at construction with a message naming the exact import. Native SQLite cannot
work on Workers at all; `d1` and `turso` (SQLite over HTTP) are the supported
paths, `neon` is the Postgres one.

## Verification

- `wrangler deploy --dry-run` + `wrangler dev` fetch on workerd — above.
- Root-barrel behaviour unchanged: `Norm.test.ts` still constructs
  postgres/maria/mongo/sqlite from `database` with no extra import; new tests
  add neon/turso/d1 and pin the resolved dialect + `transactions: false`.
- Unregistered-dialect path: `engines/registry.test.ts` covers both failure
  modes on a cache-busted fresh registry instance (test files share module state
  inside one runner process), plus a Deno-only test that walks `core.ts`'s
  **code**-edge import graph and fails if any driver creeps back in.
- Suites — norm green on all three runtimes: Deno 31 files / 266 steps,
  Bun 300 pass / 1 skip, Node 300 pass. The only failures anywhere are
  `tests/live-maria` and `tests/live-postgres`, which need running DB services;
  they fail identically on `origin/main` in this environment (verified by
  stashing). `live-sqlite`, `live-mongo` and the SQLite-backed suites all ran.
- `deno check` clean on `mod.ts` and every subpath in `deno.json` exports;
  `deno publish --dry-run` succeeds (JSR accepts the nested `./engines/<dialect>`
  keys); `deno task workspace:sync:check` reports 19 packages in sync;
  `deno fmt` / `deno lint` clean.
- `deno task check:edge-safety` (drivers) still passes for neon / turso / d1.
- `deno task check` green for all 19 packages.

## Known follow-up (not fixed here — drivers is out of scope for this PR)

`NeonHttpEngine`, `TursoEngine` and `D1Engine` override the protected
`_processOption<K extends keyof <X>EngineOptions>`, narrowing the generic
against their own options type. That makes them structurally unassignable to
**any** instantiation of their own base class, so `new Norm({ engine: d1Engine })`
(the BYO path) still needs a cast even though it works at runtime. The registry
absorbs this in one documented place. The clean fix is drivers-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
