### PR TITLE
docs(restler): verify documentation examples and document the public API

### DIFF
--- a/packages/restler/README.md
+++ b/packages/restler/README.md
@@ -193,6 +193,14 @@ outside the `1…120` second range, or a `contentType` that isn't one of
 `_makeRequest` resolves to a `RESTlerResponse<T>`:
 
 ```typescript
+import type { RESTlerResponse } from '@tundralibs/restler';
+
+declare const api: {
+  getUser(
+    login: string,
+  ): Promise<RESTlerResponse<{ id: number; login: string }>>;
+};
+
 const res = await api.getUser('octocat');
 
 res.url; // Final requested URL
@@ -266,7 +274,7 @@ console.log(res.body?.size, res.body?.type); // Blob size and MIME type
 `auth` is a discriminated union keyed by `type`. Set it instance-wide (in
 `RESTlerOptions`) or per request (on the endpoint — the endpoint wins).
 
-```typescript
+```typescript ignore
 // Basic — sends `Authorization: Basic base64(user:pass)`
 { type: 'BASIC', username: 'user', password: 'secret' }
 
@@ -362,6 +370,8 @@ inline PEM (`cert` / `key` / `ca`) **or** file paths (`certFile` / `keyFile` /
 > Plain HTTPS against public CAs needs no `tls` option and works everywhere.
 
 ```typescript
+import { RESTler } from '@tundralibs/restler';
+
 class SecureAPI extends RESTler {
   public readonly vendor = 'secure';
 
@@ -436,6 +446,21 @@ metrics listener can neither reject a successful response, mask the real error,
 nor silence the other listeners.
 
 ```typescript
+import { RESTler } from '@tundralibs/restler';
+
+class GitHubAPI extends RESTler {
+  public readonly vendor = 'github';
+
+  constructor(token: string) {
+    super({
+      baseURL: 'https://api.github.com',
+      auth: { type: 'BEARER', token },
+    });
+  }
+}
+
+declare const token: string;
+
 const api = new GitHubAPI(token);
 
 api.on('rateLimit', (vendor, limit, reset, remaining) => {
@@ -461,6 +486,12 @@ observability-agnostic; it just lets the hooks flow through to `super`
 
 ```typescript
 import { RESTler, type RESTlerHooks } from '@tundralibs/restler';
+
+declare const token: string;
+declare const tracer: {
+  wrapClient: RESTlerHooks['witness'];
+  propagation: RESTlerHooks['headerProvider'];
+};
 
 class GitHubAPI extends RESTler {
   public readonly vendor = 'github';
@@ -505,7 +536,7 @@ on: `tracer.propagation` reads the active span at send time, so the
 joins the trace correctly parented. A throwing provider is contained — the
 request proceeds without its headers. It is not tracing-specific:
 
-```typescript
+```typescript ignore
 headerProvider: () => ({
   'x-correlation-id': String(ambient.get()?.correlationId ?? ''),
 }),
@@ -595,7 +626,17 @@ throws.
 | `RESTlerError`        | Base class for all of the above.                                           |
 
 ```typescript
-import { RESTlerError, RESTlerTimeoutError } from '@tundralibs/restler';
+import {
+  RESTlerError,
+  type RESTlerResponse,
+  RESTlerTimeoutError,
+} from '@tundralibs/restler';
+
+declare const api: {
+  getUser(
+    login: string,
+  ): Promise<RESTlerResponse<{ id: number; login: string }>>;
+};
 
 try {
   const res = await api.getUser('octocat');

--- a/packages/restler/RESTler.ts
+++ b/packages/restler/RESTler.ts
@@ -308,7 +308,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * that authenticates with a vendor-specific header extends the sensitive set
    * by overriding this method — for example:
    *
-   * ```typescript
+   * ```typescript ignore
    * protected override _isSensitiveHeader(name: string): boolean {
    *   return name.toLowerCase() === 'x-vendor-secret' ||
    *     super._isSensitiveHeader(name);

--- a/packages/restler/RESTler.ts
+++ b/packages/restler/RESTler.ts
@@ -76,6 +76,10 @@ const SENSITIVE_HEADER =
  * console.log(res.body?.id);
  * ```
  *
+ * @typeParam O - The options bag the subclass accepts. Extend
+ *   {@link RESTlerOptions} to add vendor-specific options; they then type the
+ *   constructor argument and `_getOption`.
+ *
  * @see {@link RESTlerOptions} for configuration options
  * @see {@link RESTlerEndpoint} for the per-request endpoint shape
  */
@@ -206,6 +210,14 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     event: K,
     callback: RESTlerEvents[K],
   ): this;
+  /**
+   * Array form: each entry is registered — and isolation-wrapped —
+   * independently, so one faulty listener does not affect its siblings.
+   *
+   * @param event - The event to subscribe to.
+   * @param callback - The listeners to register. Non-function entries are
+   *   dropped rather than registered.
+   */
   override on<K extends keyof RESTlerEvents>(
     event: K,
     callback: RESTlerEvents[K][],
@@ -238,6 +250,13 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     event: K,
     callback: RESTlerEvents[K],
   ): this;
+  /**
+   * Array form: each entry fires at most once, independently of the others.
+   *
+   * @param event - The event to subscribe to.
+   * @param callback - The listeners to register. Non-function entries are
+   *   dropped rather than registered.
+   */
   override once<K extends keyof RESTlerEvents>(
     event: K,
     callback: RESTlerEvents[K][],
@@ -270,6 +289,14 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     event: K,
     callback?: RESTlerEvents[K],
   ): this;
+  /**
+   * Array form: each entry is resolved back to the isolation wrapper
+   * {@link on} registered for it, then removed.
+   *
+   * @param event - The event to unsubscribe from.
+   * @param callback - The listeners to remove. When omitted, every listener
+   *   for `event` is removed.
+   */
   override off<K extends keyof RESTlerEvents>(
     event: K,
     callback?: RESTlerEvents[K][],

--- a/packages/restler/types/RESTlerHooks.ts
+++ b/packages/restler/types/RESTlerHooks.ts
@@ -51,7 +51,10 @@ export type RESTlerHeaderProvider = () => Record<string, string>;
  * application's composition root through a vendor client's constructor:
  *
  * ```ts
+ * import { RESTler, type RESTlerHooks } from '@tundralibs/restler';
+ *
  * class GitHubAPI extends RESTler {
+ *   public readonly vendor = 'github';
  *   constructor(token: string, hooks: RESTlerHooks = {}) {
  *     super({ baseURL: 'https://api.github.com', auth: { type: 'BEARER', token }, ...hooks });
  *   }


### PR DESCRIPTION
## What

**The "restler already passes" baseline was wrong** — and the reason is the useful part. `README.md` aborted on a SyntaxError at block 6 (`{ type: 'BASIC', … }`, an object literal tagged as TS), which stopped the check before it reached **15 real errors** in later blocks. A clean-looking 0 was actually a silent abort.

Now 0: 12 blocks compiling, 2 retagged. JSDoc `@example` 1 error + 1 abort → 0; `RESTlerHooks`' example gained the abstract `vendor` member it needs to compile.

Subclass generic parameters were preserved throughout — the typing is the lesson in restler's examples, so none were weakened to force a pass.

These files ship inside the JSR tarball and land in consumers' `node_modules`, where their coding agents read them. A broken example is worse than none, because a model reproduces it confidently. Verified with `deno check --doc-only` on every `.md` and every non-test source file. Each block compiles as its own module, so examples are self-contained. Blocks that are not runnable code are retagged ` ignore ` rather than contorted into compiling. No prose rewritten, no executable code changed, no dependency added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)