### PR TITLE
docs(id): verify documentation examples and document the public API

### DIFF
--- a/packages/id/docs/ID-CUID.md
+++ b/packages/id/docs/ID-CUID.md
@@ -34,7 +34,7 @@ rolling counter, a per-process fingerprint, and a random tail — giving you:
 Pairs with `Guardian.string().cuid()` from `@tundralibs/guardian`, which
 validates the same 25-char `c[a-z0-9]{24}` format.
 
-> **Looking for CUID2?** Use {@link ./ID-CUID2.md cuid2} instead — it's
+> **Looking for CUID2?** Use [cuid2](./ID-CUID2.md) instead — it's
 > cryptographically secure, deliberately not time-sortable (so the
 > minting time can't be reconstructed from the ID), and configurable
 > length. CUID v1 is kept for compatibility and process-local
@@ -143,10 +143,10 @@ const ok = CuidGuard.parse(id); // round-trips cleanly
 **Prefer something else when:**
 
 - You need cryptographic collision resistance → use
-  {@link ./ID-CUID2.md cuid2}.
+  [cuid2](./ID-CUID2.md).
 - You need distributed sortability across machines without coordination
-  → use {@link ./ID-ULID.md ulid}.
-- You need MongoDB-native IDs → use {@link ./ID-ObjectID.md ObjectID}.
+  → use [ulid](./ID-ULID.md).
+- You need MongoDB-native IDs → use [ObjectID](./ID-ObjectID.md).
 
 ## CUID vs CUID2
 

--- a/packages/id/docs/ID-CUID.md
+++ b/packages/id/docs/ID-CUID.md
@@ -72,7 +72,7 @@ case-insensitive databases.
 
 Generate a 25-character CUID.
 
-```typescript
+```typescript ignore
 function cuid(): string;
 ```
 

--- a/packages/id/docs/ID-CUID2.md
+++ b/packages/id/docs/ID-CUID2.md
@@ -66,7 +66,7 @@ to downstream parsers).
 
 Generate a CUID2 identifier.
 
-```typescript
+```typescript ignore
 function cuid2(length?: number): string;
 ```
 

--- a/packages/id/docs/ID-CUID2.md
+++ b/packages/id/docs/ID-CUID2.md
@@ -20,7 +20,7 @@ length, lowercase-alphanumeric, **not** time-sortable by design.
 
 ## Overview
 
-CUID2 is the cryptographically secure successor to {@link ./ID-CUID.md CUID}.
+CUID2 is the cryptographically secure successor to [CUID](./ID-CUID.md).
 Every character is drawn from `crypto.getRandomValues`, the format
 deliberately omits a timestamp segment (so the minting time can't be
 reconstructed), and the length is configurable to match your collision-

--- a/packages/id/docs/ID-Comparison.md
+++ b/packages/id/docs/ID-Comparison.md
@@ -85,7 +85,7 @@
 
 → **Use NanoID** (21 chars, customizable, URL-safe)
 
-```typescript
+```typescript ignore
 // Short, clean URLs
 https://app.com/p/g0b30yv24uuo0grjv
 ```
@@ -132,6 +132,8 @@ the native 24-char hex `ObjectId`)
 → **Use NanoID** with custom alphabet (high entropy)
 
 ```typescript
+import { ALPHA_NUMERIC_CASE, nanoID } from '@tundralibs/id';
+
 // 32-char alphanumeric token
 nanoID(32, ALPHA_NUMERIC_CASE);
 ```
@@ -622,6 +624,8 @@ const apiKey = nanoID(32, ALPHA_NUMERIC_CASE);
 #### 🛡️ **Medium Security (Session IDs, Resource IDs)**
 
 ```typescript
+import { nanoID, ulid } from '@tundralibs/id';
+
 // NanoID or ULID work well
 const sessionId = nanoID(); // 21 chars
 const resourceId = ulid(); // 26 chars
@@ -636,6 +640,8 @@ const resourceId = ulid(); // 26 chars
 #### 📊 **Low Security (Internal IDs, Database Keys)**
 
 ```typescript
+import { sequenceID, simpleID } from '@tundralibs/id';
+
 // Any generator is suitable
 const userId = sequenceID()();
 const orderId = simpleID()();
@@ -710,7 +716,7 @@ CREATE TABLE users_seq (
 
 #### MongoDB
 
-```typescript
+```typescript ignore
 // ObjectID (native format)
 {
   _id: ObjectId("507f1f77bcf86cd799439011"), // 12 bytes (binary)

--- a/packages/id/docs/ID-NanoID.md
+++ b/packages/id/docs/ID-NanoID.md
@@ -93,7 +93,7 @@ import { nanoID } from 'jsr:@tundralibs/id';
 
 Generates a cryptographically secure unique identifier.
 
-```typescript
+```typescript ignore
 function nanoID(size?: number, base?: string): string;
 ```
 
@@ -441,7 +441,7 @@ const sessionId = nanoID(32); // Security-critical (maximum uniqueness)
 import { ALPHA_NUMERIC_CASE, nanoID, PASSWORD, WEB_SAFE } from '@tundralibs/id';
 
 // ❌ BAD: Using complex characters where not needed
-const filename = nanoID(12, PASSWORD); // Special chars problematic in filenames
+const badFilename = nanoID(12, PASSWORD); // Special chars problematic in filenames
 
 // ✅ GOOD: Appropriate character sets
 const filename = nanoID(12, ALPHA_NUMERIC_CASE); // Safe for all systems
@@ -478,7 +478,7 @@ const batchIds = generateBatch(10000);
 import { nanoID } from '@tundralibs/id';
 
 // ❌ BAD: No error handling
-function createUser(name: string) {
+function createUserUnchecked(name: string) {
   const id = nanoID(0); // Will throw error
   return { id, name };
 }

--- a/packages/id/docs/ID-ObjectID.md
+++ b/packages/id/docs/ID-ObjectID.md
@@ -71,7 +71,7 @@ is **not** a uniform hex value.
 
 ### ObjectID Function
 
-```typescript
+```typescript ignore
 function ObjectID(
   counter?: number,
   machineId?: string,
@@ -237,6 +237,8 @@ console.log(`Created at: ${date.toISOString()} + ${millis}ms`);
 ### Utility Function for Timestamp Extraction
 
 ```typescript
+import { ObjectID } from '@tundralibs/id';
+
 function extractObjectIdTimestamp(objectId: string): Date {
   // Extract timestamp (seconds)
   const timestampHex = objectId.substring(0, 8);
@@ -251,6 +253,7 @@ function extractObjectIdTimestamp(objectId: string): Date {
 }
 
 // Usage
+const generateId = ObjectID();
 const id = generateId();
 const createdAt = extractObjectIdTimestamp(id);
 console.log(createdAt.toISOString());
@@ -266,6 +269,8 @@ timestamp and origin (not as a native MongoDB `_id` — see
 
 ```typescript
 import { ObjectID } from '@tundralibs/id';
+
+declare const collection: { insertOne(doc: unknown): Promise<unknown> };
 
 const generateId = ObjectID();
 
@@ -328,6 +333,8 @@ Generate unique file identifiers:
 ```typescript
 import { ObjectID } from '@tundralibs/id';
 
+declare function saveFile(path: string, file: File): Promise<void>;
+
 const fileGen = ObjectID(0, 'file');
 
 async function uploadFile(file: File) {
@@ -376,6 +383,8 @@ IDs generated later will be lexicographically greater:
 
 ```typescript
 import { ObjectID } from '@tundralibs/id';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const generateId = ObjectID();
 
@@ -438,6 +447,8 @@ console.log(ids.size === 2_000_000); // => true (no duplicates)
 Safe to use across multiple machines and processes:
 
 ```typescript
+import { ObjectID } from '@tundralibs/id';
+
 // Machine A
 const machineA = ObjectID(0, 'machA');
 
@@ -487,7 +498,7 @@ export function createUser() {
 }
 
 // ❌ Bad - Creating new generator each time
-export function createUser() {
+export function createUserBad() {
   const gen = ObjectID(0, 'usr'); // Creates new generator
   return {
     id: gen(),
@@ -548,6 +559,8 @@ function areIdsEqual(id1: string, id2: string): boolean {
 Validate ObjectID format when receiving from external sources:
 
 ```typescript
+declare const requestBody: { id: string };
+
 function isValidObjectId(id: string): boolean {
   // Check length (26 characters)
   if (id.length !== 26) return false;
@@ -615,7 +628,7 @@ function MongoCompatibleObjectID() {
 
 ### Using with MongoDB Drivers
 
-```typescript
+```typescript ignore
 import { MongoClient, ObjectId } from 'mongodb';
 import { ObjectID } from '@tundralibs/id';
 

--- a/packages/id/docs/ID-Performance.md
+++ b/packages/id/docs/ID-Performance.md
@@ -148,6 +148,8 @@ NanoID (32)       ██████                          ~48 bytes
 **Per-ID Memory Usage:**
 
 ```typescript
+import { nanoID, ObjectID, sequenceID, simpleID, ulid } from '@tundralibs/id';
+
 // Minimal Memory
 const seq = sequenceID(); // ~8 bytes per ID (number)
 const simple = simpleID(0, 4); // ~16 bytes per ID (4-8 char string)
@@ -157,13 +159,15 @@ const oid = ObjectID(0); // ~24 bytes per ID (24 char hex string)
 const nano = nanoID(10); // ~24 bytes per ID (10 char string)
 
 // Higher Memory
-const ulid = ulid(); // ~32 bytes per ID (26 char string)
+const ulidId = ulid(); // ~32 bytes per ID (26 char string)
 const nano32 = nanoID(32); // ~48 bytes per ID (32 char string)
 ```
 
 **Generator Instance Memory:**
 
 ```typescript
+import { nanoID, ObjectID, sequenceID, simpleID, ulid } from '@tundralibs/id';
+
 // Near-zero overhead
 nanoID(); // Stateless function
 ulid(); // Stateless function
@@ -199,6 +203,8 @@ ObjectID(0); // ~48 bytes (machineId + processId + counter)
 **Concurrent Performance:**
 
 ```typescript
+import { nanoID, ObjectID } from '@tundralibs/id';
+
 // Good: NanoID scales linearly with cores
 async function generateInParallel() {
   const promises = Array.from(
@@ -239,6 +245,14 @@ const oid2 = ObjectID(2);
 **1. Choose the Right Alphabet**
 
 ```typescript
+import {
+  ALPHA_NUMERIC,
+  ALPHABETS,
+  nanoID,
+  NUMBERS,
+  PASSWORD,
+} from '@tundralibs/id';
+
 // Fastest: Numeric only
 const numeric = nanoID(10, NUMBERS); // ~30% faster than alphanumeric
 
@@ -255,6 +269,8 @@ const password = nanoID(10, PASSWORD); // More secure, but slower
 **2. Optimize Length**
 
 ```typescript
+import { nanoID } from '@tundralibs/id';
+
 // Ultra-fast: Short IDs
 const short = nanoID(8); // 2x faster than 16-char
 const medium = nanoID(16); // Standard
@@ -264,6 +280,8 @@ const long = nanoID(32); // Secure but 2x slower
 **3. Batch Generation**
 
 ```typescript
+import { nanoID } from '@tundralibs/id';
+
 // Inefficient: Creating many small IDs
 const ids = [];
 for (let i = 0; i < 1000; i++) {
@@ -271,7 +289,7 @@ for (let i = 0; i < 1000; i++) {
 }
 
 // Better: Pre-generate if possible
-const ids = Array.from({ length: 1000 }, () => nanoID(10));
+const preGeneratedIds = Array.from({ length: 1000 }, () => nanoID(10));
 
 // Best: Use a pool for high-frequency access
 class IDPool {
@@ -294,6 +312,8 @@ class IDPool {
 **4. Collision Probability**
 
 ```typescript
+import { nanoID } from '@tundralibs/id';
+
 // For 1 million IDs, collision probability:
 nanoID(8); // 0.0001% (1 in 1M)      - Not recommended
 nanoID(10); // 0.000001% (1 in 100M)  - Good for most apps
@@ -306,8 +326,10 @@ nanoID(21); // ~0% (1 in 10^34)       - Default, excellent
 **1. Reuse Generators**
 
 ```typescript
+import { ObjectID } from '@tundralibs/id';
+
 // ❌ Inefficient: Creating generator per call
-function getNewId() {
+function getNewIdSlow() {
   return ObjectID(0)(); // Overhead every time
 }
 
@@ -321,6 +343,10 @@ function getNewId() {
 **2. Manual Machine ID for Performance**
 
 ```typescript
+import { ObjectID } from '@tundralibs/id';
+
+declare function getWorkerId(): number;
+
 // Slightly slower: Auto-detects machine ID
 const autoOid = ObjectID(0);
 
@@ -351,6 +377,13 @@ function getCreatedTime(id: string): Date {
 **4. Batch Generation Strategy**
 
 ```typescript
+import { ObjectID } from '@tundralibs/id';
+
+declare const db: {
+  collection: { insertMany(docs: unknown[]): Promise<void> };
+};
+declare const data: Record<string, unknown>;
+
 // For bulk inserts
 function* generateObjectIDs(count: number): Generator<string> {
   const oid = ObjectID(0);
@@ -371,6 +404,8 @@ await db.collection.insertMany(
 **1. Standard vs Monotonic**
 
 ```typescript
+import { monotonicUlid, ulid } from '@tundralibs/id';
+
 // Fastest: Standard ULID (no state)
 const id1 = ulid(); // ~1.0μs
 
@@ -384,18 +419,22 @@ const id2 = monotonicUlid(); // ~1.1μs
 **2. Custom Timestamp for Batch Generation**
 
 ```typescript
+import { ulid } from '@tundralibs/id';
+
 // Inefficient: System calls for each ID
 const ids = Array.from({ length: 1000 }, () => ulid());
 
 // Efficient: Reuse timestamp for batch
 const timestamp = Date.now();
-const ids = Array.from({ length: 1000 }, () => ulid(timestamp));
+const batchedIds = Array.from({ length: 1000 }, () => ulid(timestamp));
 // ~10% faster for large batches
 ```
 
 **3. Monotonic Batch Generation**
 
 ```typescript
+import { monotonicUlid } from '@tundralibs/id';
+
 // Best for high-frequency generation in same ms
 const timestamp = Date.now();
 const ids = [];
@@ -408,12 +447,16 @@ for (let i = 0; i < 100; i++) {
 **4. Timestamp Extraction**
 
 ```typescript
+import { getTimestamp, ulid } from '@tundralibs/id';
+
 // Fast: Direct timestamp extraction
 const id = ulid();
 const timestamp = getTimestamp(id); // ~0.1μs
 
 // Avoid re-generating for timestamp comparison
 // Instead, extract and compare
+const id1 = ulid();
+const id2 = ulid();
 const time1 = getTimestamp(id1);
 const time2 = getTimestamp(id2);
 if (time1 < time2) { /* ... */ }
@@ -422,6 +465,8 @@ if (time1 < time2) { /* ... */ }
 **5. Pre-allocation for High Throughput**
 
 ```typescript
+import { ulid } from '@tundralibs/id';
+
 // For scenarios requiring 10k+ IDs/second
 class ULIDPool {
   private pool: string[] = [];
@@ -450,6 +495,8 @@ class ULIDPool {
 **1. Default vs Override**
 
 ```typescript
+import { sequenceID } from '@tundralibs/id';
+
 // Fastest: Default sequential generation
 const id = sequenceID(); // ~0.1μs
 
@@ -461,6 +508,8 @@ const id2 = sequenceID(1000); // ~0.15μs
 **2. Thread Safety**
 
 ```typescript
+import { sequenceID } from '@tundralibs/id';
+
 // Each worker should have its own sequence
 // to avoid contention
 
@@ -476,21 +525,25 @@ const getWorker2Id = () => sequenceID(worker2Sequence++);
 **3. Reset Strategy**
 
 ```typescript
+import { sequenceID } from '@tundralibs/id';
+
 // For long-running processes, consider overflow
 let currentSeq = 0;
 const MAX_SAFE_INTEGER = 9007199254740991;
 
-function getNextId(): number {
+function getNextId(): bigint {
   if (currentSeq >= MAX_SAFE_INTEGER) {
     currentSeq = 0; // Reset or handle overflow
   }
-  return sequenceID(currentSeq++);
+  return sequenceID(currentSeq++)();
 }
 ```
 
 **4. Combine with Timestamp**
 
 ```typescript
+import { sequenceID } from '@tundralibs/id';
+
 // For distributed uniqueness with high performance
 function makeGlobalId(workerId: number): string {
   const timestamp = Date.now();
@@ -505,6 +558,8 @@ function makeGlobalId(workerId: number): string {
 **1. Length vs Performance**
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // Fastest: 4 characters
 const short = simpleID(0, 4)(); // ~0.4μs
 
@@ -520,8 +575,10 @@ const long = simpleID(0, 8)(); // ~0.6μs
 **2. Reuse Generator Instances**
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // ❌ Avoid: Creating new generator each time
-function getId() {
+function getIdSlow() {
   return simpleID(0, 6)();
 }
 
@@ -535,16 +592,18 @@ function getId() {
 **3. Worker-Specific Seeds**
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // In distributed systems, use worker-specific seeds
 class WorkerIDGenerator {
-  private generator;
+  private generator: () => bigint;
 
   constructor(workerId: number) {
     // Use worker ID as seed for uniqueness
     this.generator = simpleID(workerId, 6);
   }
 
-  generate(): string {
+  generate(): bigint {
     return this.generator();
   }
 }
@@ -559,6 +618,8 @@ const worker2Ids = new WorkerIDGenerator(2);
 **4. Balance Length and Collision**
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // For 1 million IDs:
 simpleID(0, 4); // Risk of collision in large datasets
 simpleID(0, 6); // Good balance for most applications
@@ -629,6 +690,8 @@ class EventIDGenerator {
 ```typescript
 // Solution: Pre-generate IDs in batches
 import { ObjectID } from '@tundralibs/id';
+
+declare const db: { insertMany(docs: unknown[]): Promise<void> };
 
 async function bulkInsert(records: any[]): Promise<void> {
   const oid = ObjectID(0);
@@ -756,7 +819,7 @@ const id = ulid();
 
 **Pattern 1: Thread-Local Generators**
 
-```typescript
+```typescript ignore
 // Deno Workers example
 import { ObjectID } from '@tundralibs/id';
 
@@ -822,12 +885,12 @@ class ThreadSafeSequence {
     }
   }
 
-  getForThread(threadId: number): number {
+  getForThread(threadId: number): bigint {
     const range = this.ranges.get(threadId)!;
     if (range.current >= range.end) {
       throw new Error('Range exhausted');
     }
-    return sequenceID(range.current++);
+    return sequenceID(range.current++)();
   }
 }
 
@@ -839,6 +902,8 @@ class ThreadSafeSequence {
 **Pattern 4: Message-Passing ID Generation**
 
 ```typescript
+import { ObjectID } from '@tundralibs/id';
+
 // Centralized ID generator with message queue
 class CentralIDGenerator {
   private generator = ObjectID(0);
@@ -903,6 +968,8 @@ deno bench simpleID.bench.ts
 ### Benchmark Code Structure
 
 ```typescript
+import { ALPHABETS, nanoID, ulid } from '@tundralibs/id';
+
 // Example benchmark structure
 Deno.bench({
   name: 'id.Generate nanoID of length 10',
@@ -973,7 +1040,7 @@ Deno.serve((req) => {
 
 **Scenario**: MongoDB document insertion
 
-```typescript
+```typescript ignore
 import { ObjectID } from '@tundralibs/id';
 import { MongoClient } from 'mongodb';
 
@@ -1009,6 +1076,12 @@ await collection.insertMany(records);
 ```typescript
 import { ulid } from '@tundralibs/id';
 
+declare const kafka: {
+  produce(
+    message: { topic: string; key: string; value: string },
+  ): Promise<void>;
+};
+
 class EventBus {
   async publish(event: string, data: any): Promise<void> {
     const eventId = ulid(); // ~1μs
@@ -1039,6 +1112,8 @@ class EventBus {
 
 ```typescript
 import { nanoID } from '@tundralibs/id';
+
+declare const storage: { writeBatch(entries: unknown[]): Promise<void> };
 
 class LogAggregator {
   private buffer: any[] = [];
@@ -1094,7 +1169,7 @@ class LogAggregator {
 
 ### vs. uuid (Node.js standard)
 
-```typescript
+```typescript ignore
 // TundraLibs NanoID
 nanoID(10); // ~0.8μs
 // UUID v4 (Node.js)
@@ -1120,7 +1195,7 @@ ulid(); // ~1.2μs
 
 ### vs. nanoid (npm package)
 
-```typescript
+```typescript ignore
 // TundraLibs NanoID
 import { nanoID } from '@tundralibs/id';
 nanoID(10); // ~0.8μs
@@ -1141,7 +1216,7 @@ nanoid(10); // ~0.9μs
 
 ### vs. MongoDB ObjectID (Official Driver)
 
-```typescript
+```typescript ignore
 // TundraLibs ObjectID
 const oid = ObjectID(0);
 oid(); // ~0.3μs
@@ -1162,7 +1237,7 @@ new ObjectId(); // ~0.5μs
 
 ### vs. cuid / cuid2
 
-```typescript
+```typescript ignore
 // TundraLibs ULID
 ulid(); // ~1.0μs
 
@@ -1180,7 +1255,7 @@ createId(); // ~2.0μs
 
 ### vs. Short UUID
 
-```typescript
+```typescript ignore
 // TundraLibs SimpleID
 simpleID(0, 6)(); // ~0.5μs
 
@@ -1348,6 +1423,8 @@ measureIDGeneration(() => ulid(), 100000);
 ### Memory Profiling
 
 ```typescript
+import { nanoID } from '@tundralibs/id';
+
 // Check memory usage
 function measureMemoryUsage(
   generator: () => string,
@@ -1373,6 +1450,8 @@ measureMemoryUsage(() => nanoID(10), 10000);
 ### Profiling Hot Paths
 
 ```typescript
+import { nanoID } from '@tundralibs/id';
+
 // Identify if ID generation is a bottleneck
 class RequestHandler {
   private idGenerationTime = 0;
@@ -1400,6 +1479,8 @@ class RequestHandler {
 ### Comparative Profiling
 
 ```typescript
+import { nanoID, ObjectID, sequenceID, simpleID, ulid } from '@tundralibs/id';
+
 // Compare multiple implementations
 async function compareGenerators(): Promise<void> {
   const generators = {

--- a/packages/id/docs/ID-SequenceID.md
+++ b/packages/id/docs/ID-SequenceID.md
@@ -93,7 +93,7 @@ SequenceID generates a 64-bit integer composed of three components — this matc
 
 **Example ID Decomposition:**
 
-```typescript
+```typescript ignore
 ID: 72623859790382856n
 
 Server ID:    1            (Process ID % 256)
@@ -133,7 +133,7 @@ import { sequenceID } from 'jsr:@tundralibs/id';
 
 Creates a database-friendly sequential ID generator.
 
-```typescript
+```typescript ignore
 function sequenceID(cnt?: number): (counter?: number) => bigint;
 ```
 
@@ -155,6 +155,8 @@ A generator function that produces unique 64-bit integer IDs.
 **Example:**
 
 ```typescript
+import { sequenceID } from '@tundralibs/id';
+
 const generator = sequenceID();
 const id = generator(); // 72623859790382856n
 ```
@@ -373,7 +375,7 @@ CREATE TABLE users (
 CREATE INDEX idx_users_id ON users(id);
 ```
 
-```typescript
+```typescript ignore
 import { sequenceID } from '@tundralibs/id';
 import { Pool } from 'pg';
 
@@ -416,7 +418,7 @@ CREATE TABLE orders (
 ) ENGINE=InnoDB;
 ```
 
-```typescript
+```typescript ignore
 import { sequenceID } from '@tundralibs/id';
 import mysql from 'mysql2/promise';
 

--- a/packages/id/docs/ID-SimpleID.md
+++ b/packages/id/docs/ID-SimpleID.md
@@ -135,7 +135,7 @@ Different configurations produce different ID formats:
 
 Creates a date-based sequential ID generator function.
 
-```typescript
+```typescript ignore
 function simpleID(
   seed?: number,
   minLen?: number,
@@ -188,6 +188,8 @@ function simpleID(
 The returned function generates the next ID in sequence:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const gen = simpleID();
 const id1 = gen(); // 202412260001n
 const id2 = gen(); // 202412260002n
@@ -310,6 +312,8 @@ SimpleID automatically resets the counter to zero at the start of each new day. 
 The generator tracks the current date (YYYYMMDD format) and compares it on each ID generation:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const gen = simpleID(0, 4);
 
 // December 26, 2024
@@ -340,6 +344,8 @@ SimpleID is ideal for scenarios requiring human-readable, date-traceable identif
 Perfect for invoices, receipts, quotes, and purchase orders:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const invoiceGen = simpleID(1000, 4);
 const receiptGen = simpleID(5000, 4);
 const quoteGen = simpleID(2000, 4);
@@ -355,6 +361,8 @@ const quote = quoteGen(); // QTE-202412262001
 Track orders with date-based references:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const orderGen = simpleID(0, 6);
 
 // Orders are naturally sorted by date
@@ -367,6 +375,8 @@ const order2 = orderGen(); // 20241226000002
 Generate support tickets or event tickets:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const ticketGen = simpleID(10000, 5);
 
 // Support tickets
@@ -379,6 +389,8 @@ const ticket2 = ticketGen(); // TKT-2024122610002
 High-frequency log entries with microsecond precision:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const logGen = simpleID(0, 3, true);
 
 // Precise event timestamps
@@ -391,6 +403,8 @@ const event2 = logGen(); // 20241226143052789002
 Generate daily report identifiers:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const reportGen = simpleID(1, 3);
 
 // Daily report numbering
@@ -409,6 +423,8 @@ Select `minLen` based on expected daily volume:
 - **6 digits** (000001-999999): Up to ~1,000,000 IDs per day
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // Low volume (< 10K/day)
 const lowVol = simpleID(0, 4);
 
@@ -424,6 +440,8 @@ const highVol = simpleID(0, 6);
 Start sequences at meaningful numbers:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // Start at 1 for natural counting
 const natural = simpleID(1, 4);
 
@@ -439,6 +457,8 @@ const legacy = simpleID(10000, 5);
 Add prefixes and separators for better readability:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 const gen = simpleID(1000, 4);
 const id = gen();
 
@@ -457,7 +477,7 @@ const formatted = id.toString().replace(
 
 Keep IDs as BigInt in databases for efficient sorting and indexing:
 
-```typescript
+```typescript ignore
 // PostgreSQL
 CREATE TABLE invoices (
   id BIGINT PRIMARY KEY,
@@ -490,6 +510,8 @@ const getDateInTz = (tz: string) => {
 Enable microseconds only when needed:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // Standard business documents (NO microseconds)
 const invoiceGen = simpleID(1000, 4, false);
 
@@ -502,6 +524,8 @@ const logGen = simpleID(0, 3, true);
 Design counter length with future growth in mind:
 
 ```typescript
+import { simpleID } from '@tundralibs/id';
+
 // Current: 100 orders/day
 // Growth: 1000 orders/day expected
 // Use 5 digits for headroom

--- a/packages/id/docs/ID-ULID.md
+++ b/packages/id/docs/ID-ULID.md
@@ -73,7 +73,7 @@ ULIDs use **Crockford's Base32** alphabet: `0123456789ABCDEFGHJKMNPQRSTVWXYZ`
 
 Generates a ULID with the current or specified timestamp.
 
-```typescript
+```typescript ignore
 function ulid(timestamp?: number, monotonic?: boolean): string;
 ```
 
@@ -132,7 +132,7 @@ const mono2 = ulid(Date.now(), true);
 
 Generates a monotonic ULID with guaranteed lexicographic ordering within the same millisecond.
 
-```typescript
+```typescript ignore
 function monotonicUlid(timestamp?: number): string;
 ```
 
@@ -179,7 +179,7 @@ const log2 = monotonicUlid(); // "01ARZ3NDEKTSV4RRFFQ69G5FAW"
 
 Extracts the timestamp component from a ULID string.
 
-```typescript
+```typescript ignore
 function getTimestamp(id: string): number;
 ```
 
@@ -230,6 +230,8 @@ Generate ULIDs for general-purpose unique identifiers:
 
 ```typescript
 import { ulid } from '@tundralibs/id';
+
+declare const db: { users: { insert(row: unknown): Promise<void> } };
 
 // Simple ID generation
 const userId = ulid();
@@ -292,6 +294,10 @@ class Logger {
 
     // IDs will be sorted even if logs happen in same millisecond
     this.writeToDatabase(logEntry);
+  }
+
+  private writeToDatabase(entry: unknown): void {
+    // Persist the entry with your storage layer of choice
   }
 }
 
@@ -362,6 +368,14 @@ ULIDs are designed to sort lexicographically by creation time, making database q
 
 ```typescript
 import { ulid } from '@tundralibs/id';
+
+declare const db: {
+  collection: {
+    find(query: unknown): { sort(order: unknown): Promise<unknown[]> };
+  };
+};
+declare const startTime: number;
+declare const endTime: number;
 
 // Generate ULIDs over time
 const id1 = ulid(1600000000000); // Sept 13, 2020
@@ -441,6 +455,8 @@ Maintain event order with high-frequency logging:
 import { monotonicUlid } from '@tundralibs/id';
 
 class EventLogger {
+  private eventStore!: { append(event: unknown): Promise<void> };
+
   async logEvent(type: string, data: unknown) {
     const event = {
       id: monotonicUlid(), // Guarantees order
@@ -454,6 +470,7 @@ class EventLogger {
 }
 
 // Even thousands of events per second maintain order
+const logger = new EventLogger();
 for (let i = 0; i < 10000; i++) {
   await logger.logEvent('user_action', { index: i });
 }
@@ -463,7 +480,7 @@ for (let i = 0; i < 10000; i++) {
 
 Track and correlate API requests:
 
-```typescript
+```typescript ignore
 import { ulid } from '@tundralibs/id';
 
 app.use((req, res, next) => {
@@ -496,6 +513,8 @@ ULIDs use the same bit length as UUIDs, making them suitable for any system desi
 The timestamp-first design enables natural chronological ordering:
 
 ```typescript
+import { ulid } from '@tundralibs/id';
+
 const ids = [
   ulid(Date.now() + 1000), // +1 second
   ulid(Date.now()), // now
@@ -539,8 +558,10 @@ const random = crypto.getRandomValues(new Uint8Array(10));
 When generating many IDs in rapid succession:
 
 ```typescript
+import { monotonicUlid, ulid } from '@tundralibs/id';
+
 // ❌ Don't use regular ulid() for high-frequency
-const ids = Array.from({ length: 10000 }, () => ulid());
+const unorderedIds = Array.from({ length: 10000 }, () => ulid());
 // May have inconsistent ordering within same millisecond
 
 // ✅ Use monotonicUlid() instead
@@ -552,7 +573,7 @@ const ids = Array.from({ length: 10000 }, () => monotonicUlid());
 
 While ULIDs can be stored as binary (16 bytes), string storage is recommended:
 
-```typescript
+```typescript ignore
 // ✅ Recommended: String storage
 {
   _id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -571,13 +592,15 @@ While ULIDs can be stored as binary (16 bytes), string storage is recommended:
 In multi-process or multi-machine environments:
 
 ```typescript
+import { monotonicUlid, ulid } from '@tundralibs/id';
+
 // ✅ Use regular ulid() - no global state
 // Different servers, workers, or isolates
 const id = ulid();
 
 // ❌ Don't use monotonicUlid() across processes
 // Global state not shared between processes
-const id = monotonicUlid(); // May not be monotonic across boundaries
+const monotonicId = monotonicUlid(); // May not be monotonic across boundaries
 ```
 
 ### Include Timestamp Extraction in Queries
@@ -585,6 +608,12 @@ const id = monotonicUlid(); // May not be monotonic across boundaries
 Leverage the timestamp component for efficient filtering:
 
 ```typescript
+import { ulid } from '@tundralibs/id';
+
+declare const db: { find(query: unknown): Promise<unknown[]> };
+declare const startTime: number;
+declare const endTime: number;
+
 // Generate range boundaries
 const startId = ulid(startTime);
 const endId = ulid(endTime);
@@ -600,6 +629,8 @@ const results = await db.find({
 Always validate ULIDs from external sources:
 
 ```typescript
+import { getTimestamp } from '@tundralibs/id';
+
 function isValidUlid(id: string): boolean {
   if (id.length !== 26) return false;
 
@@ -620,6 +651,15 @@ function isValidUlid(id: string): boolean {
 ULIDs naturally cluster by time in B-tree indexes:
 
 ```typescript
+import { ulid } from '@tundralibs/id';
+
+declare const db: {
+  collection: {
+    createIndex(spec: unknown): Promise<void>;
+    find(query: unknown): Promise<unknown[]>;
+  };
+};
+
 // ✅ Good: New ULIDs append to index
 // Minimizes index rebalancing and write amplification
 await db.collection.createIndex({ id: 1 });
@@ -668,7 +708,7 @@ const recentDocs = await db.collection.find({
 
 ULIDs can coexist with UUIDs in the same system:
 
-```typescript
+```typescript ignore
 import { ulid } from '@tundralibs/id';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/id/errors/Base.ts
+++ b/packages/id/errors/Base.ts
@@ -10,6 +10,7 @@
  * @example
  * ```ts
  * import { IDError } from '@tundralibs/id/errors';
+ * import { ObjectID } from '@tundralibs/id/ObjectID';
  *
  * try {
  *   ObjectID(-1);

--- a/packages/id/errors/InvalidOptionError.ts
+++ b/packages/id/errors/InvalidOptionError.ts
@@ -43,6 +43,15 @@ export type InvalidOptionErrorMeta = {
  * ```
  */
 export class InvalidOptionError extends IDError<InvalidOptionErrorMeta> {
+  /**
+   * Construct directly only when writing a generator that shares this
+   * validation contract; the bundled generators raise it themselves.
+   *
+   * @param message - Error text; `${generator}`, `${option}` and `${value}`
+   *   placeholders are substituted from `meta`.
+   * @param meta - Identifies the rejected argument; becomes `error.context`.
+   * @param cause - Underlying error for chaining.
+   */
   constructor(
     message: string,
     meta: InvalidOptionErrorMeta,

--- a/packages/id/errors/InvalidOptionError.ts
+++ b/packages/id/errors/InvalidOptionError.ts
@@ -31,6 +31,8 @@ export type InvalidOptionErrorMeta = {
  *
  * @example
  * ```ts
+ * import { ObjectID } from '@tundralibs/id/ObjectID';
+ *
  * try {
  *   ObjectID(-1);
  * } catch (e) {

--- a/packages/id/errors/InvalidULIDError.ts
+++ b/packages/id/errors/InvalidULIDError.ts
@@ -36,6 +36,8 @@ export type InvalidULIDErrorMeta = {
  *
  * @example
  * ```ts
+ * import { getTimestamp } from '@tundralibs/id/ulid';
+ *
  * try {
  *   getTimestamp('not-a-ulid');
  * } catch (e) {

--- a/packages/id/errors/InvalidULIDError.ts
+++ b/packages/id/errors/InvalidULIDError.ts
@@ -48,6 +48,16 @@ export type InvalidULIDErrorMeta = {
  * ```
  */
 export class InvalidULIDError extends IDError<InvalidULIDErrorMeta> {
+  /**
+   * Construct directly only when writing your own ULID decoder;
+   * {@link getTimestamp} raises it itself.
+   *
+   * @param message - Error text; `${id}`, `${reason}` and the remaining
+   *   `meta` keys are substituted as `${...}` placeholders.
+   * @param meta - The string that failed to decode and why; becomes
+   *   `error.context`.
+   * @param cause - Underlying error for chaining.
+   */
   constructor(
     message: string,
     meta: InvalidULIDErrorMeta,

--- a/packages/id/errors/MonotonicOverflowError.ts
+++ b/packages/id/errors/MonotonicOverflowError.ts
@@ -38,6 +38,17 @@ export type MonotonicOverflowErrorMeta = {
  */
 export class MonotonicOverflowError
   extends IDError<MonotonicOverflowErrorMeta> {
+  /**
+   * Construct directly only when implementing a monotonic generator with
+   * the same overflow guarantee; the bundled monotonic paths raise it
+   * themselves.
+   *
+   * @param message - Error text; a `${timestamp}` placeholder is substituted
+   *   from `meta`.
+   * @param meta - Millisecond timestamp at which the random space was
+   *   exhausted; becomes `error.context`.
+   * @param cause - Underlying error for chaining.
+   */
   constructor(
     message: string,
     meta: MonotonicOverflowErrorMeta,

--- a/packages/id/nanoID.ts
+++ b/packages/id/nanoID.ts
@@ -85,7 +85,7 @@ const MAX_U32_PER_CALL = 16384;
  * @throws {@link InvalidOptionError} If the length parameter is less than 1
  *
  * @example
- * ```typescript
+ * ```typescript ignore
  * const randomNumbers = random(5); // Uint32Array with 5 random values
  * ```
  */

--- a/packages/id/nanoID.ts
+++ b/packages/id/nanoID.ts
@@ -46,7 +46,7 @@ export const ALPHABETS = 'abcdefghijklmnopqrstuvwxyz';
 /**
  * Web-safe characters: a-z, 0-9, _, - (URL-safe, 38 characters)
  */
-export const WEB_SAFE = ALPHABETS + '_' + NUMBERS + '-';
+export const WEB_SAFE: string = ALPHABETS + '_' + NUMBERS + '-';
 
 /**
  * Alphanumeric characters: a-z, A-Z, 0-9
@@ -55,14 +55,15 @@ export const ALPHA_NUMERIC: string = ALPHABETS + NUMBERS +
   ALPHABETS.toUpperCase();
 
 /**
- * Case-sensitive alphanumeric: a-z, 0-9 (lowercase only)
+ * Lowercase alphanumeric: a-z, 0-9 (36 characters). Despite the name this
+ * set carries no uppercase — {@link ALPHA_NUMERIC} is the mixed-case one.
  */
-export const ALPHA_NUMERIC_CASE = ALPHABETS + NUMBERS;
+export const ALPHA_NUMERIC_CASE: string = ALPHABETS + NUMBERS;
 
 /**
  * Password-safe characters including special symbols
  */
-export const PASSWORD = '!@$%^&*' + WEB_SAFE;
+export const PASSWORD: string = '!@$%^&*' + WEB_SAFE;
 
 /**
  * Web Crypto's `getRandomValues` rejects any view longer than 65536 bytes

--- a/packages/id/sequenceID.ts
+++ b/packages/id/sequenceID.ts
@@ -107,7 +107,7 @@ function initSequenceID(counter: number = 0) {
    *
    * @example
    * ```typescript
-   * const generator = initSequenceID();
+   * const generator = sequenceID();
    * const id1 = generator();      // Uses internal counter
    * const id2 = generator(5000);  // Resets counter to 5000
    * const id3 = generator();      // Continues from 5001
@@ -174,9 +174,9 @@ function initSequenceID(counter: number = 0) {
  *
  * // Override counter mid-sequence
  * const flexSeq = sequenceID();
- * const id1 = flexSeq();       // Uses internal counter
- * const id2 = flexSeq(5000);   // Resets to 5000
- * const id3 = flexSeq();       // Continues from 5001
+ * const flexId1 = flexSeq();     // Uses internal counter
+ * const flexId2 = flexSeq(5000); // Resets to 5000
+ * const flexId3 = flexSeq();     // Continues from 5001
  *
  * // Use as database primary key
  * const userIdGen = sequenceID();

--- a/packages/id/ulid.ts
+++ b/packages/id/ulid.ts
@@ -336,7 +336,7 @@ function encodeRandom(randomBytes: Uint8Array): string {
  * @internal
  *
  * @example
- * ```typescript
+ * ```typescript ignore
  * const bytes = new Uint8Array([0x00, 0x00, 0xFF, 0xFF]);
  * const incremented = incrementRandom(bytes, Date.now()); // [0x00, 0x01, 0x00, 0x00]
  * ```
@@ -390,6 +390,7 @@ function incrementRandom(
  * const date = new Date(timestamp); // 2019-01-01T00:00:00.000Z
  *
  * // Validate ULID age
+ * const someUlid = ulid();
  * const ageMs = Date.now() - getTimestamp(someUlid);
  * const ageHours = ageMs / (1000 * 60 * 60);
  * ```


### PR DESCRIPTION
## What

All 10 `.md` files (206 blocks) and all 13 non-test source files in `packages/id` now pass `deno check --doc-only`.

**Four files were aborting on a SyntaxError**, hiding their real counts entirely. The clearest illustration: `ID-Performance.md` reported **0 errors** at first read, then **113** once the first fix let the checker traverse past the abort. `ID-Comparison.md` showed 1 error hiding 5 more.

Retagged ` ignore ` where genuinely not code: ~30 bare signature listings (the largest category), an ASCII bit-layout diagram, embedded SQL and MongoDB document shapes, cross-library timing comparisons that declare `ulid()` twice for two different libraries, blocks importing third-party packages (`mongodb`, `nanoid`, `uuid`, `pg`, `mysql2`, …), and two `@internal` helpers that cannot be imported from outside their module.

## Drift found — source untouched

**1. `sequenceID` is documented as returning an id, but returns a generator.** The real signature is `(counter?) => bigint`. Two blocks in `ID-Performance.md` failed to compile and are corrected to call the generator — but **three neighbouring blocks compile while still teaching it wrong** (`const id = sequenceID();`). Left per the minimal-diff rule; **the SequenceID section of that doc needs a semantic pass**, since compiling is not the same as correct here.

**2. `initSequenceID` does not exist** — a JSDoc example in source called it; corrected to `sequenceID`.

**3. `JsonWebKey` has no `kid`** in Deno's lib, so three JWKS-lookup examples needed `JsonWebKey & { kid?: string }`.

## Gates

`deno fmt --check` clean (40 files) · `deno check packages/id/mod.ts` clean · tests 10 passed / 93 steps / 0 failed · `deno doc --lint` **7 before, 7 after**. Phase-2 diff verified as comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)