### PR TITLE
feat(rpc): carry structured data on error result frames

### DIFF
--- a/packages/rpc/Client.test.ts
+++ b/packages/rpc/Client.test.ts
@@ -200,6 +200,50 @@ function suite() {
     );
   });
 
+  it('command() rejection carries .code and structured .data', async () => {
+    server = new Server();
+    server.command('validate', undefined, () => {
+      throw Object.assign(new Error('Validation failed'), {
+        code: 'VALIDATION_FAILED',
+        data: { fields: { email: 'already taken' } },
+      });
+    });
+    await server.listen({ port, hostname: '127.0.0.1' });
+    client = new Client({
+      url: `ws://127.0.0.1:${port}`,
+      reconnect: { enabled: false },
+    });
+    await client.connect();
+    const err = await asserts.assertRejects(
+      () => client.command('validate'),
+      Error,
+      'Validation failed',
+    ) as Error & { code?: string; data?: { fields?: unknown } };
+    // Message format unchanged (`CODE: text`), code and data ALSO
+    // attached so callers branch without parsing the string.
+    asserts.assertEquals(err.code, 'VALIDATION_FAILED');
+    asserts.assertEquals(err.data?.fields, { email: 'already taken' });
+    asserts.assert(err.message.startsWith('VALIDATION_FAILED: '));
+  });
+
+  it('a failure without data leaves .data undefined', async () => {
+    server = new Server();
+    server.command('plain', undefined, () => {
+      throw new Error('nope');
+    });
+    await server.listen({ port, hostname: '127.0.0.1' });
+    client = new Client({
+      url: `ws://127.0.0.1:${port}`,
+      reconnect: { enabled: false },
+    });
+    await client.connect();
+    const err = await asserts.assertRejects(
+      () => client.command('plain'),
+      Error,
+    ) as Error & { data?: unknown };
+    asserts.assertEquals(err.data, undefined);
+  });
+
   it('command() rejects with REQUEST_TIMEOUT when handler never responds', async () => {
     server = new Server();
     // Handler resolves after 5 seconds — far past the client's 50 ms

--- a/packages/rpc/Client.ts
+++ b/packages/rpc/Client.ts
@@ -239,11 +239,13 @@ export class Client {
   /**
    * Invoke a command and wait for the server's `result` frame.
    *
-   * Resolves to the handler's return value on success; rejects with
-   * an `Error` whose `.message` is the server-side error message on
-   * `ok: false` responses. Times out after `timeoutMs` (or the
-   * client's `defaultTimeoutMs`) — pass `0` to disable for a single
-   * call.
+   * Resolves to the handler's return value on success; rejects on
+   * `ok: false` responses with an `Error` whose `.message` is
+   * `` `${code}: ${serverMessage}` ``, and which also carries `.code`
+   * plus any structured `.data` the handler attached — branch on the
+   * code instead of parsing the message. Times out after `timeoutMs`
+   * (or the client's `defaultTimeoutMs`) — pass `0` to disable for a
+   * single call.
    *
    * @throws If the send path throws (a throwing `useSend` middleware, or
    *   the socket leaving `OPEN` mid-send), the returned Promise rejects
@@ -816,7 +818,9 @@ export class Client {
           return { id: obj.id, type: 'result', ok: true, data: obj.data };
         }
         if (obj.ok === false) {
-          const err = obj.error as { code?: unknown; message?: unknown } | null;
+          const err = obj.error as
+            | { code?: unknown; message?: unknown; data?: unknown }
+            | null;
           if (
             !err || typeof err.code !== 'string' ||
             typeof err.message !== 'string'
@@ -827,7 +831,14 @@ export class Client {
             id: obj.id,
             type: 'result',
             ok: false,
-            error: { code: err.code, message: err.message },
+            // `data` is optional structured detail; absent from peers
+            // that predate it, so it is carried through as-is and
+            // never validated into a rejection.
+            error: {
+              code: err.code,
+              message: err.message,
+              ...(err.data === undefined ? {} : { data: err.data }),
+            },
           };
         }
         return null;
@@ -929,8 +940,20 @@ export class Client {
     if (frame.ok) {
       pending.resolve(frame.data);
     } else {
+      // The message format is unchanged (`CODE: text`); `code` and any
+      // structured `data` are ALSO attached as properties, so callers
+      // can branch on the code and read the detail without parsing the
+      // string.
       pending.reject(
-        new Error(`${frame.error.code}: ${frame.error.message}`),
+        Object.assign(
+          new Error(`${frame.error.code}: ${frame.error.message}`),
+          {
+            code: frame.error.code,
+            ...(frame.error.data === undefined
+              ? {}
+              : { data: frame.error.data }),
+          },
+        ),
       );
     }
   }

--- a/packages/rpc/Server.test.ts
+++ b/packages/rpc/Server.test.ts
@@ -323,6 +323,57 @@ describe({
         await hub.close();
       });
 
+      it('a thrown error carries code AND structured data to the client', async () => {
+        const hub = new Server();
+        hub.command('validate', undefined, () => {
+          // The documented way a handler sends detail with a failure.
+          throw Object.assign(new Error('Validation failed'), {
+            code: 'VALIDATION_FAILED',
+            data: { fields: { email: 'already taken' } },
+          });
+        });
+
+        const ws = new MockWs();
+        await open(hub, ws);
+        await send(
+          hub,
+          ws,
+          encodeInbound({ id: '1', type: 'cmd', cmd: 'validate' }),
+        );
+        asserts.assertEquals(ws.sent[0], {
+          id: '1',
+          type: 'result',
+          ok: false,
+          error: {
+            code: 'VALIDATION_FAILED',
+            message: 'Validation failed',
+            data: { fields: { email: 'already taken' } },
+          },
+        });
+        await hub.close();
+      });
+
+      it('a thrown error WITHOUT data omits the field entirely', async () => {
+        // Byte-identical to what a pre-`data` server sent.
+        const hub = new Server();
+        hub.command('plain', undefined, () => {
+          throw new Error('nope');
+        });
+        const ws = new MockWs();
+        await open(hub, ws);
+        await send(
+          hub,
+          ws,
+          encodeInbound({ id: '1', type: 'cmd', cmd: 'plain' }),
+        );
+        const frame = ws.sent[0] as { error: Record<string, unknown> };
+        asserts.assertEquals(Object.keys(frame.error).sort(), [
+          'code',
+          'message',
+        ]);
+        await hub.close();
+      });
+
       it('throws when registering the same name twice', () => {
         const hub = new Server();
         hub.command('foo', undefined, () => 1);

--- a/packages/rpc/Server.ts
+++ b/packages/rpc/Server.ts
@@ -515,11 +515,16 @@ export class Server<T = unknown> {
       );
     } catch (err) {
       const code = (err as { code?: unknown })?.code;
+      // A handler may attach structured detail to the thrown error
+      // (`Object.assign(new Error(msg), { code, data })`); it rides the
+      // error frame so the caller gets more than a string.
+      const data = (err as { data?: unknown })?.data;
       this._sendResultError(
         ws,
         frame.id,
         typeof code === 'string' ? code : 'HANDLER_ERROR',
         err instanceof Error ? err.message : String(err),
+        data,
       );
     }
   }
@@ -749,12 +754,16 @@ export class Server<T = unknown> {
     id: string,
     code: string,
     message: string,
+    data?: unknown,
   ): void {
     this._send(ws, {
       id,
       type: 'result',
       ok: false,
-      error: { code, message },
+      // `data` is omitted entirely when absent — an `undefined` value
+      // would serialise away anyway, but omitting keeps the frame
+      // byte-identical to what pre-`data` servers sent.
+      error: data === undefined ? { code, message } : { code, message, data },
     });
   }
 

--- a/packages/rpc/types/protocol/ResultFrame.ts
+++ b/packages/rpc/types/protocol/ResultFrame.ts
@@ -5,5 +5,16 @@ export type ResultFrame =
     id: string;
     type: 'result';
     ok: false;
-    error: { code: string; message: string };
+    /**
+     * `code`/`message` identify the failure. `data` is OPTIONAL
+     * structured detail a handler chose to send with it (validation
+     * field errors, a retry hint) — a handler supplies it by attaching
+     * `data` to the thrown error, and the client surfaces it on the
+     * rejection. Additive: peers that predate it simply ignore the
+     * field.
+     *
+     * It crosses the wire to the CALLER, so it carries the same
+     * disclosure duty as any error body — never put internals in it.
+     */
+    error: { code: string; message: string; data?: unknown };
   };


### PR DESCRIPTION
The error variant of `ResultFrame` carried only `{ code, message }`, so a handler that failed with structured detail — validation field errors, a retry hint — could send nothing but a string. A caller over the socket got strictly less than the same handler would return over HTTP.

## What changes

- `ResultFrame`s error variant gains an **optional** `data?: unknown`.
- The server forwards `data` off a thrown error exactly as it already forwards `code`:
  ```ts
  throw Object.assign(new Error("Validation failed"), {
    code: "VALIDATION_FAILED",
    data: { fields: { email: "already taken" } },
  });
  ```
- The client attaches `.code` and `.data` to the rejection, so callers branch on the code instead of parsing the message. **The message format is unchanged** (`CODE: text`).

## Compatibility

Additive on the wire. A thrown error without `data` produces a **byte-identical** frame to before (pinned by a test), and peers that predate the field ignore it. No signature changes; `_sendResultError` gains a trailing optional parameter.

## Tests

Four added: server emits `data` when present, server omits the key entirely when absent, client surfaces `.code`/`.data` on the rejection, client leaves `.data` undefined for a plain failure. Existing suite unchanged (136 steps green).

## Why now

`@tundralibs/rapid` needs it: a handler setting `{ status: 422, content: { fields } }` currently reaches a socket client as `RAPID_UNHANDLED` / "Internal server error" with the body discarded, while the same handler over HTTP returns the full 422. This field closes that gap — rapid maps its disclosure envelope onto `code`/`message` and passes handler-authored content through as `data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)