### PR TITLE
docs(oql): document Workers and browser runtime support

### DIFF
--- a/packages/oql/README.md
+++ b/packages/oql/README.md
@@ -5,6 +5,8 @@ Type-safe, database-agnostic query definitions for TypeScript/JavaScript.
 ![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
 ![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
 ![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)
+![Browsers](https://img.shields.io/badge/Browsers-4285F4?logo=googlechrome&logoColor=white)
 
 ## Overview
 
@@ -46,6 +48,19 @@ bunx jsr add @tundralibs/oql
 ```bash
 npx jsr add @tundralibs/oql
 ```
+
+### Runtime support
+
+OQL builds and translates query definitions — it never opens a connection
+or executes anything itself, so it has no I/O, no filesystem access, and
+no runtime-specific globals. It runs unchanged on **Deno**, **Bun**,
+**Node.js**, **Cloudflare Workers**, and **browsers**.
+
+Bundling for Workers or the browser needs no special configuration — no
+`nodejs_compat` flag, no aliases, no polyfills. Executing the queries OQL
+produces is the driver's job, and that is where runtime support varies:
+see [@tundralibs/drivers](https://jsr.io/@tundralibs/drivers) for which
+engines work where.
 
 ## Quick Start
 


### PR DESCRIPTION
## What

Adds Cloudflare Workers and browser badges plus a **Runtime support** section to oql's README.

OQL builds and translates query definitions — it never opens a connection or executes anything — so it has no I/O, no filesystem access, and no runtime-specific globals. Verified: `deno bundle --platform=browser` succeeds at 323 KB with **zero** unresolvable specifiers.

The section also points out that *executing* the queries is the driver's concern, since that is where runtime support actually varies — so readers aren't left thinking a green oql badge means their database works at the edge.

## Why now: this also fixes a live packaging bug

`npm.jsr.io` serves a stale `latest` dist-tag for oql — npm says `1.0.0-dev6.4` while jsr.io says `1.0.0`. So `npx jsr add @tundralibs/oql` on Node or Bun installs a months-old prerelease.

**This mechanism is now confirmed, not theorised.** oql and guardian were the only two packages whose sole stable release was `1.0.0` with nothing published since; all 12 packages with `-dev` history and a later release had correct tags. Guardian released 1.0.1 earlier today and its tag corrected itself immediately — a clean `npx jsr add @tundralibs/guardian` now installs 1.0.1 and runs. Nothing was stuck server-side and no yanking was needed.

Releasing oql 1.0.1 applies the identical fix. After it publishes, confirm with:

```bash
curl -s https://npm.jsr.io/@jsr/tundralibs__oql | python3 -c "import json,sys; print(json.load(sys.stdin)['dist-tags'])"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)