### PR TITLE
fix(rpc): attach the error code when rejecting on an out-of-band error frame

### DIFF
--- a/packages/rpc/Client.test.ts
+++ b/packages/rpc/Client.test.ts
@@ -244,6 +244,52 @@ function suite() {
     asserts.assertEquals(err.data, undefined);
   });
 
+  it('an out-of-band error frame rejects with .code attached', async () => {
+    // Regression: the out-of-band reject path (a standalone
+    // `{ type: 'error', id, code, message }` frame) used to hand back a
+    // BARE `new Error('CODE: text')`, while the `result` path above
+    // attached `.code`. A caller who had learned `err.code` works read
+    // `undefined` for protocol-level failures. Both paths now build the
+    // same shape.
+    //
+    // Driving the real server (rather than hand-feeding a frame to the
+    // dispatcher) also pins the server's id recovery: the correlation
+    // only exists because BAD_FORMAT carries the offending id back. Lose
+    // it and there is no pending to reject, and this call hangs to
+    // REQUEST_TIMEOUT instead — a distinguishable failure.
+    server = new Server();
+    server.command('echo', undefined, (ctx) => ctx.payload);
+    await server.listen({ port, hostname: '127.0.0.1' });
+    client = new Client({
+      url: `ws://127.0.0.1:${port}`,
+      reconnect: { enabled: false },
+      // Short, so a lost correlation fails the test quickly rather than
+      // stalling the suite for the 30s default.
+      defaultTimeoutMs: 1000,
+    });
+    await client.connect();
+    client.useSend((ctx, next) => {
+      // Keep the id, break the type: well-formed JSON the server cannot
+      // decode, whose id is still recoverable — so the BAD_FORMAT error
+      // frame comes back correlated to this very request.
+      ctx.frame = {
+        id: ctx.frame.id,
+        type: 'weird',
+      } as unknown as ClientSendContext['frame'];
+      return next();
+    });
+    const err = await asserts.assertRejects(
+      () => client.command('echo', 'hi'),
+      Error,
+    ) as Error & { code?: string; data?: unknown };
+    asserts.assertEquals(err.code, 'BAD_FORMAT');
+    // Message format is byte-identical to the pre-fix bare Error, so
+    // anyone matching on the string is unaffected.
+    asserts.assertEquals(err.message, 'BAD_FORMAT: invalid frame');
+    // `ServerErrorFrame` has no `data` field — nothing to attach.
+    asserts.assertEquals(err.data, undefined);
+  });
+
   it('command() rejects with REQUEST_TIMEOUT when handler never responds', async () => {
     server = new Server();
     // Handler resolves after 5 seconds — far past the client's 50 ms

--- a/packages/rpc/Client.ts
+++ b/packages/rpc/Client.ts
@@ -93,14 +93,21 @@ export class Client {
   // these fields if they need to. The double-underscore naming is
   // strictly informational — nothing inside this class is part of the
   // public surface unless typed as `public`.
+  /** Constructor options, stored unmodified. */
   protected readonly _opts: ClientOptions;
+  /** Reconnect policy with every field defaulted. */
   protected readonly _reconnect: Required<ReconnectPolicy>;
+  /** Timeout applied to calls that don't pass their own `timeoutMs`. */
   protected readonly _defaultTimeoutMs: number;
 
+  /** Send-path middleware, run in registration order. */
   protected readonly _sendMiddleware: ClientSendMiddleware[] = [];
+  /** Receive-path middleware, run in registration order. */
   protected readonly _receiveMiddleware: ClientReceiveMiddleware[] = [];
 
+  /** In-flight requests awaiting a `result`, keyed by frame id. */
   protected readonly _pending: Map<string, _PendingRequest> = new Map();
+  /** Locally-tracked subscriptions, keyed by channel name. */
   protected readonly _subscriptions: Map<string, _ChannelSubscription> =
     new Map();
   // Frame ids of `unsub` frames this client has sent whose `unsubscribed`
@@ -114,18 +121,26 @@ export class Client {
   // NOT merely until `unsubscribe()`'s ack-wait times out. Bounding the
   // window to the timeout would let a late ack be misread as
   // server-initiated and delete a freshly re-created subscription.
+  /** Ids of our own `unsub` frames whose `unsubscribed` ack is outstanding. */
   protected readonly _pendingUnsubs: Set<string> = new Set();
 
+  /** The live socket, or `null` while disconnected or between retries. */
   protected _ws: WebSocket | null = null;
+  /** Current connection state; surfaced publicly via {@link state}. */
   protected _state: ClientState = 'DISCONNECTED';
+  /** Latched by {@link close} to stop reconnects; cleared by {@link connect}. */
   protected _closeRequested = false;
+  /** Retries used in the current backoff cycle; reset to 0 on a good open. */
   protected _reconnectAttempt = 0;
   // Handle + waker for the backoff sleep between reconnect attempts, so
   // `close()` can cancel a pending retry instead of leaving a timer —
   // and the event loop — alive up to `maxDelayMs` after close.
+  /** Armed backoff timer, or `undefined` when no retry is parked. */
   protected _reconnectTimer: ReturnType<typeof setTimeout> | undefined =
     undefined;
+  /** Resolver that unparks the backoff sleep early (used by {@link close}). */
   protected _reconnectWake: (() => void) | undefined = undefined;
+  /** Monotonic frame-id counter, reset on every successful open. */
   protected _nextId = 0;
   // Per-connection nonce, bumped on every (re)connect. Folded into the
   // frame-id prefix so ids minted on a new socket can never collide
@@ -133,8 +148,16 @@ export class Client {
   // otherwise the sequential `c1, c2, …` counter would let an old
   // socket's late reply resolve a freshly minted request with the same
   // id.
+  /** Per-connection nonce forming the `c<connId>-` frame-id prefix. */
   protected _connId = 0;
 
+  /**
+   * Create a client. Does not open the socket — call {@link connect}.
+   *
+   * @param opts - Only `url` is required; the rest default to a 30s
+   *   request timeout and reconnect enabled with 10 attempts.
+   * @throws {@link RpcConfigError} When `url` is missing or not a string.
+   */
   constructor(opts: ClientOptions) {
     if (!opts.url || typeof opts.url !== 'string') {
       throw new RpcConfigError(
@@ -447,17 +470,33 @@ export class Client {
   // Internals
   // =========================================================================
 
+  /**
+   * Mint the next frame id, shaped `c<connId>-<n>`. The connection nonce
+   * keeps ids unique across reconnects, so a late `result` from a dead
+   * socket can never resolve a request minted on the new one.
+   */
   protected _nextFrameId(): string {
     this._nextId++;
     return `c${this._connId}-${this._nextId}`;
   }
 
+  /**
+   * Guard every public send path against a non-`CONNECTED` state.
+   *
+   * @throws {@link RpcStateError} When the client is not connected.
+   */
   protected _assertSendable(): void {
     if (this._state !== 'CONNECTED') {
       throw new RpcStateError(`Client not connected (state=${this._state})`);
     }
   }
 
+  /**
+   * Open one WebSocket and settle on its first `open` or `error`. On
+   * success it bumps the connection nonce, wires the socket handlers, and
+   * replays surviving subscriptions; on failure state returns to
+   * `'DISCONNECTED'` and the error is re-thrown to the caller.
+   */
   protected _openSocket(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       this._state = 'CONNECTING';
@@ -498,6 +537,11 @@ export class Client {
     });
   }
 
+  /**
+   * Attach the steady-state `message` / `close` / `error` listeners to a
+   * socket that has already opened. Non-string messages are dropped — the
+   * server only ever sends text JSON.
+   */
   protected _wireSocketHandlers(ws: WebSocket): void {
     ws.addEventListener('message', (event: MessageEvent) => {
       // The wire format is text JSON. Binary frames are unexpected
@@ -516,6 +560,12 @@ export class Client {
     });
   }
 
+  /**
+   * React to the socket closing: reject every in-flight request with
+   * `CONNECTION_LOST`, drop outstanding unsub correlations, and arm the
+   * backoff — but only when the close was not requested by {@link close}
+   * and the socket had actually reached `'CONNECTED'`.
+   */
   protected _handleClose(_event: CloseEvent): void {
     const wasConnected = this._state === 'CONNECTED';
     this._ws = null;
@@ -532,6 +582,13 @@ export class Client {
     }
   }
 
+  /**
+   * Sleep out one exponential-backoff delay, then reopen — recursing on
+   * failure until `maxAttempts` is spent, at which point
+   * {@link ClientOptions.onReconnectFailed} fires and retrying stops.
+   * Unparks early and bails if {@link close} or a manual {@link connect}
+   * intervenes, so it can never open a second concurrent socket.
+   */
   protected async _scheduleReconnect(): Promise<void> {
     if (this._reconnectAttempt >= this._reconnect.maxAttempts) {
       // Exhausted every attempt. Previously this returned silently,
@@ -586,6 +643,13 @@ export class Client {
     }
   }
 
+  /**
+   * Record an in-flight request under `id` and return the promise its
+   * `result` frame will settle.
+   *
+   * @param timeoutMs - Arms a `REQUEST_TIMEOUT` rejection; `0` or less
+   *   leaves the request pending indefinitely.
+   */
   protected _registerPending<R>(
     id: string,
     timeoutMs: number,
@@ -619,6 +683,7 @@ export class Client {
     this._pending.delete(id);
   }
 
+  /** Reject and clear every in-flight request, cancelling their timeouts. */
   protected _rejectAllPending(err: Error): void {
     for (const [id, pending] of this._pending) {
       if (pending.timeoutHandle !== undefined) {
@@ -629,6 +694,11 @@ export class Client {
     }
   }
 
+  /**
+   * Create the local subscription record for `channel`, including the
+   * `pendingAck` promise that the server's `subscribed` frame resolves.
+   * Overwrites any existing record for the same channel.
+   */
   protected _registerSubscription(
     channel: string,
     handler: (data: unknown) => void,
@@ -649,6 +719,11 @@ export class Client {
     return sub;
   }
 
+  /**
+   * Build the caller-facing {@link ClientSubscription} handle. Its
+   * `unsubscribe()` is idempotent per handle and best-effort — it never
+   * throws, since the server drops subscriptions on close regardless.
+   */
   protected _makeSubscriptionHandle(channel: string): ClientSubscription {
     let unsubscribed = false;
     return {
@@ -700,6 +775,11 @@ export class Client {
     };
   }
 
+  /**
+   * Replay every surviving subscription over a freshly opened socket.
+   * Fire-and-forget: failures don't fail {@link connect}, they surface
+   * through {@link ClientOptions.onSubscriptionError}.
+   */
   protected _resubscribeAll(): void {
     // Replay subscriptions after a reconnect. Each gets a fresh
     // pendingAck so callers that re-await the subscription handle
@@ -761,6 +841,13 @@ export class Client {
     this._opts.onSubscriptionError?.(channel, error);
   }
 
+  /**
+   * Run `frame` through the {@link useSend} chain; the final `next()`
+   * writes it to the wire. A middleware that skips `next()` silently drops
+   * the frame, leaving the caller's request to time out.
+   *
+   * @throws {@link RpcStateError} When a middleware calls `next()` twice.
+   */
   protected async _sendThroughMiddleware(frame: InboundFrame): Promise<void> {
     const ctx: ClientSendContext = { frame, state: {} };
     const chain = this._sendMiddleware;
@@ -782,6 +869,13 @@ export class Client {
     await runner(0);
   }
 
+  /**
+   * Serialize and write a frame to the live socket.
+   *
+   * @throws {@link RpcStateError} When the socket is absent or not `OPEN`
+   *   — including when it closed mid-send, after the caller's own
+   *   `_assertSendable` guard already passed.
+   */
   protected _writeFrame(frame: InboundFrame): void {
     if (!this._ws || this._ws.readyState !== 1 /* OPEN */) {
       throw new RpcStateError('Client not connected');
@@ -870,6 +964,11 @@ export class Client {
     }
   }
 
+  /**
+   * Run `frame` through the {@link useReceive} chain; the final `next()`
+   * dispatches it. A middleware that throws is logged and swallowed so one
+   * bad frame can't take down the receive loop.
+   */
   protected async _receiveThroughMiddleware(
     frame: OutboundFrame,
   ): Promise<void> {
@@ -900,6 +999,11 @@ export class Client {
     }
   }
 
+  /**
+   * Route a validated server frame to its per-type dispatcher. An
+   * out-of-band `error` frame rejects the request its `id` correlates to;
+   * an uncorrelated one is dropped (observable via {@link useReceive}).
+   */
   protected _dispatchFrame(frame: OutboundFrame): void {
     switch (frame.type) {
       case 'result':
@@ -930,6 +1034,12 @@ export class Client {
     }
   }
 
+  /**
+   * Settle the request correlated with a `result` frame. On `ok: false`
+   * the rejection is an `Error` messaged `` `${code}: ${message}` `` with
+   * `.code` and any structured `.data` attached as properties. A frame
+   * whose id matches nothing (a late reply after a timeout) is dropped.
+   */
   protected _dispatchResult(frame: ResultFrame): void {
     const pending = this._pending.get(frame.id);
     if (!pending) return;
@@ -958,6 +1068,11 @@ export class Client {
     }
   }
 
+  /**
+   * Handle a `subscribed` / `unsubscribed` ack. An `unsubscribed` whose id
+   * we sent just settles the waiting `unsubscribe()`; one we never sent is
+   * a server-initiated drop and removes the local subscription.
+   */
   protected _dispatchSubAck(frame: SubscribedFrame): void {
     if (frame.type === 'unsubscribed') {
       // Correlate against our own outstanding unsub before touching the
@@ -1002,6 +1117,11 @@ export class Client {
     }
   }
 
+  /**
+   * Deliver a `msg` frame to its channel handler. Messages for unknown
+   * channels are dropped, and a throwing handler is logged rather than
+   * allowed to break the receive loop.
+   */
   protected _dispatchMessage(frame: MessageFrame): void {
     const sub = this._subscriptions.get(frame.channel);
     if (!sub) return;

--- a/packages/rpc/Client.ts
+++ b/packages/rpc/Client.ts
@@ -77,6 +77,31 @@ const DEFAULT_RECONNECT: Required<ReconnectPolicy> = {
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
+ * Build the rejection handed to a caller whose request failed on the
+ * wire: an `Error` messaged `` `${code}: ${message}` `` that ALSO
+ * carries `code` — and `data` when the frame supplied any — as
+ * properties, so callers branch on the code instead of parsing the
+ * string.
+ *
+ * Both server-driven reject paths go through here (a `result` frame
+ * with `ok: false`, and a correlated out-of-band `error` frame) so
+ * they cannot drift back into handing out different error shapes.
+ * Only the `result` arm has structured detail to pass — the
+ * `ServerErrorFrame` shape has no `data` field — so the out-of-band
+ * caller simply omits the argument.
+ */
+function rejectionError(
+  code: string,
+  message: string,
+  data?: unknown,
+): Error & { code: string; data?: unknown } {
+  return Object.assign(new Error(`${code}: ${message}`), {
+    code,
+    ...(data === undefined ? {} : { data }),
+  });
+}
+
+/**
  * RPC + pub/sub client. See module JSDoc for lifecycle.
  *
  * @example
@@ -891,7 +916,7 @@ export class Client {
    * The shared `decodeFrame` helper in `protocol.ts` is hardcoded to the
    * server's input side (`InboundFrame`: `cmd` / `sub` / `unsub` /
    * `pub`) and returns null for anything else — so the client has to
-   * do its own envelope validation. We accept the four
+   * do its own envelope validation. We accept the five
    * client-facing types (`result` / `subscribed` / `unsubscribed` /
    * `msg` / `error`) and drop everything else as malformed.
    */
@@ -1001,8 +1026,10 @@ export class Client {
 
   /**
    * Route a validated server frame to its per-type dispatcher. An
-   * out-of-band `error` frame rejects the request its `id` correlates to;
-   * an uncorrelated one is dropped (observable via {@link useReceive}).
+   * out-of-band `error` frame rejects the request its `id` correlates
+   * to — with the frame's `code` attached, matching the `result` reject
+   * path; an uncorrelated one is dropped (observable via
+   * {@link useReceive}).
    */
   protected _dispatchFrame(frame: OutboundFrame): void {
     switch (frame.type) {
@@ -1026,7 +1053,11 @@ export class Client {
             if (pending.timeoutHandle !== undefined) {
               clearTimeout(pending.timeoutHandle);
             }
-            pending.reject(new Error(`${frame.code}: ${frame.message}`));
+            // Same shape as the `result` reject path: message format
+            // unchanged (`CODE: text`), with `code` attached so callers
+            // branch on protocol failures the same way they branch on
+            // handler failures. No `data` — the `error` frame has none.
+            pending.reject(rejectionError(frame.code, frame.message));
             this._pending.delete(frame.id);
           }
         }
@@ -1055,15 +1086,7 @@ export class Client {
       // can branch on the code and read the detail without parsing the
       // string.
       pending.reject(
-        Object.assign(
-          new Error(`${frame.error.code}: ${frame.error.message}`),
-          {
-            code: frame.error.code,
-            ...(frame.error.data === undefined
-              ? {}
-              : { data: frame.error.data }),
-          },
-        ),
+        rejectionError(frame.error.code, frame.error.message, frame.error.data),
       );
     }
   }

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -928,11 +928,16 @@ them, when a `command()` cannot be completed: `REQUEST_TIMEOUT` (no
 socket dropped with the call in flight) and `CLOSED` (`client.close()`
 was called with the call in flight).
 
-Only failures that arrive as a `result` frame attach a `.code`
-property to the rejection. The three above — and rejections caused by
-an out-of-band `error` frame — carry their code in the `Error`'s
-`message` instead, so branch on `err.message` when you need to
-distinguish them.
+Every failure that arrives from the server attaches a `.code` property
+to the rejection — both the `result` frame path above and a rejection
+caused by a correlated out-of-band `error` frame (e.g. `BAD_FORMAT`
+for a malformed frame whose id the server could recover). Only the
+`result` path can also carry `.data`; the `error` frame has no field
+for it.
+
+The three client-side codes above are the exception: they have no wire
+frame behind them and carry their code in the `Error`'s `message`
+only, so branch on `err.message` for those.
 
 ## Runtime support
 

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -145,7 +145,7 @@ await server.close();
 
 ### `new Server<T = unknown>(options?)`
 
-```ts
+```ts ignore
 type ServerOptions<T> = {
   pubsub?: PubSubAdapter; // defaults to MemoryPubSubAdapter
   upgrade?: (req, info) => UpgradeDecision<T> | Promise<UpgradeDecision<T>>;
@@ -174,7 +174,7 @@ own policy — close, log, or drop further sends.
 
 ### Configuration (chainable)
 
-```ts
+```ts ignore
 server.use(middleware); // Koa-style middleware
 server.command(name, schema | undefined, handler); // Command handler
 server.channel(name, options); // Channel registration
@@ -182,7 +182,7 @@ server.channel(name, options); // Channel registration
 
 ### Wire-up
 
-```ts
+```ts ignore
 server.handlers(); // → WebSocketHandler<T>, pass to WebServer
 await server.listen({ port }); // standalone — internal WebServer
 await server.publish(channel, data); // server-initiated broadcast
@@ -203,6 +203,8 @@ import { Server } from '@tundralibs/rpc';
 const rpc = new Server();
 rpc.command('ping', undefined, () => 'pong');
 
+const handleUsers = (_req: Request): Response => new Response('[]');
+
 const web = new WebServer('API', {
   mode: 'TCP',
   port: 8080,
@@ -221,6 +223,8 @@ await web.start();
 ### Standalone server
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
 const server = new Server();
 server.command('echo', undefined, (ctx) => ctx.payload);
 
@@ -306,6 +310,11 @@ later. A subsequent `connect()` clears that and reconnects normally.
 Two middleware chains — one per direction:
 
 ```ts
+import { Client } from '@tundralibs/rpc';
+
+const client = new Client({ url: 'ws://localhost:8080' });
+const getAuthToken = (): string => 'token';
+
 client.useSend(async (ctx, next) => {
   // ctx.frame is the OUTBOUND frame (cmd / sub / unsub / pub).
   // Mutate, log, retry — then call next() to write the frame.
@@ -335,7 +344,7 @@ send middleware reject the awaiting caller of
 
 ### Lifecycle
 
-```ts
+```ts ignore
 client.state; // 'DISCONNECTED' | 'CONNECTING' | 'CONNECTED' | 'CLOSING'
 await client.connect(); // open WebSocket, resolve on 'open'
 await client.command(name, body); // request/response
@@ -379,6 +388,10 @@ You can pass a `httpHandler` if you want non-WS requests to do
 something other than 404:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 await server.listen({
   port: 8080,
   httpHandler: () => new Response('Use the WebSocket endpoint'),
@@ -388,7 +401,11 @@ await server.listen({
 ### Authenticated upgrade with typed connection state
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
 type Conn = { userId: string; subscriptions: Set<string> };
+
+const verifyToken = (_token: string | null): string | undefined => undefined;
 
 const server = new Server<Conn>({
   upgrade: (req) => {
@@ -414,11 +431,19 @@ await server.listen({ port: 8080 });
 any validator that throws on invalid input fits.
 
 ```ts
-import { GuardianProxy, type } from '@tundralibs/guardian';
+import { Guardian } from '@tundralibs/guardian';
+import { Server } from '@tundralibs/rpc';
 
-const CreateUser = type({
-  name: 'string',
-  email: 'string',
+const server = new Server();
+const db = {
+  users: {
+    create: (_user: { name: string; email: string }) => Promise.resolve('u-1'),
+  },
+};
+
+const CreateUser = Guardian.object({
+  name: Guardian.string(),
+  email: Guardian.string(),
 }); // assume Guardian; replace with your schema lib
 
 server.command(
@@ -435,6 +460,10 @@ server.command(
 Plain hand-written validators work too:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 server.command(
   'sendMessage',
   (input) => {
@@ -454,6 +483,10 @@ server.command(
 ### Middleware: timing + logging
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 server.use(async (ctx, next) => {
   const start = performance.now();
   try {
@@ -473,6 +506,10 @@ the throw into a `result` frame with `ok: false`. Custom error codes
 flow through via `err.code`.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 server.use(async (ctx, next) => {
   if (!(ctx.ws.data as { userId?: string }).userId) {
     const err = new Error('not authenticated') as Error & { code: string };
@@ -486,6 +523,12 @@ server.use(async (ctx, next) => {
 Or short-circuit silently (returns `ok: true` with no data):
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+import type { ServerWebSocket } from '@tundralibs/compat/webserver';
+
+const server = new Server();
+const rateLimited = (_ws: ServerWebSocket<unknown>) => false;
+
 server.use(async (ctx, next) => {
   if (rateLimited(ctx.ws)) {
     return; // skip handler, but ack the request
@@ -497,6 +540,11 @@ server.use(async (ctx, next) => {
 ### Channel with authorize hook
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+const canJoin = (_userId: string, _room: string): boolean => true;
+
 server.channel('chat:room1', {
   authorize: (ctx) => {
     const userId = (ctx.ws.data as { userId?: string }).userId;
@@ -514,6 +562,10 @@ server.channel('chat:room1', {
 ### Server-initiated broadcast
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 // Anywhere on the server
 await server.publish('chat:room1', {
   from: 'system',
@@ -530,6 +582,11 @@ By default, clients can only **subscribe** to channels — they can't
 publish into them. Add an `onPublish` to opt in:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+const parseChatMessage = (payload: unknown) => payload as { text: string };
+
 server.channel('chat:room1', {
   authorize: (ctx) => Boolean((ctx.ws.data as { userId?: string }).userId),
   onPublish: async (ctx, payload) => {
@@ -551,6 +608,11 @@ subscribe time, so a publish without a prior `subscribe()` is rejected
 with `NOT_SUBSCRIBED`:
 
 ```ts
+import { Client } from '@tundralibs/rpc';
+
+const client = new Client({ url: 'ws://localhost:8080' });
+const render = (_msg: unknown) => {};
+
 // Subscribe first, then publish to the same channel.
 await client.subscribe('chat:room1', (msg) => render(msg));
 await client.publish('chat:room1', { text: 'hi' });
@@ -573,6 +635,16 @@ already give you `ctx.id`, schema validation, structured ack via
 return value, custom error codes via thrown errors:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+type Conn = { userId: string };
+
+const server = new Server<Conn>();
+const ChatMessageSchema = {
+  parse: (input: unknown) => input as { channel: string; message: string },
+};
+const canSendTo = (_userId: string, _channel: string): boolean => true;
+
 server.command(
   'publishChat',
   (input) => ChatMessageSchema.parse(input),
@@ -598,7 +670,7 @@ The default `MemoryPubSubAdapter` is in-process only. For broadcast
 across multiple node instances, write an adapter against the same
 `PubSubAdapter` interface and pass it to the server:
 
-```ts
+```ts ignore
 import {
   type AdapterCapabilities,
   Server,

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -145,14 +145,36 @@ await server.close();
 
 ### `new Server<T = unknown>(options?)`
 
-```ts ignore
-type ServerOptions<T> = {
-  pubsub?: PubSubAdapter; // defaults to MemoryPubSubAdapter
-  upgrade?: (req, info) => UpgradeDecision<T> | Promise<UpgradeDecision<T>>;
-  maxFrameSize?: number; // bytes — default 1 MB; 0 disables
-  backpressureThreshold?: number; // bytes — undefined disables observation
-  onBackpressure?: (ws, bufferedAmount) => void | Promise<void>;
-};
+Every option is optional; this spells all of them out at once.
+
+```ts
+import { Server } from '@tundralibs/rpc';
+import { MemoryPubSubAdapter } from '@tundralibs/rpc/pubsub';
+
+type Conn = { userId: string };
+
+const server = new Server<Conn>({
+  // Pub/sub adapter — this is the default when omitted.
+  pubsub: new MemoryPubSubAdapter(),
+
+  // Decides what `T` becomes for each connection.
+  upgrade: (req, info) => {
+    const userId = req.headers.get('x-user-id');
+    if (!userId) return false; // refuse — falls through to HTTP
+    console.log('upgrade from', info.remoteAddress);
+    return { data: { userId } };
+  },
+
+  // Incoming frames over this many bytes are rejected before
+  // decoding. Default 1 MB; 0 disables the cap.
+  maxFrameSize: 1_048_576,
+
+  // Outbound-buffer soft cap in bytes. Omit to disable observation.
+  backpressureThreshold: 4 * 1_048_576,
+  onBackpressure: (ws, bufferedAmount) => {
+    console.warn('slow consumer', ws.data.userId, bufferedAmount);
+  },
+});
 ```
 
 `T` is the per-connection state type. The `upgrade` hook (same shape
@@ -174,18 +196,47 @@ own policy — close, log, or drop further sends.
 
 ### Configuration (chainable)
 
-```ts ignore
-server.use(middleware); // Koa-style middleware
-server.command(name, schema | undefined, handler); // Command handler
-server.channel(name, options); // Channel registration
+`use`, `command`, and `channel` all return the server, so registration
+chains:
+
+```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server()
+  // Koa-style middleware — wraps every command.
+  .use(async (ctx, next) => {
+    console.log('->', ctx.cmd);
+    await next();
+  })
+  // Command with no validator — the handler gets the raw payload.
+  .command('echo', undefined, (ctx) => ctx.payload)
+  // Command with a validator — `ctx.payload` is the validator's return type.
+  .command(
+    'greet',
+    (input) => input as { name: string },
+    (ctx) => `hello ${ctx.payload.name}`,
+  )
+  // Channel registration — `{}` is subscribe-only, no hooks.
+  .channel('news', {});
 ```
 
 ### Wire-up
 
-```ts ignore
-server.handlers(); // → WebSocketHandler<T>, pass to WebServer
-await server.listen({ port }); // standalone — internal WebServer
-await server.publish(channel, data); // server-initiated broadcast
+```ts
+import { Server } from '@tundralibs/rpc';
+import type { WebSocketHandler } from '@tundralibs/compat/webserver';
+
+const server = new Server();
+server.channel('news', {});
+
+// Either — mount into a WebServer you already run…
+const handlers: WebSocketHandler<unknown> = server.handlers();
+console.log('mount these on WebServer.websocket:', handlers);
+
+// …or run standalone on an internally-managed WebServer.
+await server.listen({ port: 8080 });
+
+await server.publish('news', { headline: 'Hello' }); // broadcast
 await server.close(); // tear down
 ```
 
@@ -271,19 +322,42 @@ await client.close();
 
 ### `new Client(options)`
 
+`url` is the only required option; the rest are shown here with their
+defaults.
+
 ```ts
-type ClientOptions = {
-  url: string; // ws:// or wss://
-  protocols?: string | string[]; // sub-protocol(s) on handshake
-  defaultTimeoutMs?: number; // default 30_000; 0 disables
-  reconnect?: {
-    enabled?: boolean; // default true
-    maxAttempts?: number; // default 10
-    initialDelayMs?: number; // default 500
-    backoffFactor?: number; // default 2
-    maxDelayMs?: number; // default 30_000
-  };
-};
+import { Client } from '@tundralibs/rpc';
+
+const client = new Client({
+  url: 'ws://localhost:8080', // ws:// or wss://
+
+  // Sub-protocol(s) offered on the handshake. Nothing in this package
+  // requires one — the server picks via its upgrade hook's `protocol`.
+  protocols: ['my-app-v1'],
+
+  defaultTimeoutMs: 30_000, // 0 disables command timeouts
+
+  reconnect: {
+    enabled: true,
+    maxAttempts: 10,
+    initialDelayMs: 500,
+    backoffFactor: 2,
+    maxDelayMs: 30_000,
+  },
+
+  // A subscription replayed after a reconnect was refused (the
+  // connection lost its authorization, or the channel is gone). The
+  // dead subscription has already been dropped when this fires.
+  onSubscriptionError: (channel, error) => {
+    console.warn('re-subscribe refused:', channel, error.message);
+  },
+
+  // Auto-reconnect exhausted `reconnect.maxAttempts`. The client now
+  // stays DISCONNECTED and will not retry on its own.
+  onReconnectFailed: (attempts) => {
+    console.error(`gave up after ${attempts} attempts`);
+  },
+});
 ```
 
 When `reconnect.enabled` is true (default), an unexpected close
@@ -344,12 +418,32 @@ send middleware reject the awaiting caller of
 
 ### Lifecycle
 
-```ts ignore
-client.state; // 'DISCONNECTED' | 'CONNECTING' | 'CONNECTED' | 'CLOSING'
-await client.connect(); // open WebSocket, resolve on 'open'
-await client.command(name, body); // request/response
-await client.subscribe(channel, h); // returns subscription handle
-await client.publish(channel, p); // ack'd publish
+```ts
+import { Client } from '@tundralibs/rpc';
+import type { ClientState, ClientSubscription } from '@tundralibs/rpc';
+
+const client = new Client({ url: 'ws://localhost:8080' });
+
+// 'DISCONNECTED' | 'CONNECTING' | 'CONNECTED' | 'CLOSING'
+const state: ClientState = client.state;
+console.log(state);
+
+await client.connect(); // open WebSocket, resolves on 'open'
+
+// Request/response — the type parameter types the resolved value.
+const reply = await client.command<{ text: string }>('echo', { text: 'hi' });
+console.log(reply.text);
+
+// Returns a subscription handle.
+const sub: ClientSubscription = await client.subscribe('chat:room1', (data) => {
+  console.log('msg:', data);
+});
+
+// Ack'd publish — needs `onPublish` on the server's channel, and the
+// active subscription above (see "Client publish via channel onPublish").
+await client.publish('chat:room1', { text: 'hi' });
+
+await sub.unsubscribe();
 await client.close(); // graceful close, stops reconnects
 ```
 
@@ -443,8 +537,8 @@ const db = {
 
 const CreateUser = Guardian.object({
   name: Guardian.string(),
-  email: Guardian.string(),
-}); // assume Guardian; replace with your schema lib
+  email: Guardian.string().email(),
+});
 
 server.command(
   'createUser',
@@ -670,13 +764,24 @@ The default `MemoryPubSubAdapter` is in-process only. For broadcast
 across multiple node instances, write an adapter against the same
 `PubSubAdapter` interface and pass it to the server:
 
-```ts ignore
+```ts
 import {
   type AdapterCapabilities,
-  Server,
   PubSubAdapter,
+  Server,
   type Subscription,
 } from '@tundralibs/rpc';
+
+// The surface your Redis client of choice has to provide — `cacher`
+// already speaks Redis, or use a direct driver.
+declare class RedisClient {
+  constructor(opts: { url: string });
+  on(event: 'message', cb: (topic: string, raw: string) => void): void;
+  subscribe(topic: string): void;
+  unsubscribe(topic: string): void;
+  publish(topic: string, payload: string): Promise<void>;
+  quit(): Promise<void>;
+}
 
 class RedisPubSubAdapter extends PubSubAdapter {
   override readonly capabilities: AdapterCapabilities = {
@@ -689,24 +794,76 @@ class RedisPubSubAdapter extends PubSubAdapter {
     backpressureVisibility: false,
   };
 
-  // ... use cacher's redis client or a direct driver
+  // Two connections: a Redis connection in subscribe mode can't issue
+  // normal commands, so PUBLISH needs its own.
+  private __pub: RedisClient;
+  private __sub: RedisClient;
+  private __handlers = new Map<string, Set<(data: unknown) => void>>();
+  private __closed = false;
 
-  override subscribe(topic: string, handler: (data: unknown) => void): Subscription {
-    // SUBSCRIBE topic on a pub-only Redis connection
-    // Route incoming messages to handler
-    // Return { unsubscribe() { /* UNSUBSCRIBE */ } }
+  constructor(opts: { url: string }) {
+    super();
+    this.__pub = new RedisClient(opts);
+    this.__sub = new RedisClient(opts);
+    this.__sub.on('message', (topic, raw) => {
+      const handlers = this.__handlers.get(topic);
+      if (!handlers) return;
+      let data: unknown;
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        return; // malformed — drop
+      }
+      // One throwing subscriber must not stop the rest of the fan-out.
+      for (const fn of [...handlers]) {
+        try {
+          fn(data);
+        } catch { /* swallow */ }
+      }
+    });
+  }
+
+  override subscribe(
+    topic: string,
+    handler: (data: unknown) => void,
+  ): Subscription {
+    if (this.__closed) throw new Error('adapter closed');
+    let set = this.__handlers.get(topic);
+    if (!set) {
+      set = new Set();
+      this.__handlers.set(topic, set);
+      this.__sub.subscribe(topic); // SUBSCRIBE on the first local handler
+    }
+    set.add(handler);
+    return {
+      unsubscribe: () => {
+        const current = this.__handlers.get(topic);
+        if (!current) return;
+        current.delete(handler); // idempotent
+        if (current.size === 0) {
+          this.__handlers.delete(topic);
+          this.__sub.unsubscribe(topic); // UNSUBSCRIBE on the last one
+        }
+      },
+    };
   }
 
   override async publish(topic: string, data: unknown): Promise<void> {
-    // PUBLISH topic JSON.stringify(data)
+    if (this.__closed) return; // publish after close must not deliver
+    await this.__pub.publish(topic, JSON.stringify(data));
   }
 
   override async close(): Promise<void> {
-    // QUIT
+    if (this.__closed) return; // idempotent
+    this.__closed = true;
+    this.__handlers.clear();
+    await Promise.all([this.__sub.quit(), this.__pub.quit()]);
   }
 }
 
-const server = new Server({ pubsub: new RedisPubSubAdapter(...) });
+const server = new Server({
+  pubsub: new RedisPubSubAdapter({ url: 'redis://localhost:6379' }),
+});
 ```
 
 Full adapter contract and capability flags: [Rpc-PubSub](docs/Rpc-PubSub.md).
@@ -731,6 +888,51 @@ same channel.
 | `PUBLISH_ERROR`   | server   | `onPublish` handler threw                                                                 |
 | `HANDLER_ERROR`   | server   | Command handler threw without a custom `.code`                                            |
 | _custom_          | userland | Throw `Object.assign(new Error(msg), { code: 'YOUR_CODE' })` from a handler or middleware |
+
+A thrown error may also carry a `data` property. It rides along on the
+`result` frame's `error` object and reaches the caller as `.data` on
+the rejection, so a failure can return structure rather than only a
+string:
+
+```ts
+import { Client, Server } from '@tundralibs/rpc';
+
+const server = new Server();
+server.command('createUser', undefined, () => {
+  throw Object.assign(new Error('invalid user'), {
+    code: 'VALIDATION',
+    data: { fields: { email: 'must be an email address' } },
+  });
+});
+await server.listen({ port: 8080, hostname: '127.0.0.1' });
+
+const client = new Client({ url: 'ws://127.0.0.1:8080' });
+await client.connect();
+
+try {
+  await client.command('createUser', { email: 'nope' });
+} catch (err) {
+  const { code, data } = err as Error & { code?: string; data?: unknown };
+  console.error(code, data); // 'VALIDATION' { fields: { … } }
+}
+
+await client.close();
+await server.close();
+```
+
+`error.data` is sent verbatim to the caller — keep internals out of it.
+
+Three more codes are raised **client-side**, with no wire frame behind
+them, when a `command()` cannot be completed: `REQUEST_TIMEOUT` (no
+`result` arrived within `defaultTimeoutMs`), `CONNECTION_LOST` (the
+socket dropped with the call in flight) and `CLOSED` (`client.close()`
+was called with the call in flight).
+
+Only failures that arrive as a `result` frame attach a `.code`
+property to the rejection. The three above — and rejections caused by
+an out-of-band `error` frame — carry their code in the `Error`'s
+`message` instead, so branch on `err.message` when you need to
+distinguish them.
 
 ## Runtime support
 

--- a/packages/rpc/Server.ts
+++ b/packages/rpc/Server.ts
@@ -95,20 +95,33 @@ export class Server<T = unknown> {
   // reachable from a subclass, but may be rearranged between minor
   // versions. Nothing here is part of the public surface unless typed
   // as `public`.
+  /** Constructor options, stored unmodified. */
   protected readonly _opts: ServerOptions<T>;
+  /** Active pub/sub adapter; surfaced publicly via {@link adapter}. */
   protected readonly _pubsub: PubSubAdapter;
+  /** The underlying transport primitive this Server routes frames for. */
   protected readonly _wss: WebSocketServer<T, InboundFrame>;
 
+  /** Command middleware, run in registration order before the handler. */
   protected readonly _middleware: Middleware<T>[] = [];
   private readonly __commands = new Map<string, _CommandRegistration<T>>();
   // `protected` extension seam — a subclass (see examples/pattern-subscribe.ts)
   // reads/writes this to register channels lazily. Explicitly typed because
   // JSR slow-types requires an explicit type on every public-API symbol.
+  /** Registered channels keyed by exact name — no pattern matching. */
   protected readonly _channels: Map<string, ChannelOptions<T>> = new Map();
   private readonly __connState = new WeakMap<ServerWebSocket<T>, _ConnState>();
 
+  /** Set by {@link close}; makes late upgrades and frames be refused. */
   protected _closed = false;
 
+  /**
+   * Create a server with no commands or channels registered — chain
+   * {@link command} and {@link channel} next.
+   *
+   * @param options - Without `pubsub`, a {@link MemoryPubSubAdapter} is
+   *   created, which does not broadcast across processes.
+   */
   constructor(options: ServerOptions<T> = {}) {
     this._opts = options;
     this._pubsub = options.pubsub ?? new MemoryPubSubAdapter();
@@ -372,6 +385,11 @@ export class Server<T = unknown> {
   // Internal handlers
   // =========================================================================
 
+  /**
+   * Tear down a disconnected connection's subscriptions and fire each
+   * channel's `onUnsubscribe`. Hooks are fire-and-forget here — the socket
+   * is already gone, so throws and rejections are swallowed.
+   */
   protected _handleClose(ws: ServerWebSocket<T>): void {
     const state = this.__connState.get(ws);
     if (!state) return;
@@ -413,6 +431,11 @@ export class Server<T = unknown> {
     }
   }
 
+  /**
+   * Route one decoded client frame to its per-type handler. After
+   * {@link close} nothing is served — the socket is closed instead, since
+   * a mounted outer `WebServer` can keep delivering frames.
+   */
   protected async _dispatch(
     ws: ServerWebSocket<T>,
     frame: InboundFrame,
@@ -447,6 +470,14 @@ export class Server<T = unknown> {
   // Command path
   // -------------------------------------------------------------------------
 
+  /**
+   * Serve a `cmd` frame: validate, run the middleware chain, invoke the
+   * handler, and answer with exactly one `result`. Always replies — an
+   * unregistered command answers `UNKNOWN_COMMAND`, a rejected validator
+   * `VALIDATION`, and a throwing handler `HANDLER_ERROR` unless it
+   * attached a string `.code`. A handler's `.data` rides along on the
+   * error frame as structured detail.
+   */
   protected async _handleCommand(
     ws: ServerWebSocket<T>,
     frame: CommandFrame,
@@ -542,6 +573,15 @@ export class Server<T = unknown> {
   // Pub/Sub path
   // -------------------------------------------------------------------------
 
+  /**
+   * Serve a `sub` frame, answering `subscribed` on success or a `result`
+   * error (`UNKNOWN_CHANNEL`, `AUTHZ_ERROR`, `FORBIDDEN`). `authorize` is
+   * re-run on every subscribe, so a client whose access was revoked has
+   * its existing subscription dropped — firing `onUnsubscribe` — rather
+   * than keeping the one it was granted earlier. A duplicate subscribe
+   * from a still-authorized client is re-acked without re-firing
+   * `onSubscribe`.
+   */
   protected async _handleSubscribe(
     ws: ServerWebSocket<T>,
     frame: SubscribeFrame,
@@ -640,6 +680,12 @@ export class Server<T = unknown> {
     }
   }
 
+  /**
+   * Serve an `unsub` frame. Idempotent: a stray unsub for a channel that
+   * was never subscribed still gets an `unsubscribed` ack, but only a
+   * removal that actually took effect fires `onUnsubscribe`, keeping that
+   * hook one-for-one with `onSubscribe`.
+   */
   protected async _handleUnsubscribe(
     ws: ServerWebSocket<T>,
     frame: UnsubscribeFrame,
@@ -678,6 +724,13 @@ export class Server<T = unknown> {
     }
   }
 
+  /**
+   * Serve a `pub` frame by handing it to the channel's `onPublish` hook.
+   * The client must already be subscribed — that is what carries the
+   * subscribe-time `authorize` decision onto this path. Answers
+   * `UNKNOWN_CHANNEL`, `PUBLISH_REFUSED` (no `onPublish` registered),
+   * `NOT_SUBSCRIBED`, or `PUBLISH_ERROR` if the hook throws.
+   */
   protected async _handlePublish(
     ws: ServerWebSocket<T>,
     frame: PublishFrame,
@@ -736,6 +789,11 @@ export class Server<T = unknown> {
   // Wire helpers
   // -------------------------------------------------------------------------
 
+  /**
+   * Encode and send one frame, then poll back-pressure so
+   * {@link ServerOptions.onBackpressure} fires for Server-originated
+   * traffic. A socket that closed mid-send is swallowed, not thrown.
+   */
   protected _send(ws: ServerWebSocket<T>, frame: OutboundFrame): void {
     try {
       ws.send(encodeFrame(frame));
@@ -750,6 +808,7 @@ export class Server<T = unknown> {
     this._wss.__checkBackpressure(ws);
   }
 
+  /** Answer request `id` with a success `result` carrying `data`. */
   protected _sendResultOk(
     ws: ServerWebSocket<T>,
     id: string,
@@ -758,6 +817,14 @@ export class Server<T = unknown> {
     this._send(ws, { id, type: 'result', ok: true, data });
   }
 
+  /**
+   * Answer request `id` with a failure `result`. The client rejects on
+   * `` `${code}: ${message}` `` but reads `code` off the error object, so
+   * `code` is the stable contract and `message` is free-form.
+   *
+   * @param data - Optional structured detail. Omitted from the frame
+   *   entirely when absent, keeping it byte-identical to pre-`data` peers.
+   */
   protected _sendResultError(
     ws: ServerWebSocket<T>,
     id: string,
@@ -776,6 +843,11 @@ export class Server<T = unknown> {
     });
   }
 
+  /**
+   * Send a subscription ack echoing the client's frame `id`. That echo is
+   * what lets the client tell its own unsub ack apart from a
+   * server-initiated drop, which carries an id the client never sent.
+   */
   protected _sendSubscribed(
     ws: ServerWebSocket<T>,
     id: string,

--- a/packages/rpc/Server.ts
+++ b/packages/rpc/Server.ts
@@ -258,6 +258,11 @@ export class Server<T = unknown> {
    *
    * @example
    * ```ts
+   * import { Server } from '@tundralibs/rpc';
+   *
+   * const server = new Server();
+   * const clusterMode = true;
+   *
    * if (clusterMode && !server.adapter.capabilities.crossProcess) {
    *   console.warn('cluster mode with single-process pub/sub adapter');
    * }
@@ -298,6 +303,10 @@ export class Server<T = unknown> {
    *
    * @example Heartbeat sweeper
    * ```ts
+   * import { Server } from '@tundralibs/rpc';
+   *
+   * const server = new Server();
+   *
    * server.command('heartbeat', undefined, (ctx) => {
    *   (ctx.ws.data as { lastSeen?: number }).lastSeen = Date.now();
    * });

--- a/packages/rpc/docs/Rpc-Extending.md
+++ b/packages/rpc/docs/Rpc-Extending.md
@@ -77,7 +77,17 @@ export class PatternServer<T = unknown> extends Server<T> {
 Use it:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+import type { ChannelOptions } from '@tundralibs/rpc';
+
+// The subclass defined in the block above.
+declare class PatternServer<T = unknown> extends Server<T> {
+  pattern(glob: string, opts: ChannelOptions<T>): this;
+}
+
 type Conn = { userId: string };
+
+const canJoin = (_userId: string, _channel: string): boolean => true;
 
 const server = new PatternServer<Conn>();
 
@@ -121,6 +131,10 @@ sub/unsub/pub frames before Hub's standard handling, override the
 matching `_handle*` method.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+import type { InboundFrame } from '@tundralibs/rpc';
+import type { ServerWebSocket } from '@tundralibs/compat/webserver';
+
 class LoggingServer<T> extends Server<T> {
   override async _handleSubscribe(
     ws: ServerWebSocket<T>,
@@ -148,6 +162,13 @@ this, but `onSubscribe` + a per-channel ring buffer does it in
 frames, so the client can't tell them apart.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+type Conn = { userId: string };
+
+const server = new Server<Conn>();
+const canJoin = (_userId: string, _channel: string): boolean => true;
+
 const buffers = new Map<string, unknown[]>();
 const BUFFER_SIZE = 50;
 
@@ -201,6 +222,10 @@ contract conversation when someone needs it.
 Want to inspect every outbound frame Hub sends? Override `_send`:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+import type { OutboundFrame } from '@tundralibs/rpc';
+import type { ServerWebSocket } from '@tundralibs/compat/webserver';
+
 class ObservedHub<T> extends Server<T> {
   outboundCount = 0;
 
@@ -223,6 +248,12 @@ backpressure, or anything else the primitive exposes that Hub doesn't
 surface directly.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const metrics = {
+  bp: { inc: (_labels: { remote: string | undefined }, _value: number) => {} },
+};
+
 class MetricsServer<T> extends Server<T> {
   constructor() {
     super();

--- a/packages/rpc/docs/Rpc-Extending.md
+++ b/packages/rpc/docs/Rpc-Extending.md
@@ -28,7 +28,7 @@ generalizes.
 
 ## Recipe: Pattern subscribe via subclass
 
-Want `chat:*` wildcards without waiting for Hub to ship pattern
+Want `chat:*` wildcards without waiting for `Server` to ship pattern
 matching? Override `_handleSubscribe`:
 
 ```ts
@@ -102,7 +102,7 @@ server.pattern('user:**', {
 ```
 
 That's the entire feature. ~25 lines. You pick the glob syntax,
-precedence (exact-first vs pattern-first), cleanup policy. Hub
+precedence (exact-first vs pattern-first), cleanup policy. `Server`
 provides the primitives; you compose.
 
 For a runnable version, see
@@ -114,7 +114,7 @@ For a runnable version, see
   `chat:room1` won't reach a `chat:*` subscriber on instance B unless
   the underlying pub/sub adapter does pattern matching server-side
   (Redis `PSUBSCRIBE`, NATS `*`/`>`). The subclass approach lazily
-  registers concrete channels — fine within one Hub, but the adapter
+  registers concrete channels — fine within one `Server`, but the adapter
   still sees only literal names.
 - **Capability self-description.** `MemoryPubSubAdapter.capabilities.patternSubscribe`
   stays `false` because the _adapter_ still doesn't pattern-match. The
@@ -126,8 +126,8 @@ Until then, the subclass approach covers single-process apps.
 
 ## Recipe: Custom inbound frame inspection
 
-Hub's middleware wraps **commands**. If you need to react to
-sub/unsub/pub frames before Hub's standard handling, override the
+`Server`'s middleware wraps **commands**. If you need to react to
+sub/unsub/pub frames before `Server`'s standard handling, override the
 matching `_handle*` method.
 
 ```ts
@@ -156,7 +156,7 @@ class LoggingServer<T> extends Server<T> {
 
 ## Recipe: Replay — last-N messages on subscribe
 
-"New subscribers should see the last 50 messages." Hub doesn't ship
+"New subscribers should see the last 50 messages." `Server` doesn't ship
 this, but `onSubscribe` + a per-channel ring buffer does it in
 ~10 lines. The replay path uses the same wire shape as live `msg`
 frames, so the client can't tell them apart.
@@ -207,7 +207,7 @@ not broadcast through the adapter).
 - **Persistence.** The buffer dies with the process. Restart the
   server → no history. Fine for "last 50 chat messages while you
   reconnect" — not fine for guaranteed event delivery.
-- **Cross-process replay.** Each Hub instance has its own buffer. A
+- **Cross-process replay.** Each `Server` instance has its own buffer. A
   subscriber on instance B doesn't see messages captured by
   instance A.
 - **Replay-by-cursor.** You can't say "give me everything since
@@ -219,14 +219,14 @@ contract conversation when someone needs it.
 
 ## Recipe: Wrapping send for outbound observation
 
-Want to inspect every outbound frame Hub sends? Override `_send`:
+Want to inspect every outbound frame `Server` sends? Override `_send`:
 
 ```ts
 import { Server } from '@tundralibs/rpc';
 import type { OutboundFrame } from '@tundralibs/rpc';
 import type { ServerWebSocket } from '@tundralibs/compat/webserver';
 
-class ObservedHub<T> extends Server<T> {
+class ObservedServer<T> extends Server<T> {
   outboundCount = 0;
 
   override _send(ws: ServerWebSocket<T>, frame: OutboundFrame): void {
@@ -241,10 +241,10 @@ acknowledgement, msg fan-out, and protocol error. One choke point.
 
 ## Reaching the underlying primitive
 
-Hub wraps a `WebSocketServer` from `@tundralibs/compat/websocket`.
+`Server` wraps a `WebSocketServer` from `@tundralibs/compat/websocket`.
 You can reach it through `server._wss` (from a subclass) if you need to
 register a secondary message handler, set a custom codec, observe
-backpressure, or anything else the primitive exposes that Hub doesn't
+backpressure, or anything else the primitive exposes that `Server` doesn't
 surface directly.
 
 ```ts
@@ -266,11 +266,11 @@ class MetricsServer<T> extends Server<T> {
 
 ## When NOT to subclass
 
-If your extension is something most Hub users would want, it's
-probably worth proposing as a Hub feature instead of subclassing.
+If your extension is something most `Server` users would want, it's
+probably worth proposing as a package feature instead of subclassing.
 The subclass approach is the right tool when:
 
-- You need a policy decision Hub deliberately leaves out (pattern
+- You need a policy decision `Server` deliberately leaves out (pattern
   syntax, glob vs MQTT vs regex, exact-vs-pattern precedence).
 - The feature is specific to your deployment / topology.
 - You want to ship the change immediately rather than wait for a

--- a/packages/rpc/docs/Rpc-Middleware.md
+++ b/packages/rpc/docs/Rpc-Middleware.md
@@ -28,6 +28,8 @@ routing — anything that crosscuts your handlers.
 ```ts
 import type { Middleware } from '@tundralibs/rpc';
 
+type MyConn = { userId: string };
+
 const mw: Middleware<MyConn> = async (ctx, next) => {
   // before
   await next();
@@ -45,6 +47,10 @@ Middleware runs in registration order, with each one wrapping the rest
 of the chain in `next()`:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 server.use(async (_, next) => {
   console.log('1: before');
   await next();
@@ -76,6 +82,10 @@ Outer middleware sees the inner middleware's after-effects in
 Middleware writes to it; later middleware and the handler read.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 server.use(async (ctx, next) => {
   ctx.state.startedAt = performance.now();
   await next();
@@ -104,6 +114,12 @@ any downstream middleware. The framework still acks the request with
 `ok: true` (data: `undefined`) so the client isn't left waiting:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+import type { ServerWebSocket } from '@tundralibs/compat/webserver';
+
+const server = new Server();
+const rateLimited = (_ws: ServerWebSocket<unknown>) => false;
+
 server.use(async (ctx, _next) => {
   if (rateLimited(ctx.ws)) {
     // handler never runs; client gets { ok: true, data: undefined }
@@ -123,6 +139,10 @@ Throws from middleware (or the handler) become `result` frames with
 `HANDLER_ERROR`.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 class AuthError extends Error {
   code = 'UNAUTHENTICATED';
   constructor() {
@@ -151,6 +171,11 @@ Wrap `await next()` in `try / catch` if you want middleware to log /
 swallow / transform errors before they reach the client:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+const metrics = { commandErrors: { inc: (_labels: { cmd: string }) => {} } };
+
 server.use(async (ctx, next) => {
   try {
     await next();
@@ -167,7 +192,13 @@ Set typed connection state in the upgrade hook, gate commands in
 middleware:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
 type Conn = { userId: string; roles: Set<string> };
+
+const verifyToken = (_token: string | null): string | undefined => undefined;
+const rolesFor = (_userId: string): Set<string> => new Set();
+const requiredRolesFor = (_cmd: string): string[] => [];
 
 const server = new Server<Conn>({
   upgrade: (req) => {
@@ -197,7 +228,11 @@ server.use(async (ctx, next) => {
 Per-connection token bucket in `ws.data` (or a separate WeakMap):
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
 type Conn = { tokens: number; refillAt: number };
+
+const server = new Server();
 
 server.use(async (ctx, next) => {
   const now = Date.now();
@@ -223,6 +258,10 @@ server.use(async (ctx, next) => {
 ## Recipe: Timing + Logging
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 server.use(async (ctx, next) => {
   const t0 = performance.now();
   let outcome: 'ok' | 'fail' = 'ok';
@@ -247,6 +286,10 @@ middleware and the handler.
 Middleware sees every command. Use `ctx.cmd` to scope behavior:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
+const server = new Server();
+
 const PUBLIC_COMMANDS = new Set(['ping', 'time']);
 
 server.use(async (ctx, next) => {
@@ -264,6 +307,14 @@ sign the middleware should be split — register the auth one only on
 private commands by wrapping them in a higher-order helper:
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+import type { CommandHandler } from '@tundralibs/rpc';
+
+type Conn = { userId: string };
+
+const server = new Server<Conn>();
+const PostSchema = (input: unknown) => input as { title: string };
+
 const requireAuth =
   <P, R>(handler: CommandHandler<Conn, P, R>): CommandHandler<Conn, P, R> =>
   async (ctx) => {
@@ -298,6 +349,8 @@ The client pings the server on a timer; the server tracks last-seen
 and sweeps stale connections.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
 type Conn = { lastSeen?: number };
 
 const server = new Server<Conn>({
@@ -335,6 +388,8 @@ first, push from the server using a system channel and have clients
 echo back via a `pong` command.
 
 ```ts
+import { Server } from '@tundralibs/rpc';
+
 type Conn = { lastPong?: number };
 
 const server = new Server<Conn>({

--- a/packages/rpc/docs/Rpc-Middleware.md
+++ b/packages/rpc/docs/Rpc-Middleware.md
@@ -4,9 +4,9 @@ Koa-style middleware composes around every command. Use it for
 auth, rate limits, timing, logging, request-scoped state, and error
 routing — anything that crosscuts your handlers.
 
-> Hub middleware is **per-command** — it sees `ctx.cmd`, `ctx.payload`,
+> `Server` middleware is **per-command** — it sees `ctx.cmd`, `ctx.payload`,
 > `ctx.id`. For lower-level message middleware (sees raw decoded
-> messages, not Hub commands), use the
+> messages, not `Server` commands), use the
 > [`@tundralibs/compat/websocket`](../../compat/websocket/Compat-WebSocket.md)
 > primitive directly.
 
@@ -332,8 +332,8 @@ server.command('createPost', PostSchema, requireAuth(async (ctx) => {/* … */})
 
 ## Recipe: Heartbeat / Liveness
 
-Hub deliberately doesn't ship a built-in heartbeat. **Application-level
-heartbeat is a 10-line userland recipe** because Hub already gives you
+`Server` deliberately doesn't ship a built-in heartbeat. **Application-level
+heartbeat is a 10-line userland recipe** because `Server` already gives you
 everything you need: command handlers, `ctx.ws.data` for per-connection
 state, `server.connections` for iteration, and `ws.close()` for
 disconnecting stale sockets.
@@ -432,11 +432,11 @@ iterate:
 - **Don't log `ws.data` carelessly.** Per-connection state often
   carries auth tokens, session IDs, or PII. Make sure debug logs,
   metrics, and error reports don't dump it wholesale.
-- **Mass-action capability.** Code with `hub` in scope can send to
-  or close every connection. Keep the `hub` reference out of any
+- **Mass-action capability.** Code holding the `server` in scope can send to
+  or close every connection. Keep the `server` reference out of any
   module that handles untrusted input as code (eval-style, not as
   data).
-- **Filter for cross-tenant safety.** If one Hub serves multiple
+- **Filter for cross-tenant safety.** If one `Server` serves multiple
   tenants, the sweeper sees all of them — filter on
   `ws.data.tenantId` (or equivalent) inside the loop.
 - **Don't `await` per connection without batching.** `await

--- a/packages/rpc/docs/Rpc-Protocol.md
+++ b/packages/rpc/docs/Rpc-Protocol.md
@@ -121,8 +121,45 @@ Failure:
 }
 ```
 
-`data` is omitted when undefined. The `error` object always has
-`code` and `message` strings.
+`data` is omitted when undefined. The `error` object always has `code`
+and `message` strings, plus an **optional** `data` of structured detail
+a handler chose to send along (field-level validation errors, a retry
+hint, …):
+
+```jsonc
+{
+  "id": "1",
+  "type": "result",
+  "ok": false,
+  "error": {
+    "code": "VALIDATION",
+    "message": "name required",
+    "data": { "fields": { "name": "required" } }
+  }
+}
+```
+
+A handler opts in by attaching `data` to the error it throws; the field
+is omitted entirely when absent, so peers that predate it are
+unaffected. `Client.command()` surfaces it as `.data` on the rejection
+alongside `.code`:
+
+```ts
+import { Client } from '@tundralibs/rpc';
+
+const client = new Client({ url: 'ws://localhost:8080' });
+await client.connect();
+
+try {
+  await client.command('createUser', { email: 'nope' });
+} catch (err) {
+  const { code, data } = err as Error & { code?: string; data?: unknown };
+  console.error(code, data); // 'VALIDATION' { fields: { name: 'required' } }
+}
+```
+
+`error.data` crosses the wire to the caller, so it carries the same
+disclosure duty as any error body — never put internals in it.
 
 ### `subscribed` / `unsubscribed`
 

--- a/packages/rpc/docs/Rpc-PubSub.md
+++ b/packages/rpc/docs/Rpc-PubSub.md
@@ -78,9 +78,9 @@ Capabilities declare what the adapter does **beyond** the required
 minimum.
 
 > **Today they are adapter self-description, not framework-enforced.**
-> Hub does not currently gate any feature on these flags — it just
+> `Server` does not currently gate any feature on these flags — it just
 > calls `subscribe` / `publish` / `close`. The flags exist for _your_
-> code to inspect at startup (see below). When Hub gains pattern
+> code to inspect at startup (see below). When `Server` gains pattern
 > subscribe, presence, or replay features, the corresponding flags
 > will become enforced — adapters declaring `false` will refuse to
 > register the dependent features. Until then, treat the matrix as
@@ -102,7 +102,7 @@ if (
   process.env.CLUSTER_MODE === 'on' && !server.adapter.capabilities.crossProcess
 ) {
   console.warn(
-    'Hub: in-process adapter configured but CLUSTER_MODE=on — ' +
+    'rpc: in-process adapter configured but CLUSTER_MODE=on — ' +
       'subscribers on other instances will not receive publishes.',
   );
 }
@@ -116,9 +116,9 @@ if (!server.adapter.capabilities.guaranteedDelivery) {
 }
 ```
 
-Custom adapters that mis-declare are user error — Hub trusts what the
-adapter says. If you write a Redis pub/sub adapter and set
-`guaranteedDelivery: true`, Hub won't catch the lie; your downstream
+Custom adapters that mis-declare are user error — `Server` trusts what
+the adapter says. If you write a Redis pub/sub adapter and set
+`guaranteedDelivery: true`, `Server` won't catch the lie; your downstream
 code will.
 
 ## `MemoryPubSubAdapter`
@@ -476,9 +476,9 @@ with "no clients connected on this server."
 
 Both are useful but have outsized implementation costs in some
 backends. Don't claim them in `capabilities` unless you actually
-implement them — the framework checks at runtime and a false claim
-manifests as silently dropped messages or empty presence lists. Real
-test pressure helps catch this.
+implement them — nothing verifies the claim for you, so a false one
+manifests downstream as silently dropped messages or empty presence
+lists. Real test pressure helps catch this.
 
 ---
 

--- a/packages/rpc/docs/Rpc-PubSub.md
+++ b/packages/rpc/docs/Rpc-PubSub.md
@@ -20,6 +20,8 @@ same contract.
 ## The Contract
 
 ```ts
+import type { AdapterCapabilities } from '@tundralibs/rpc';
+
 abstract class PubSubAdapter {
   abstract subscribe(
     topic: string,
@@ -178,10 +180,12 @@ class MyAdapter extends PubSubAdapter {
     handler: (data: unknown) => void,
   ): Subscription {
     // Register handler; return cleanup function
+    return { unsubscribe: () => {} };
   }
 
   override publish(topic: string, data: unknown): Promise<void> {
     // Send to all subscribers (possibly across processes)
+    return Promise.resolve();
   }
 
   override async close(): Promise<void> {
@@ -193,6 +197,11 @@ class MyAdapter extends PubSubAdapter {
 Pass an instance into the server:
 
 ```ts
+import { PubSubAdapter, Server } from '@tundralibs/rpc';
+
+// The subclass defined in the block above.
+declare const MyAdapter: new () => PubSubAdapter;
+
 const server = new Server({ pubsub: new MyAdapter() });
 ```
 
@@ -207,6 +216,16 @@ import {
   PubSubAdapter,
   type Subscription,
 } from '@tundralibs/rpc';
+
+// The surface your Redis client of choice has to provide.
+declare class RedisClient {
+  constructor(opts: { url: string });
+  on(event: 'message', cb: (topic: string, raw: string) => void): void;
+  subscribe(topic: string): void;
+  unsubscribe(topic: string): void;
+  publish(topic: string, payload: string): Promise<void>;
+  quit(): Promise<void>;
+}
 
 class RedisPubSubAdapter extends PubSubAdapter {
   override readonly capabilities: AdapterCapabilities = {
@@ -315,7 +334,10 @@ deliberately **not** re-exported from `@tundralibs/rpc` or
 ```ts
 import { describe } from '@tundralibs/compat/test';
 import { runAdapterConformance } from '@tundralibs/rpc/conformance';
-import { MyRedisAdapter } from './MyRedisAdapter.ts';
+import type { PubSubAdapter } from '@tundralibs/rpc';
+
+// Your adapter: `import { MyRedisAdapter } from './MyRedisAdapter.ts';`
+declare const MyRedisAdapter: new (opts: { url: string }) => PubSubAdapter;
 
 describe('MyRedisAdapter', () => {
   runAdapterConformance(() => new MyRedisAdapter({ url: 'redis://...' }));
@@ -355,6 +377,11 @@ yet — their assertions will land alongside framework-level support.
 ### Knobs
 
 ```ts
+import { runAdapterConformance } from '@tundralibs/rpc/conformance';
+import { MemoryPubSubAdapter } from '@tundralibs/rpc/pubsub';
+
+const factory = () => new MemoryPubSubAdapter();
+
 runAdapterConformance(factory, {
   deliveryTimeoutMs: 5_000, // default 1000; bump for slow transports
 });

--- a/packages/rpc/examples/pattern-subscribe.ts
+++ b/packages/rpc/examples/pattern-subscribe.ts
@@ -9,7 +9,10 @@
  *
  * Then connect a WebSocket client (e.g. browser DevTools):
  *
- *   const ws = new WebSocket('ws://localhost:8088');
+ *   // The `user` query param becomes ws.data.userId, and `user:**`
+ *   // only authorizes channels owned by that user — so connect as 42
+ *   // for the `user:42:dm` subscribe below to be accepted.
+ *   const ws = new WebSocket('ws://localhost:8088/?user=42');
  *   ws.onmessage = (e) => console.log(JSON.parse(e.data));
  *   ws.onopen = () => {
  *     ws.send(JSON.stringify({ id: '1', type: 'sub', channel: 'chat:room1' }));

--- a/packages/rpc/pubsub/MemoryPubSubAdapter.ts
+++ b/packages/rpc/pubsub/MemoryPubSubAdapter.ts
@@ -24,6 +24,11 @@ import {
  *   serialization, no network.
  */
 export class MemoryPubSubAdapter extends PubSubAdapter {
+  /**
+   * Ordering and delivery are guaranteed because dispatch is a direct
+   * function call; everything requiring shared or durable state —
+   * patterns, presence, replay, cross-process — is `false`.
+   */
   override readonly capabilities: AdapterCapabilities = {
     patternSubscribe: false,
     presence: false,
@@ -38,6 +43,14 @@ export class MemoryPubSubAdapter extends PubSubAdapter {
     new Map();
   private __closed = false;
 
+  /**
+   * Add `handler` to `topic`'s subscriber set. Registering the same
+   * function twice is a no-op — handlers are held in a `Set`, so it is
+   * delivered to once and the first `unsubscribe()` removes it.
+   *
+   * @throws {@link Error} When called after {@link close}. (The adapter
+   *   contract permits either throwing or no-op'ing; this one throws.)
+   */
   override subscribe(
     topic: string,
     handler: (data: unknown) => void,
@@ -61,6 +74,13 @@ export class MemoryPubSubAdapter extends PubSubAdapter {
     };
   }
 
+  /**
+   * Call every subscriber of `topic` synchronously — handlers have already
+   * run by the time the returned promise is awaited. `data` is passed by
+   * reference with no serialization, so subscribers see the same object.
+   * A throwing handler is swallowed so fan-out continues. No-ops after
+   * {@link close}.
+   */
   override publish(topic: string, data: unknown): Promise<void> {
     if (this.__closed) return Promise.resolve();
     const set = this.__subscribers.get(topic);
@@ -75,6 +95,10 @@ export class MemoryPubSubAdapter extends PubSubAdapter {
     return Promise.resolve();
   }
 
+  /**
+   * Drop every subscriber and latch the adapter closed. Idempotent, and
+   * terminal — there is no reopen.
+   */
   override close(): Promise<void> {
     this.__closed = true;
     this.__subscribers.clear();

--- a/packages/rpc/pubsub/conformance.ts
+++ b/packages/rpc/pubsub/conformance.ts
@@ -12,7 +12,10 @@
  * ```ts
  * import { runAdapterConformance } from '@tundralibs/rpc/conformance';
  * import { describe } from '@tundralibs/compat/test';
- * import { MyRedisAdapter } from './MyRedisAdapter.ts';
+ * import type { PubSubAdapter } from '@tundralibs/rpc';
+ *
+ * // Your adapter: `import { MyRedisAdapter } from './MyRedisAdapter.ts';`
+ * declare const MyRedisAdapter: new (o: { url: string }) => PubSubAdapter;
  *
  * describe('MyRedisAdapter', () => {
  *   runAdapterConformance(() => new MyRedisAdapter({ url: '...' }));


### PR DESCRIPTION
## The fix

rpc had two paths that reject a pending request, handing back **different error shapes**:

- **Correlated** (`_dispatchResult`) attached `code` and any structured `data`.
- **Out-of-band** (`_dispatchFrame`) rejected with a bare `Error` — no `.code`.

So a consumer who learned `err.code` works got `undefined` for exactly the protocol-level
failures. The reachable case is `BAD_FORMAT`, where the server recovers a parsable `id` and
therefore *does* reject the caller's pending call.

Now both paths route through a shared `rejectionError(code, message, data?)` helper, so they
cannot drift apart again. The message string is **byte-identical** (`` `${code}: ${message}` ``),
so anyone matching on it is unaffected.

`FRAME_TOO_LARGE` is unchanged and stays deliberately id-less — parsing an oversize payload to
recover an id would reintroduce the DoS the size gate exists to prevent.

The new test drives a **real `Server`**, so it also pins the server's id recovery: lose that and
the test fails as a timeout rather than silently passing. Verified red before the fix.

Also corrected README:931, which explicitly documented the inconsistency, and a stale
"four"/five count at `Client.ts:894`.

---

## What

Makes every TypeScript example in rpc's shipped documentation type-check — markdown plus the JSDoc `@example` blocks that render on the JSR package page.

- **Markdown**: all files pass. `README.md` had a SyntaxError aborting the check at block 26/26; `Rpc-Middleware.md` 58 errors, `Rpc-Extending.md` 26, `Rpc-PubSub.md` 14 — all now 0.
- **JSDoc**: `Server.ts` 5 → 0, `pubsub/conformance.ts` 1 → 0. Comment-only edits; zero executable lines changed.
- **Retagged 5** (all README): the `ServerOptions` declaration listing and three chainable cheat-sheets, plus a Redis adapter sketch with comment-only method bodies. `ClientOptions` was left checked — it already compiles.

## Real drift this caught

**A fabricated Guardian example.** The README imported `{ GuardianProxy, type }` from `@tundralibs/guardian` — **neither is exported** — and the body used arktype syntax (`type({ name: 'string' })`). Anyone copying it would fail immediately. Rewritten against the real API: `Guardian.object({ name: Guardian.string() })`.

**Conformance examples still broken after the move.** The `@tundralibs/rpc/conformance` import paths were already correct, but the examples themselves did not compile: `Rpc-PubSub.md` imported a non-existent `./MyRedisAdapter.ts`, and the "Knobs" snippet called `runAdapterConformance(factory, …)` with no import and no `factory`. The same broken relative import appeared in `conformance.ts`'s own module JSDoc.

## Gates

`deno fmt --check` clean; `deno check packages/rpc/mod.ts` passes; 5 test files pass; `deno doc --lint` **66 before, 66 after**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
