### PR TITLE
feat(workspace): offer Workers and browser badges in the package scaffold

### DIFF
--- a/.github/scripts/workspace.ts
+++ b/.github/scripts/workspace.ts
@@ -455,6 +455,13 @@ TODO: brief description of what this package does and why it exists.
 ![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
 ![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
 ![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
+<!-- Uncomment the environments this package actually supports, after verifying:
+     Workers  -- wrangler deploy --dry-run, on a consumer importing this package
+     Browsers -- deno bundle --platform=browser -o /dev/null <pkg>/mod.ts
+     A package that needs sockets, the filesystem, or a native binding supports neither.
+![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)
+![Browsers](https://img.shields.io/badge/Browsers-4285F4?logo=googlechrome&logoColor=white)
+-->
 
 ## Installation
 


### PR DESCRIPTION
## What

New packages scaffolded by `workspace:add` now include Cloudflare Workers and browser badges **commented out**, with a note on how to verify support before uncommenting.

```
<!-- Uncomment the environments this package actually supports, after verifying:
     Workers  -- wrangler deploy --dry-run, on a consumer importing this package
     Browsers -- deno bundle --platform=browser -o /dev/null <pkg>/mod.ts
     A package that needs sockets, the filesystem, or a native binding supports neither.
![Cloudflare Workers](…)
![Browsers](…)
-->
```

## Why commented rather than default

Support is genuinely per-package. Verified across the suite: pure-logic packages (crypt, guardian, oql, id, metro-man, radrouter) run in both environments; anything needing sockets, the filesystem, or a native binding runs in neither. Emitting the badges uncommented would make every new package claim support it may not have — the opposite of the problem this fixes.

## Verified

Scaffolded a throwaway package, confirmed the README output, removed it, and confirmed `deno task workspace:sync:check` reports **19 packages in sync** with only `workspace.ts` modified. `deno check` and `deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)