### PR TITLE
docs(pact): verify documentation examples and document the public API

### DIFF
--- a/packages/pact/Groups.ts
+++ b/packages/pact/Groups.ts
@@ -47,6 +47,11 @@ export class Groups {
    */
   private __clearedThrough = 0;
 
+  /**
+   * Wrap a consumer's group resolver in a lazy cache. Nothing is fetched here
+   * — ids resolve on first use and stay cached until {@link Groups.sync}
+   * refreshes them or {@link Groups.clear} drops them.
+   */
   constructor(resolver: GroupResolver) {
     this.__resolver = resolver;
   }

--- a/packages/pact/PACT.ts
+++ b/packages/pact/PACT.ts
@@ -13,6 +13,8 @@
  *
  * @example
  * ```ts
+ * declare const audit: (module: string, permission: string | bigint) => void;
+ *
  * const pact = new PACT({
  *   bits: { READ: 1n, EDIT: 2n, DELETE: 4n },
  *   modules: { Post: ['READ', 'EDIT', 'DELETE'] },

--- a/packages/pact/PACT.ts
+++ b/packages/pact/PACT.ts
@@ -112,6 +112,13 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
   protected _fetch: typeof globalThis.fetch = compatFetch;
 
   /**
+   * Build the engine from the permission registry plus whichever token, group
+   * and OAuth wiring the deployment needs. `algorithm` defaults to `HS256` and
+   * `expiry` to 3600 seconds; `secret` is held privately rather than in the
+   * option store, so `getOptions()` can never surface it. Supplying
+   * `groupResolver` enables the group cache, and a positive `syncInterval`
+   * starts its refresh timer.
+   *
    * @throws {@link PactDefinitionError} when `bits` is missing
    *   (`MISSING_OPTION`), the registry is malformed (via {@link Permissions}),
    *   the `secret` shape/length contradicts the algorithm (`INVALID_OPTION`),
@@ -217,6 +224,11 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     event: K,
     callback: PACTEvents[K],
   ): this;
+  /**
+   * Register several listeners for `event` — equivalent to calling
+   * {@link PACT.on} once per entry, with the same isolation and non-function
+   * handling.
+   */
   override on<K extends keyof PACTEvents>(
     event: K,
     callback: PACTEvents[K][],
@@ -244,6 +256,10 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     event: K,
     callback: PACTEvents[K],
   ): this;
+  /**
+   * Register several one-shot listeners for `event`. Each fires and removes
+   * itself independently of the others.
+   */
   override once<K extends keyof PACTEvents>(
     event: K,
     callback: PACTEvents[K][],
@@ -273,6 +289,10 @@ export class PACT<P extends PACTPermissionBits = PACTPermissionBits>
     event: K,
     callback?: PACTEvents[K],
   ): this;
+  /**
+   * Remove several listeners for `event`, or every listener for it when
+   * `callback` is omitted. Entries that were never registered are ignored.
+   */
   override off<K extends keyof PACTEvents>(
     event: K,
     callback?: PACTEvents[K][],

--- a/packages/pact/Permissions.ts
+++ b/packages/pact/Permissions.ts
@@ -52,6 +52,12 @@ export class Permissions<P extends PACTPermissionBits = PACTPermissionBits> {
   private readonly __modules: Map<string, ModuleEntry<P>> | undefined;
 
   /**
+   * Build the engine from a permission registry and an optional module
+   * catalog. With a catalog, every check is additionally validated against the
+   * module's applicable set — an unknown module, or a permission the module
+   * does not declare, is a configuration error rather than a denial. Without
+   * one, any registered permission is checkable against any module name.
+   *
    * @param bits - the permission registry (name → positive, unique BigInt bit).
    * @param modules - optional module catalog (module → applicable permissions).
    *

--- a/packages/pact/README.md
+++ b/packages/pact/README.md
@@ -61,6 +61,18 @@ npx jsr add @tundralibs/pact
 
 ```typescript
 import { PACT, serializeGrants } from '@tundralibs/pact';
+import type { PACTGrants, PACTLoginOutcome } from '@tundralibs/pact/types';
+
+// ── your app's own data layer and helpers ────────────────────────────
+declare const myDb: {
+  grantsForGroups(ids: string[]): Promise<Record<string, PACTGrants>>;
+};
+declare const blocklist: Set<string>;
+declare const verifyPassword: (creds: unknown) => Promise<PACTLoginOutcome>;
+declare const audit: (event: string, ...rest: unknown[]) => void;
+declare const user: { id: string; groupIds: string[] };
+declare const presented: string;
+declare const stored: { secretHash: string };
 
 const pact = new PACT({
   // authorization: the breadth of permissions, and where they apply

--- a/packages/pact/docs/Pact-ApiKeys.md
+++ b/packages/pact/docs/Pact-ApiKeys.md
@@ -78,6 +78,9 @@ import { PACT } from '@tundralibs/pact';
 
 const pact = new PACT({ bits: { READ: 1n } });
 
+declare const presented: string;
+declare const stored: { secretHash: string };
+
 // `presented` comes off the request; `stored.secretHash` from your database
 const ok = await pact.verifyAPIKey(presented, stored.secretHash);
 if (!ok) {
@@ -98,6 +101,14 @@ Mint on issue, store the id + hash, verify on each request:
 import { PACT } from '@tundralibs/pact';
 
 const pact = new PACT({ bits: { READ: 1n } });
+
+// your own storage — PACT keeps no records
+declare const db: {
+  apiKeys: {
+    insert(row: { id: string; secretHash: string }): Promise<void>;
+    findById(id: string): Promise<{ secretHash: string } | null>;
+  };
+};
 
 // 1. Mint — when a user creates an API key
 async function issueKey() {
@@ -127,6 +138,8 @@ import { PACT } from '@tundralibs/pact';
 const pact = new PACT({ bits: { READ: 1n } });
 
 const key = await pact.generateAPIKey();
+
+declare const body: string;
 
 // The client signs a request body with its secret…
 const signature = await pact.sign(body, key.secret);

--- a/packages/pact/docs/Pact-Authorization.md
+++ b/packages/pact/docs/Pact-Authorization.md
@@ -74,6 +74,7 @@ against an undeclared module or an inapplicable permission throws
 ```typescript
 import { PACT } from '@tundralibs/pact';
 // pact configured as in "The bitmask model" above
+declare const pact: PACT;
 
 pact.can('Ghost', 'READ', {}); // throws PactDefinitionError — UNKNOWN_MODULE
 pact.can('Billing', 'EDIT', {}); // throws PactDefinitionError — PERMISSION_NOT_IN_MODULE
@@ -109,6 +110,7 @@ semantics.
 ```typescript
 import { PACT } from '@tundralibs/pact';
 // pact configured as in "The bitmask model" above
+declare const pact: PACT;
 
 const grants = { Post: 3n }; // READ | EDIT
 
@@ -156,6 +158,7 @@ against the module's catalog when one exists).
 ```typescript
 import { PACT } from '@tundralibs/pact';
 // pact configured as in "The bitmask model" above
+declare const pact: PACT;
 
 pact.grant(0n, 'READ', 'EDIT'); // 3n — READ | EDIT
 pact.revoke(3n, 'EDIT'); // 1n — READ
@@ -197,6 +200,7 @@ instance rule yourself.
 ```typescript
 import { PACT } from '@tundralibs/pact';
 // pact configured as in "The bitmask model" above
+declare const pact: PACT;
 
 function editPost(
   post: { authorId: string },

--- a/packages/pact/docs/Pact-Errors.md
+++ b/packages/pact/docs/Pact-Errors.md
@@ -87,19 +87,30 @@ denial is a 403, a definition error is a bug:
 
 ```typescript
 import { PACT, PactDefinitionError, PactDeniedError } from '@tundralibs/pact';
+import type { PACTGrants } from '@tundralibs/pact/types';
 
-try {
-  pact.assert('Post', 'DELETE', grants);
-} catch (err) {
-  if (err instanceof PactDeniedError) {
-    // authorization outcome — err.module / err.permission are typed
-    return respond(403, `denied: ${err.permission} on ${err.module}`);
+declare const pact: PACT;
+declare const grants: PACTGrants;
+declare const respond: (status: number, body: string) => Response;
+
+function deletePost(): Response {
+  try {
+    pact.assert('Post', 'DELETE', grants);
+  } catch (err) {
+    if (err instanceof PactDeniedError) {
+      // authorization outcome — err.context.module / .permission are typed
+      return respond(
+        403,
+        `denied: ${err.context.permission} on ${err.context.module}`,
+      );
+    }
+    if (err instanceof PactDefinitionError) {
+      // a bug in how PACT was configured (e.g. UNKNOWN_MODULE) — fix the setup
+      return respond(500, 'authorization is misconfigured');
+    }
+    throw err;
   }
-  if (err instanceof PactDefinitionError) {
-    // a bug in how PACT was configured (e.g. UNKNOWN_MODULE) — fix the setup
-    return respond(500, 'authorization is misconfigured');
-  }
-  throw err;
+  return respond(204, '');
 }
 ```
 
@@ -109,21 +120,29 @@ flat switch instead of a class ladder:
 ```typescript
 import { PACT, PactError } from '@tundralibs/pact';
 
-try {
-  await pact.login('google', { code, verifier });
-} catch (err) {
-  if (err instanceof PactError) {
-    switch (err.code) {
-      case 'OAUTH_STATE_MISMATCH':
-        return respond(400, 'stale or forged callback');
-      case 'OAUTH_EXCHANGE_FAILED':
-      case 'OAUTH_PROFILE_FAILED':
-        return respond(502, 'upstream OAuth provider failed');
-      case 'UNKNOWN_STRATEGY':
-        throw err; // config bug — no provider named 'google'
+declare const pact: PACT;
+declare const code: string;
+declare const verifier: string;
+declare const respond: (status: number, body: string) => Response;
+
+async function oauthCallback(): Promise<Response> {
+  try {
+    await pact.login('google', { code, verifier });
+  } catch (err) {
+    if (err instanceof PactError) {
+      switch (err.code) {
+        case 'OAUTH_STATE_MISMATCH':
+          return respond(400, 'stale or forged callback');
+        case 'OAUTH_EXCHANGE_FAILED':
+        case 'OAUTH_PROFILE_FAILED':
+          return respond(502, 'upstream OAuth provider failed');
+        case 'UNKNOWN_STRATEGY':
+          throw err; // config bug — no provider named 'google'
+      }
     }
+    throw err;
   }
-  throw err;
+  return respond(204, '');
 }
 ```
 
@@ -132,6 +151,8 @@ contract — useful for structured logging:
 
 ```typescript
 import { PACT, PactError } from '@tundralibs/pact';
+
+declare const err: unknown;
 
 if (err instanceof PactError) {
   err.code; // stable PactErrorCode, or undefined when the site left it unset
@@ -152,18 +173,25 @@ when verifying or refreshing, handle both:
 import { PACT, PactTokenError } from '@tundralibs/pact';
 import { JWTError } from '@tundralibs/crypt/JWT';
 
-try {
-  const claims = await pact.verifyJWT(token);
-} catch (err) {
-  if (err instanceof PactTokenError) {
-    // err.code === 'TOKEN_REVOKED' — your isRevoked seam vetoed a valid token
-    return respond(401, 'token revoked');
+declare const pact: PACT;
+declare const token: string;
+declare const respond: (status: number, body: string) => Response;
+
+async function authenticate(): Promise<Response> {
+  try {
+    const claims = await pact.verifyJWT(token);
+  } catch (err) {
+    if (err instanceof PactTokenError) {
+      // err.code === 'TOKEN_REVOKED' — your isRevoked seam vetoed a valid token
+      return respond(401, 'token revoked');
+    }
+    if (err instanceof JWTError) {
+      // bad signature, expired, or wrong iss/aud — raised by @tundralibs/crypt
+      return respond(401, 'token invalid');
+    }
+    throw err;
   }
-  if (err instanceof JWTError) {
-    // bad signature, expired, or wrong iss/aud — raised by @tundralibs/crypt
-    return respond(401, 'token invalid');
-  }
-  throw err;
+  return respond(200, 'ok');
 }
 ```
 
@@ -227,6 +255,9 @@ takes a single handler or an array of handlers:
 ```typescript
 import { PACT } from '@tundralibs/pact';
 
+declare const audit: { log(event: string, ...rest: unknown[]): void };
+declare const revocationStore: { record(jti: string): void };
+
 const pact = new PACT({
   bits: { READ: 1n, EDIT: 2n },
   modules: { Post: ['READ', 'EDIT'] },
@@ -241,6 +272,12 @@ Or attach later with `.on(event, handler)` — the same events, registered
 imperatively:
 
 ```typescript
+import { PACT } from '@tundralibs/pact';
+
+declare const pact: PACT;
+declare const metrics: { increment(key: string): void };
+declare const audit: { log(event: string, ...rest: unknown[]): void };
+
 pact.on('login', (strategy, principal, isNew) => {
   metrics.increment(`login.${strategy}.${isNew ? 'signup' : 'return'}`);
 });

--- a/packages/pact/docs/Pact-Groups.md
+++ b/packages/pact/docs/Pact-Groups.md
@@ -46,6 +46,11 @@ Set `groupResolver` (required for every group method) and, optionally,
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+import type { PACTGrants } from '@tundralibs/pact';
+
+declare const db: {
+  grantsForGroups(ids: string[]): Promise<Record<string, PACTGrants>>;
+};
 
 const pact = new PACT({
   bits: { READ: 1n, EDIT: 2n, DELETE: 4n },
@@ -71,6 +76,10 @@ no grants** (`{}`), so they are not re-fetched on every check.
 ```typescript
 import { PACT } from '@tundralibs/pact';
 import type { GroupResolver, PACTGrants } from '@tundralibs/pact';
+
+declare const db: {
+  grantRowsFor(id: string): Promise<Array<{ module: string; mask: string }>>;
+};
 
 const groupResolver: GroupResolver = async (groupIds) => {
   const result: Record<string, PACTGrants> = {};
@@ -103,6 +112,9 @@ argument adds per-principal grants that OR in the same way (shown under
 import { PACT } from '@tundralibs/pact';
 
 // given the `pact` configured above
+declare const pact: PACT;
+declare const user: { id: string; groupIds: string[] };
+
 const allowed = await pact.hasPermissionForGroups(
   'Post',
   'EDIT',
@@ -119,6 +131,9 @@ a `PACTGrants` map you can reuse.
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+declare const pact: PACT;
+declare const user: { id: string; groupIds: string[] };
 
 const grants = await pact.grantsForGroups(user.groupIds, {
   Post: 4n, // a direct DELETE grant on top of the group grants
@@ -137,6 +152,8 @@ grant) provides.
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+declare const pact: PACT;
 
 // Suppose the resolver returns:
 //   editors → { Post: 3n }     (READ | EDIT)
@@ -158,6 +175,8 @@ changes on your side are not visible until you re-sync.
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+declare const pact: PACT;
 
 // First call resolves 'editors' through the resolver and caches it.
 await pact.hasPermissionForGroups('Post', 'EDIT', ['editors']);
@@ -181,6 +200,11 @@ The cache is a snapshot; re-sync to pick up changes to your group grants:
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+import type { PACTGrants } from '@tundralibs/pact';
+
+declare const db: {
+  grantsForGroups(ids: string[]): Promise<Record<string, PACTGrants>>;
+};
 
 const pact = new PACT({
   bits: { READ: 1n, EDIT: 2n },
@@ -214,6 +238,11 @@ having cached only some of the ids it was asked to resolve.
 
 ```typescript
 import { Groups } from '@tundralibs/pact';
+import type { PACTGrants } from '@tundralibs/pact';
+
+declare const db: {
+  grantsForGroups(ids: string[]): Promise<Record<string, PACTGrants>>;
+};
 
 const groups = new Groups((ids) => db.grantsForGroups(ids));
 await groups.ensure(['editors']); // resolve + cache
@@ -234,6 +263,9 @@ before embedding, deserialize after verifying.
 
 ```typescript
 import { deserializeGrants, PACT, serializeGrants } from '@tundralibs/pact';
+
+declare const pact: PACT;
+declare const user: { id: string; groupIds: string[] };
 
 const grants = await pact.grantsForGroups(user.groupIds);
 
@@ -256,6 +288,11 @@ grants:
 
 ```typescript
 import { combineGrants } from '@tundralibs/pact';
+import type { PACTGrants } from '@tundralibs/pact';
+
+declare const directGrants: PACTGrants;
+declare const tenantGrants: PACTGrants;
+declare const roleGrants: PACTGrants;
 
 const merged = combineGrants(directGrants, tenantGrants, roleGrants);
 // Later sets only ever add bits — grants are allow-only.

--- a/packages/pact/docs/Pact-OAuth.md
+++ b/packages/pact/docs/Pact-OAuth.md
@@ -46,6 +46,19 @@ With `autoIssue: true`, a successful login also mints a JWT with
 ```typescript
 import { PACT } from '@tundralibs/pact';
 
+// ── your app's own store and helpers ─────────────────────────────────
+declare const db: {
+  findByEmail(
+    email: string,
+  ): Promise<{ id: string; email: string; hash: string } | null>;
+};
+declare const verifyHash: (password: string, hash: string) => Promise<boolean>;
+declare const audit: (
+  strategy: string,
+  principalId: string,
+  isNew: boolean,
+) => void;
+
 const pact = new PACT({
   bits: { READ: 1n, WRITE: 2n },
   secret: 'a-256-bit-shared-secret-for-hs256!',
@@ -136,6 +149,13 @@ For id_token providers you can add a replay guard the same way: send a
 ```typescript
 import { PACT } from '@tundralibs/pact';
 
+// ── your session store and the request's query string ────────────────
+declare const session: {
+  set(key: string, value: { state: string; verifier: string }): Promise<void>;
+  get(key: string): Promise<{ state: string; verifier: string }>;
+};
+declare const query: URLSearchParams;
+
 const pact = new PACT({
   bits: { READ: 1n },
   oauth: {
@@ -183,6 +203,14 @@ the default outcome is `{ id: '<instance>:<profile.id>', profile }` with
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+// ── your app's own store, session and request query ──────────────────
+declare const db: {
+  findByOAuth(provider: string, id: string): Promise<{ id: string } | null>;
+  createUser(data: { email?: string; name?: string }): Promise<{ id: string }>;
+};
+declare const query: URLSearchParams;
+declare const stashed: { state: string; verifier: string };
 
 const pact = new PACT({
   bits: { READ: 1n },
@@ -287,7 +315,7 @@ Choose `'required'` when you would rather fail a login than accept an
 unverified token (`OAUTH_JWKS_UNAVAILABLE`). Recommended for high-assurance
 deployments that can absorb the availability coupling.
 
-```typescript
+```typescript ignore
 oauth: {
   apple: {
     provider: 'apple',
@@ -321,7 +349,7 @@ under any key anyway.
 **Microsoft (tenant-aware).** The authorize/token endpoints are tenant-scoped.
 Set `tenant` for a single-tenant app; it defaults to `common`.
 
-```typescript
+```typescript ignore
 oauth: {
   entra: {
     provider: 'microsoft',
@@ -341,7 +369,7 @@ a short-lived **ES256 JWT** you must mint out-of-band (PACT does not mint
 provider client secrets) and pass in. The preset sends `response_mode=form_post`, so the callback
 arrives as a POST body.
 
-```typescript
+```typescript ignore
 oauth: {
   apple: {
     provider: 'apple',
@@ -359,7 +387,7 @@ cached). The issuer **must be `https://`** — a missing issuer throws
 `PactDefinitionError`, at construction). It is also the trust anchor for the
 `id_token`'s `iss` when the issuer publishes no userinfo endpoint.
 
-```typescript
+```typescript ignore
 oauth: {
   corp: {
     provider: 'oidc',

--- a/packages/pact/docs/Pact-Tokens.md
+++ b/packages/pact/docs/Pact-Tokens.md
@@ -32,6 +32,9 @@ public key verifies.
 ```typescript
 import { PACT } from '@tundralibs/pact';
 
+declare const myPrivateKeyPem: string;
+declare const myPublicKeyPem: string;
+
 // HS* (symmetric) - one shared secret string >= the hash size in bytes
 // (RFC 7518 §3.2): HS256 >= 32, HS384 >= 48, HS512 >= 64
 const hmac = new PACT({
@@ -97,6 +100,8 @@ becomes a decimal string) before embedding them in a payload - and
 ```typescript
 import { PACT, serializeGrants } from '@tundralibs/pact';
 
+declare const pact: PACT;
+
 // grants is a { module -> BigInt mask } map (e.g. from grantsForGroups)
 const grants = { Post: 3n }; // READ | EDIT
 
@@ -121,6 +126,9 @@ blocklist, a key-rotation watermark) without PACT owning a store.
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+declare const blocklist: Set<string>;
+declare const token: string;
 
 const pact = new PACT({
   bits: { READ: 1n, EDIT: 2n },
@@ -151,6 +159,9 @@ re-issues the same claims with a fresh `exp = now + expiry`.
 ```typescript
 import { PACT } from '@tundralibs/pact';
 
+declare const pact: PACT;
+declare const oldToken: string;
+
 // Re-verifies the old token (including revocation), then re-issues
 // with a fresh exp = now + expiry.
 const fresh = await pact.refreshJWT(oldToken);
@@ -170,6 +181,9 @@ for authorization, where `verifyJWT` is the only safe path.
 ```typescript
 import { PACT } from '@tundralibs/pact';
 
+declare const pact: PACT;
+declare const token: string;
+
 // No signature check - inspection only.
 const { header, payload } = pact.decodeJWT(token);
 console.log(header.kid, payload.sub);
@@ -185,6 +199,8 @@ webhook signatures, and signed URLs.
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+declare const webhookBody: string;
 
 const pact = new PACT({
   bits: { READ: 1n },
@@ -221,6 +237,8 @@ after construction. The token lifecycle emits five events:
 
 ```typescript
 import { PACT } from '@tundralibs/pact';
+
+declare const audit: (event: string, detail?: unknown) => void;
 
 const pact = new PACT({
   bits: { READ: 1n },

--- a/packages/pact/errors/DeniedError.ts
+++ b/packages/pact/errors/DeniedError.ts
@@ -14,6 +14,14 @@ import type { PactErrorCode } from './PactErrorCodes.ts';
 export class PactDeniedError extends PactError<
   { code: PactErrorCode; module: string; permission: string }
 > {
+  /**
+   * Build a denial for `permission` on `module`. Both are carried in the error
+   * data as well as the message, so a catch site can render or log the denial
+   * without re-parsing it.
+   *
+   * @param permission - human label: a permission name, or `0b…` when the
+   *   check was made against a raw bit.
+   */
   constructor(module: string, permission: string, cause?: Error) {
     super(
       `Permission '${permission}' denied on module '${module}'`,

--- a/packages/pact/oauth/IdTokenVerifier.ts
+++ b/packages/pact/oauth/IdTokenVerifier.ts
@@ -150,6 +150,14 @@ export class IdTokenVerifier {
    */
   private __lastForcedRefresh = 0;
 
+  /**
+   * Create a verifier bound to one provider. The policy defaults to
+   * `'preferred'`, under which an unreachable key set degrades to decode-only
+   * — claims are still validated and `onDegraded` fires — rather than failing
+   * the login; `'required'` makes that case fatal.
+   *
+   * @param provider - instance name, used to label errors and degrade reports.
+   */
   constructor(
     provider: string,
     fetchRef: FetchRef,

--- a/packages/pact/oauth/OAuthClient.ts
+++ b/packages/pact/oauth/OAuthClient.ts
@@ -73,6 +73,12 @@ export class OAuthClient {
   private __discovered?: Endpoints;
 
   /**
+   * Create a client for one configured provider instance. Endpoints come from
+   * the named preset; the `oidc` preset instead resolves them by discovery
+   * against `config.issuer`, which must be https because it is also the trust
+   * anchor for the returned `id_token`. Nothing is fetched here — discovery is
+   * deferred to first use.
+   *
    * @param name - the configured instance name
    * @param config - the provider-instance configuration
    * @param fetchRef - late-bound `fetch` supplier


### PR DESCRIPTION
## What

Markdown 93 errors → 0 across 7 files; JSDoc `@example` 1 → 0. `Pact-OAuth.md` had a SyntaxError aborting the check before any of its 7 blocks were reached.

## Drift found

**`PactDeniedError.module` / `.permission` do not exist** — the typed values live on `err.context`. The doc example read them directly, so it never compiled; corrected to `err.context.*`. Note the surrounding prose table still says the error "carries the typed `module` and `permission`", which is misleading — left alone under the no-prose rule, but worth a follow-up.

BigInt masks and mask widths were preserved throughout; no example was weakened to force a pass.

These files ship inside the JSR tarball and land in consumers' `node_modules`, where their coding agents read them. A broken example is worse than none, because a model reproduces it confidently. Verified with `deno check --doc-only` on every `.md` and every non-test source file, driven to 0. Each block compiles as its own module, so examples are self-contained — repeating a one-line import across blocks is intentional. Blocks that are not runnable code (bare signature listings, config fragments, sketches with `{ ... }` bodies) are retagged ` ignore ` rather than contorted into compiling. No prose rewritten, no executable code changed, no dependency added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)