### PR TITLE
chore: add Cloudflare Workers and Browser to the bug-report runtime list

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,6 +38,8 @@ body:
         - Deno
         - Bun
         - Node.js
+        - Cloudflare Workers
+        - Browser
         - Multiple / all
     validations:
       required: true
@@ -45,7 +47,10 @@ body:
     id: runtime-version
     attributes:
       label: Runtime version
-      placeholder: e.g. deno 2.9.0
+      description: >-
+        For Cloudflare Workers, include the wrangler/workerd version and your
+        compatibility_date. For a browser, include the browser and the bundler.
+      placeholder: e.g. deno 2.9.0 / wrangler 4.123.0 + compat date 2026-08-04 / Chrome 141 + Vite 8
     validations:
       required: true
   - type: textarea

--- a/.github/scripts/workspace.ts
+++ b/.github/scripts/workspace.ts
@@ -262,6 +262,8 @@ ${dropdownOptions(pkgs)}
         - Deno
         - Bun
         - Node.js
+        - Cloudflare Workers
+        - Browser
         - Multiple / all
     validations:
       required: true
@@ -269,7 +271,10 @@ ${dropdownOptions(pkgs)}
     id: runtime-version
     attributes:
       label: Runtime version
-      placeholder: e.g. deno 2.9.0
+      description: >-
+        For Cloudflare Workers, include the wrangler/workerd version and your
+        compatibility_date. For a browser, include the browser and the bundler.
+      placeholder: e.g. deno 2.9.0 / wrangler 4.123.0 + compat date 2026-08-04 / Chrome 141 + Vite 8
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## What

Adds **Cloudflare Workers** and **Browser** to the Runtime dropdown in the bug-report template, and extends the version field to ask for what actually makes those runtimes reproducible.

## Why

The dropdown offered only Deno / Bun / Node.js / Multiple. Every Workers- or browser-specific report therefore had to be filed as "Multiple / all" with the real runtime buried in prose — #276, #277, #278, #279 and #280 are all in exactly that shape.

The suite now targets these environments deliberately: `compat` detects them, `ambient` and `drivers` document their behaviour there, and JSR carries per-runtime compatibility flags. The template had not caught up.

## The version field

`wrangler 4.123.0` on its own is not reproducible — workerd behaviour depends on `compatibility_date`, and a browser bug usually depends on the bundler. That is not hypothetical: **esbuild and rolldown disagree on unresolved specifiers, which is precisely what hid #278** (the `compat` barrel builds under Vite and fails under wrangler). So the field now asks for compat date and bundler.

## Generated file

`.github/scripts/workspace.ts` is the source; `.github/ISSUE_TEMPLATE/bug_report.yml` is regenerated via `deno task workspace:sync`. Both are in the diff. `workspace:sync:check` passes, and the YAML was parsed to confirm the dropdown and description survive generation intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)