### PR TITLE
fix(slogger): mask pass and pwd by default, and stop the two docs disagreeing

### DIFF
--- a/packages/slogger/docs/Slogger-Security.md
+++ b/packages/slogger/docs/Slogger-Security.md
@@ -153,23 +153,29 @@ coercion). None of the following are masked by the defaults:
 | `authUrl`, `authMethod`, `author`                                                                                                                                     | `auth`       |
 | `isPrivate`, `privateIp`, `privateer`                                                                                                                                 | `private`    |
 | `spinner`, `pinboard`                                                                                                                                                 | `pin`        |
+| `bypass`, `compass`, `surpass`, `encompass`, `overpass`, `passenger`, `passive`, `passed`, `db_pass`                                                                  | `pass`       |
+| `cwd`, `fwd`, `userPwd`, `pwdHash`                                                                                                                                    | `pwd`        |
 
 Two distinct reasons a key stays visible appear above: a term used as a
 **qualifier** (not the head) — `tokenBucket`, `nextTokenCount` — and a
 term that **is** the head but is one of the **whole-key-only generic
-words** (`key`, `token`, `auth`, `private`, `pin`) — `sortKey`,
-`pageToken`, `nextPageToken`, `continuationToken`, `csrfToken`,
-`resetToken`. The latter are ubiquitous pagination cursors and
-anti-forgery / reset tokens; masking them would break downstream jobs
-that resume from a logged cursor, so `token` (like `key`) never
-head-matches on its own. Their scalar type is preserved, and only the
-**enumerated** `*Token`/`*Key` secrets (below) are masked.
+words** (`key`, `token`, `auth`, `private`, `pin`, `pass`, `pwd`) —
+`sortKey`, `pageToken`, `nextPageToken`, `continuationToken`,
+`csrfToken`, `resetToken`, `bypass`, `compass`. The token ones are
+ubiquitous pagination cursors and anti-forgery / reset tokens; masking
+them would break downstream jobs that resume from a logged cursor, so
+`token` (like `key`) never head-matches on its own. `pass` is worse
+still — it is an ordinary English suffix, so head-matching it would
+redact `bypass`, `compass`, `surpass` and `encompass`. Their scalar type
+is preserved, and only the **enumerated** `*Token`/`*Key` secrets (below)
+are masked.
 
-**The bare generic words `key`, `token`, `auth`, `private` and `pin` are
-further restricted to whole-key matching only** (tiers 2 and 3 skip
-them). They are the head of far too many benign compounds (`sortKey`,
-`cacheKey`, `pageToken`, `nextPageToken`, `continuationToken`, `authUrl`,
-`isPrivate`) to head-match safely. A real secret compound that ends in
+**The bare generic words `key`, `token`, `auth`, `private`, `pin`,
+`pass` and `pwd` are further restricted to whole-key matching only**
+(tiers 2 and 3 skip them). They are the head of far too many benign
+compounds (`sortKey`, `cacheKey`, `pageToken`, `nextPageToken`,
+`continuationToken`, `authUrl`, `isPrivate`, `bypass`, `compass`) to
+head-match safely. A real secret compound that ends in
 one of these generic heads is therefore **not** caught by the generic
 word alone — it is caught only when the **specific compound is itself a
 configured field**. The defaults enumerate the common crypto-key and
@@ -188,6 +194,14 @@ component-suffix matching (and their run-together spellings — `authtoken`
 is **not** one of these (e.g. `symmetricKey`, `deployKey`, `webhookKey`,
 `webhookToken`, `pageToken`, `csrfToken`) is intentionally left visible —
 add it to `sensitiveFields` if you need it masked.
+
+The password family works the same way. `password`, `passwd` and
+`passphrase` are long and specific enough to head-match, so
+`db_password`, `userPassword` and the run-together `dbpassword` are all
+caught. The short spellings `pass` and `pwd` are whole-key only, so a
+qualified `db_pass`, `userPwd` or `x-pwd` is **not** masked by the
+defaults — name the exact key in `sensitiveFields`, or prefer the
+unambiguous `dbPassword` over `dbPass` when you choose the key.
 
 #### Limitations (by design)
 
@@ -221,13 +235,23 @@ string `'[Circular]'`. The original log object is never mutated.
 
 ### Default Sensitive Fields
 
-Slogger automatically masks these common fields:
+This is the **canonical list** — the one place in the documentation that
+enumerates the defaults, mirroring `DEFAULT_SENSITIVE_FIELDS` in
+`formatters/maskingFormatter.ts`. Other pages link here rather than
+restate it. Entries marked `whole-key only` match a context key only when
+they are the entire key (see
+[Matching Semantics](#matching-semantics)); every other entry is also
+head-anchored across word components and run-together spellings.
+
+Slogger automatically masks these fields:
 
 ```typescript
 const defaultSensitiveFields = [
   'password',
   'passwd',
   'passphrase',
+  'pass', // whole-key only
+  'pwd', // whole-key only
   'secret',
   'clientSecret',
   'client_secret',
@@ -279,26 +303,39 @@ const defaultSensitiveFields = [
 
 ### Custom Sensitive Fields
 
-Add application-specific sensitive fields:
+> **`sensitiveFields` REPLACES the defaults — it does not extend them.**
+> Passing a short list silently turns off every default not in it, so
+> `ssn`, `cvv`, `apiKey` and the rest would then be logged in cleartext.
+> To keep the defaults, restate the ones you want alongside your own —
+> copy them from
+> [Default Sensitive Fields](#default-sensitive-fields) above.
 
 ```typescript
 import { maskingFormatter } from '@tundralibs/slogger';
 
 maskingFormatter({
   sensitiveFields: [
-    // Default fields (included automatically)
+    // The defaults you want to keep — this list REPLACES them, so
+    // anything omitted here is no longer masked.
     'password',
     'token',
+    'apiKey',
+    'ssn',
+    'cvv',
 
-    // Custom application fields
+    // The application's own fields, on top.
     'internalId',
     'customerKey',
-    'sessionToken',
-    'privateKey',
     'symmetricKey',
+    'db_pass', // qualified `pass`/`pwd` compounds are not defaults
   ],
 });
 ```
+
+The example above masks exactly those ten field names and nothing else.
+If you only need to add a field or two, it is usually safer to leave
+`sensitiveFields` unset and rename the offending context key to one the
+defaults already cover.
 
 ### Nested Field Masking
 

--- a/packages/slogger/formatters/Slogger-Formatters.md
+++ b/packages/slogger/formatters/Slogger-Formatters.md
@@ -369,20 +369,22 @@ interface MaskingFormatterOptions {
 
 ### Default Sensitive Fields
 
-The masking formatter includes common sensitive field names by default:
+When you do not pass `sensitiveFields`, the masking formatter applies a
+built-in list covering the password family (`password`, `passwd`,
+`passphrase`, `pass`, `pwd`), secrets and credentials (`secret`,
+`clientSecret`, `credential`), tokens (`token`, `authToken`,
+`accessToken`, `refreshToken`, …), crypto keys (`apiKey`, `secretKey`,
+`privateKey`, …) and PII/financial fields (`ssn`, `cvv`, `creditCard`,
+`cardNumber`).
 
-- `password`
-- `pass`
-- `pwd`
-- `secret`
-- `apiKey`
-- `api_key`
-- `token`
-- `accessToken`
-- `refreshToken`
-- `creditCard`
-- `ssn`
-- `email` (when PARTIAL)
+**The full list lives in one place:
+[Security → Default Sensitive Fields](../docs/Slogger-Security.md#default-sensitive-fields).**
+It is not repeated here — a list maintained in two documents drifts, and
+a stale copy of a security default is worse than no copy, because it
+tells you a field is redacted when it is not.
+
+Note that `sensitiveFields` **replaces** the defaults rather than adding
+to them; include the defaults you still want.
 
 Matching is **head-anchored** and case-insensitive: a field name masks a
 context key only when it names the key's **end (head)** — via a whole-key
@@ -390,17 +392,22 @@ match, a camelCase / `_`-`-`-`.` word-component suffix, or (for names of 4+
 characters) a concatenation suffix that begins at a word boundary. So
 `apiKey` masks `userApiKey`/`x-api-key`/`apikey` while `sortKey` and
 `creditCardBrand` are left untouched. The bare generic words `token`,
-`key`, `auth`, `private` and `pin` match **only** as a whole key, so
-benign compounds that merely end in one of them — `sortKey`, `pageToken`,
-`nextPageToken`, `continuationToken`, `csrfToken`, `authUrl`, `isPrivate`
-— are left untouched; the real secret `*Token`/`*Key` compounds
-(`authToken`, `accessToken`, `refreshToken`, `sessionToken`, `apiToken`,
-`bearerToken`, `idToken`; `apiKey`, `secretKey`, `privateKey`, …) are
-enumerated as their own default fields instead, and are themselves
-head-anchored (so `authToken` masks `session_auth_token`/`authtoken` but
-`androidToken`/`pageToken` stay visible). See
+`key`, `auth`, `private`, `pin`, `pass` and `pwd` match **only** as a
+whole key, so benign compounds that merely end in one of them —
+`sortKey`, `pageToken`, `nextPageToken`, `continuationToken`, `csrfToken`,
+`authUrl`, `isPrivate`, `bypass`, `compass` — are left untouched; the
+real secret `*Token`/`*Key` compounds (`authToken`, `accessToken`,
+`refreshToken`, `sessionToken`, `apiToken`, `bearerToken`, `idToken`;
+`apiKey`, `secretKey`, `privateKey`, …) are enumerated as their own
+default fields instead, and are themselves head-anchored (so `authToken`
+masks `session_auth_token`/`authtoken` but `androidToken`/`pageToken`
+stay visible). See
 [Security → Matching Semantics](../docs/Slogger-Security.md#matching-semantics)
 for the full contract.
+
+Masking a field name is not the same as masking a value inside the
+message string — an email address in the message text is caught by
+`sensitivePatterns`, not by this list.
 
 ### Custom Patterns
 

--- a/packages/slogger/formatters/maskingFormatter.test.ts
+++ b/packages/slogger/formatters/maskingFormatter.test.ts
@@ -1082,4 +1082,157 @@ describe('slogger.formatters.maskingFormatter', () => {
       asserts.assert(!result.includes('LEAK_X_ID_TOKEN'));
     });
   });
+
+  // ---------------------------------------------------------------
+  // Round-8 (#275): the docs advertised `pass` and `pwd` as masked by
+  // default, but neither was in the defaults — a context of `{ pwd }`
+  // was written verbatim to every destination. Both are now defaults AND
+  // members of the whole-key-only generic set: bare `pass` is 4 chars, so
+  // as an ordinary term the concatenation-suffix tier would have matched
+  // the tail of `bypass`/`compass`/`surpass`/`encompass`.
+  // ---------------------------------------------------------------
+  describe('round-8: `pass` / `pwd` mask as whole keys only', () => {
+    const maskedTo = (parsed: string): boolean => /^\*+$/.test(parsed);
+
+    // The reproduction from the issue: all five password-family spellings
+    // must be redacted, not just the three that already were.
+    it('masks pass and pwd alongside the rest of the password family', () => {
+      const p = JSON.parse(
+        maskingFormatter()(makeLogObject('login', {
+          password: 'A',
+          passwd: 'B',
+          pass: 'C',
+          pwd: 'D',
+          secret: 'E',
+        })),
+      ).context;
+      asserts.assert(maskedTo(p.password), 'password must mask');
+      asserts.assert(maskedTo(p.passwd), 'passwd must mask');
+      asserts.assert(maskedTo(p.pass), 'pass must mask');
+      asserts.assert(maskedTo(p.pwd), 'pwd must mask');
+      asserts.assert(maskedTo(p.secret), 'secret must mask');
+    });
+
+    it('masks pass and pwd case-insensitively', () => {
+      const p = JSON.parse(
+        maskingFormatter()(makeLogObject('case', {
+          PASS: 'CAPS_LEAK',
+          Pwd: 'MIXED_LEAK',
+          PWD: 'CAPS_PWD_LEAK',
+        })),
+      ).context;
+      asserts.assert(maskedTo(p.PASS));
+      asserts.assert(maskedTo(p.Pwd));
+      asserts.assert(maskedTo(p.PWD));
+    });
+
+    // The regression that would make the fix worse than the bug: `pass`
+    // is a real English suffix. None of these may be touched, and their
+    // scalar type must survive intact (no string coercion).
+    it('does NOT mask benign words ending in pass/pwd', () => {
+      const p = JSON.parse(
+        maskingFormatter()(makeLogObject('benign', {
+          passenger: 'plane',
+          bypass: 'route',
+          compass: 'north',
+          passed: true,
+          passive: 'yes',
+          surpass: 'goal',
+          encompass: 'all',
+          overpass: 'bridge',
+          passable: 'yes',
+          passageway: 'hall',
+          cwd: '/srv/app',
+          fwd: 'onward',
+          passCount: 3, // number — must keep its type
+        })),
+      ).context;
+      asserts.assertEquals(p.passenger, 'plane');
+      asserts.assertEquals(p.bypass, 'route');
+      asserts.assertEquals(p.compass, 'north');
+      asserts.assertStrictEquals(p.passed, true);
+      asserts.assertEquals(p.passive, 'yes');
+      asserts.assertEquals(p.surpass, 'goal');
+      asserts.assertEquals(p.encompass, 'all');
+      asserts.assertEquals(p.overpass, 'bridge');
+      asserts.assertEquals(p.passable, 'yes');
+      asserts.assertEquals(p.passageway, 'hall');
+      asserts.assertEquals(p.cwd, '/srv/app');
+      asserts.assertEquals(p.fwd, 'onward');
+      asserts.assertStrictEquals(p.passCount, 3);
+    });
+
+    // Whole-key-only means the component-suffix tier is skipped too, so a
+    // qualified compound stays visible — same contract as `pin`/`key`.
+    // The longer `password`/`passwd` family still head-matches normally.
+    it('leaves qualified pass/pwd compounds to the caller, unlike password', () => {
+      const p = JSON.parse(
+        maskingFormatter()(makeLogObject('compounds', {
+          db_pass: 'DBPASS_VISIBLE',
+          userPwd: 'USERPWD_VISIBLE',
+          db_password: 'DBPW_LEAK',
+          dbpassword: 'CONCAT_LEAK',
+        })),
+      ).context;
+      asserts.assertEquals(p.db_pass, 'DBPASS_VISIBLE');
+      asserts.assertEquals(p.userPwd, 'USERPWD_VISIBLE');
+      asserts.assert(maskedTo(p.db_password), 'db_password must still mask');
+      asserts.assert(maskedTo(p.dbpassword), 'dbpassword must still mask');
+    });
+
+    // A caller naming the compound explicitly gets it masked — the
+    // documented escape hatch for the case above.
+    it('a caller naming the compound explicitly gets it masked', () => {
+      const fmt = maskingFormatter({ sensitiveFields: ['db_pass'] });
+      const p = JSON.parse(fmt(makeLogObject('custom', {
+        db_pass: 'DBPASS_LEAK',
+        compass: 'north',
+      }))).context;
+      asserts.assert(maskedTo(p.db_pass));
+      asserts.assertEquals(p.compass, 'north');
+    });
+
+    // Sibling sweep — the matcher runs before the base formatter, so the
+    // split must hold whichever formatter renders the record.
+    describe('round-8 split holds across all sibling base formatters', () => {
+      const secretVal = 'PWDSECRETLEAKVALUE';
+      const benignMarker = 'COMPASSBENIGNMARKER';
+      const ctx = {
+        pwd: secretVal, // must be masked
+        compass: benignMarker, // must survive
+      };
+      const cases: Array<[string, (log: SlogObject) => string]> = [
+        ['prettyJson (default)', maskingFormatter()],
+        ['json', maskingFormatter({ baseFormatter: jsonFormatter })],
+        ['logfmt', maskingFormatter({ baseFormatter: logfmtFormatter() })],
+        ['otel', maskingFormatter({ baseFormatter: otelLogFormatter() })],
+        [
+          'rfc5424',
+          maskingFormatter({
+            baseFormatter: rfc5424Formatter({
+              appendContext: (c) => JSON.stringify(c),
+            }),
+          }),
+        ],
+        [
+          'string',
+          maskingFormatter({
+            baseFormatter: simpleFormatter(
+              '${context.pwd}|${context.compass}',
+            ),
+          }),
+        ],
+      ];
+      for (const [name, fmt] of cases) {
+        it(`masks pwd and keeps compass under ${name}`, () => {
+          const out = fmt(makeLogObject('nav', { ...ctx }));
+          asserts.assert(!out.includes(secretVal), `pwd leaked under ${name}`);
+          asserts.assert(
+            out.includes(benignMarker),
+            `compass over-masked under ${name}`,
+          );
+        });
+      }
+    });
+  });
 });

--- a/packages/slogger/formatters/maskingFormatter.ts
+++ b/packages/slogger/formatters/maskingFormatter.ts
@@ -45,11 +45,12 @@ export type MaskingFormatterOptions = {
    * a qualifier (`creditCardBrand`, `creditCardLast4`, `tokenBucket`,
    * `nextTokenCount`, `passwordHash`, `secretary`, `tokenizer`) is NOT
    * masked and its scalar type is preserved. The bare generic words
-   * `key`, `token`, `auth`, `private` and `pin` are further restricted
-   * to whole-key matching only — see {@link GENERIC_WHOLE_KEY_ONLY} —
-   * so common benign compounds that merely end in one of them
-   * (`sortKey`, `cacheKey`, `pageToken`, `nextPageToken`,
-   * `continuationToken`, `csrfToken`) are left untouched; the real
+   * `key`, `token`, `auth`, `private`, `pin`, `pass` and `pwd` are
+   * further restricted to whole-key matching only — see
+   * {@link GENERIC_WHOLE_KEY_ONLY} — so common benign compounds that
+   * merely end in one of them (`sortKey`, `cacheKey`, `pageToken`,
+   * `nextPageToken`, `continuationToken`, `csrfToken`, `bypass`,
+   * `compass`) are left untouched; the real
    * secret `*Key`/`*Token` compounds are enumerated as their own default
    * fields instead. Replaces the default list when provided — include
    * the defaults you still want.
@@ -89,14 +90,17 @@ export type MaskingFormatterOptions = {
  * `awsAccessKey`, `x-auth-token`, `session_auth_token` and the
  * run-together `authtoken` are caught by component-/concatenation-suffix
  * matching, while benign cursors such as `pageToken`/`resetToken`/
- * `csrfToken` pass through untouched. The five bare generic words
- * (`auth`, `key`, `token`, `private`, `pin`) match only as a WHOLE key,
- * so they don't swallow `sortKey`/`authUrl`/`isPrivate`/`pageToken`.
+ * `csrfToken` pass through untouched. The seven bare generic words
+ * (`auth`, `key`, `token`, `private`, `pin`, `pass`, `pwd`) match only as
+ * a WHOLE key, so they don't swallow
+ * `sortKey`/`authUrl`/`isPrivate`/`pageToken`/`bypass`/`compass`.
  */
 const DEFAULT_SENSITIVE_FIELDS = [
   'password',
   'passwd',
   'passphrase',
+  'pass',
+  'pwd',
   'secret',
   'clientSecret',
   'client_secret',
@@ -149,20 +153,23 @@ const DEFAULT_SENSITIVE_FIELDS = [
  * Bare generic words that are the head of many unrelated context keys
  * (`sortKey`, `cacheKey`, `partitionKey`, `authUrl`, `authMethod`,
  * `isPrivate`, `privateIp`, `keyMetrics`, `spinner`, `pageToken`,
- * `nextPageToken`, `continuationToken`). Unlike other terms they match
- * ONLY as a whole key — never as a component suffix or concatenation
- * suffix — because even head-anchored matching on them would redact
- * large classes of benign keys and coerce their scalar values
- * (`sortKey`/`cacheKey` all end in the head `key`; `pageToken`,
+ * `nextPageToken`, `continuationToken`, `bypass`, `compass`). Unlike other
+ * terms they match ONLY as a whole key — never as a component suffix or
+ * concatenation suffix — because even head-anchored matching on them
+ * would redact large classes of benign keys and coerce their scalar
+ * values (`sortKey`/`cacheKey` all end in the head `key`; `pageToken`,
  * `nextPageToken`, `continuationToken`, `resetToken`, `csrfToken` all
  * end in the head `token` yet are non-secret pagination cursors /
- * anti-forgery tokens). Real secret compounds ending in one of these
- * generic heads are instead caught by enumerating the specific compound
- * as its own default (`apiKey`, `secretKey`, `accessKey`, …, and the
- * `*Token` secrets `authToken`, `accessToken`, `refreshToken`,
- * `sessionToken`, `apiToken`, `bearerToken`, `idToken`); a caller
- * wanting another (e.g. `symmetricKey`, `deployKey`, `webhookToken`)
- * adds it to `sensitiveFields`.
+ * anti-forgery tokens; `bypass`, `compass`, `surpass` and `encompass`
+ * all end in the run-together head `pass`). Real secret compounds ending
+ * in one of these generic heads are instead caught by enumerating the
+ * specific compound as its own default (`apiKey`, `secretKey`,
+ * `accessKey`, …, the `*Token` secrets `authToken`, `accessToken`,
+ * `refreshToken`, `sessionToken`, `apiToken`, `bearerToken`, `idToken`,
+ * and the password family `password`/`passwd`/`passphrase`, which are
+ * long enough to head-match safely); a caller wanting another (e.g.
+ * `symmetricKey`, `deployKey`, `webhookToken`, `dbPass`) adds it to
+ * `sensitiveFields`.
  */
 const GENERIC_WHOLE_KEY_ONLY: ReadonlySet<string> = new Set([
   'auth',
@@ -170,12 +177,15 @@ const GENERIC_WHOLE_KEY_ONLY: ReadonlySet<string> = new Set([
   'token',
   'private',
   'pin',
+  'pass',
+  'pwd',
 ]);
 
 /**
  * Shortest term eligible for concatenation-suffix matching. Terms of 3
  * characters or fewer (`otp`, `ssn`, `cvv`, `jwt`, and the generic
- * `key`/`pin`) match only as a whole key or a word-component suffix, so
+ * `key`/`pin`/`pwd`) match only as a whole key or a word-component
+ * suffix, so
  * a short term can never align to the tail of an unrelated run-together
  * word (`ssn` at the end of `businessName` — which it isn't).
  */
@@ -496,7 +506,7 @@ function isComponentSuffix(
  *
  * 1. **whole key** — `key` equals a term case-insensitively (every
  *    term, including the bare generic `key`/`token`/`auth`/`private`/
- *    `pin`);
+ *    `pin`/`pass`/`pwd`);
  * 2. **component suffix** — a non-generic term's word components are a
  *    SUFFIX of `key`'s camelCase / separator components (`authToken`
  *    masks `session_auth_token`, `apiKey` masks `userApiKey`/`x-api-key`)
@@ -515,10 +525,12 @@ function isComponentSuffix(
  * match: `creditCardBrand`, `creditCardLast4`, `tokenBucket`,
  * `nextTokenCount`, `passwordHash`, `secretary` and `tokenizer` all pass
  * through with their scalar types intact. And because the bare generic
- * `key`/`token` are whole-key only, benign compounds that merely end in
- * one of them (`sortKey`, `cacheKey`, `pageToken`, `nextPageToken`,
- * `continuationToken`, `resetToken`, `csrfToken`) are left untouched —
- * only the enumerated `*Key`/`*Token` secrets are masked.
+ * `key`/`token`/`pass` are whole-key only, benign compounds that merely
+ * end in one of them (`sortKey`, `cacheKey`, `pageToken`,
+ * `nextPageToken`, `continuationToken`, `resetToken`, `csrfToken`,
+ * `bypass`, `compass`) are left untouched — only the enumerated
+ * `*Key`/`*Token` secrets and the `password`/`passwd`/`passphrase`
+ * family are masked.
  *
  * @param key - The context key.
  * @param matcher - The compiled sensitive-key matcher.
@@ -593,8 +605,9 @@ function maskObject(
     // `authToken`/`userApiKey` and their run-together spellings
     // (`authtoken`) without masking benign qualifier-position keys
     // (`tokenBucket`, `creditCardBrand`, `pageToken`) or letting the bare
-    // generic words `key`/`token`/`auth`/`private`/`pin` over-mask
-    // `sortKey`/`pageToken`/`authUrl`. `forceMask` propagates a sensitive
+    // generic words `key`/`token`/`auth`/`private`/`pin`/`pass`/`pwd`
+    // over-mask `sortKey`/`pageToken`/`authUrl`/`bypass`. `forceMask`
+    // propagates a sensitive
     // ancestor's sensitivity onto every descendant key.
     const isSensitive = forceMask || isSensitiveKey(key, matcher);
 


### PR DESCRIPTION
Closes #275

## The reported bug

`Slogger-Formatters.md` listed `pass` and `pwd` as masked by default. They were not in `DEFAULT_SENSITIVE_FIELDS`, so a developer who logged `{ pwd }` after reading that page had it written verbatim to every destination.

```
before: {"password":"*","passwd":"*","pass":"C","pwd":"D","secret":"*"}
after:  {"password":"*","passwd":"*","pass":"*","pwd":"*","secret":"*"}
```

Both terms were added to `DEFAULT_SENSITIVE_FIELDS` **and** to `GENERIC_WHOLE_KEY_ONLY`. The second placement is load-bearing, not stylistic: verified against a pre-fix build, treating `pass` as an ordinary term also masks `bypass`, `compass`, `surpass`, `encompass` and `overpass`. Whole-key-only is what buys immunity.

Regression coverage confirms 13 benign compounds stay untouched — `passenger`, `bypass`, `compass`, `passed`, `passive`, `surpass`, `encompass`, `overpass`, `passable`, `passageway`, `cwd`, `fwd`, `passCount` — with `passed`/`passCount` keeping their scalar types rather than being coerced.

## A worse bug found while verifying

**`sensitiveFields` replaces the defaults; it does not extend them** — and `Slogger-Security.md`'s own example annotated its first entries as *"Default fields (included automatically)"*. Reproduced on this branch:

```
defaults only : {"myToken":"T","ssn":"***********","apiKey":"*","password":"*"}
custom list   : {"myToken":"*","ssn":"123-45-6789","apiKey":"K","password":"P"}
```

Adding one custom field silently discards all 51 defaults. This is arguably more dangerous than the reported issue, because it misleads precisely the reader who is actively configuring masking. Fixed with a warning and a corrected example.

## Docs reconciled

`docs/Slogger-Security.md` becomes the single authority — it already matched the source exactly (diffed entry by entry, identical in content *and* order) and already carried the matching-semantics contract that Formatters deferred to. Formatters now carries a family-level summary plus a link, deliberately without a term count, since a count drifts too.

Two further mismatches were found beyond `pass`/`pwd`: `email` was listed as masked under PARTIAL (it has never been a default field — emails are redacted in message *text* by a `sensitivePatterns` regex, a different mechanism), so 9 of 12 bullets were accurate rather than 9 of 11.

## Trade-off for reviewers

Masking coerces the value to a `*` string, so a dashboard doing `ctx.pass === true` breaks rather than degrades. The asymmetry still favours masking: over-masking costs one less-useful log line, under-masking leaks a credential permanently to every downstream aggregator. A pass/fail flag is far more often named `passed`, `passing` or `isPass`, none of which match. The escape hatch is `sensitiveFields`.

**Known residual gap, consistent with `pin`:** qualified compounds `db_pass`, `userPwd`, `x-pwd` remain visible. Whole-key-only is exactly what prevents `compass` from matching, so both cannot be had with this algorithm. Documented with the workaround rather than widening the match.

## Verification

22 passed / **364** steps / 0 failed (was 351; +13). `deno check`, `fmt`, `lint` clean. `deno doc --lint` unchanged at 0 missing-jsdoc / 0 missing-explicit-type / 4 private-type-ref. Markdown and JSDoc example checks both 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)