### PR TITLE
fix(compat): path fallback, barrel test leak, and the udpSocket hang on Workers

### DIFF
--- a/packages/cacher/AbstractEngine.test.ts
+++ b/packages/cacher/AbstractEngine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { AbstractEngine } from './AbstractEngine.ts';
 import { CacherEngineError } from './errors/mod.ts';
 import type { CacherOptions, CacheValue } from './types/mod.ts';

--- a/packages/cacher/Cacher.test.ts
+++ b/packages/cacher/Cacher.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Cacher } from './Cacher.ts';
 import { AbstractEngine } from './AbstractEngine.ts';
 import { CacherError } from './errors/mod.ts';

--- a/packages/cacher/engines/memcached/MemCacher.test.ts
+++ b/packages/cacher/engines/memcached/MemCacher.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import type { MemcachedEngine } from '@tundralibs/drivers/memcached';
 import { MemCacher, type MemCacherOptions } from './mod.ts';
 import { CacherEngineError } from '../../errors/mod.ts';

--- a/packages/cacher/engines/memory/MemoryCacher.test.ts
+++ b/packages/cacher/engines/memory/MemoryCacher.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { MemoryCacher } from './mod.ts';
 import { CacherEngineError } from '../../errors/mod.ts';
 

--- a/packages/cacher/engines/redis/RedisCacher.test.ts
+++ b/packages/cacher/engines/redis/RedisCacher.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { afterAll, beforeAll, describe, it } from '@tundralibs/compat';
+import { afterAll, beforeAll, describe, it } from '@tundralibs/compat/test';
 import { RedisCacher, type RedisCacherOptions } from './mod.ts';
 import { CacherEngineError } from '../../errors/mod.ts';
 import { envArgs } from '@tundralibs/utils';

--- a/packages/cacher/errors/Base.test.ts
+++ b/packages/cacher/errors/Base.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { CacherError } from './Base.ts';
 
 /**

--- a/packages/cacher/errors/EngineError.test.ts
+++ b/packages/cacher/errors/EngineError.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { CacherEngineError, type CacherErrorMeta } from './EngineError.ts';
 import {
   type CacherEngineErrorCode,

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -420,7 +420,10 @@ const canWrite = hasPermissionSync({ name: 'write', path: './output' });
 
 ### Test
 
-Cross-runtime testing utilities.
+Cross-runtime testing utilities. Available on the `./test` sub-path only —
+the package root does not re-export them, because the module imports
+`bun:test` and `node:test` and bundlers such as esbuild cannot resolve
+those, which would break every Cloudflare Workers build.
 
 ```typescript
 import { afterEach, beforeEach, describe, it } from '@tundralibs/compat/test';

--- a/packages/compat/docs/Compat-Path.md
+++ b/packages/compat/docs/Compat-Path.md
@@ -18,6 +18,8 @@ Cross-runtime path manipulation utilities with a unified API.
 
 The Path module provides platform-aware path manipulation utilities that work consistently across Windows, macOS, and Linux on all supported runtimes.
 
+Node and Bun delegate to `node:path`; every other runtime — Deno, browsers, Cloudflare Workers — uses `@std/path`, which is pure JavaScript. Path manipulation is therefore string work only and needs no filesystem access, so it stays available in edge and browser bundles.
+
 ### Features
 
 | Feature          | Bun | Deno | Node.js |

--- a/packages/compat/mod.test.ts
+++ b/packages/compat/mod.test.ts
@@ -204,6 +204,74 @@ describe('compat.mod (root barrel)', () => {
 });
 
 // =============================================================================
+// Test helpers stay on the ./test subpath
+// -----------------------------------------------------------------------------
+// `test.ts` imports `bun:test` and `node:test` so it can hand each runtime its
+// native BDD functions. Neither specifier resolves under esbuild, so a barrel
+// that re-exported them failed EVERY wrangler build with "Could not resolve
+// bun:test / node:test" — the whole Worker, not just the test paths. Nothing
+// an application bundles may reach test.ts; consumers import the helpers from
+// `@tundralibs/compat/test`.
+// =============================================================================
+
+/** The BDD surface `test.ts` owns. */
+const TEST_HELPERS = [
+  'afterAll',
+  'afterEach',
+  'beforeAll',
+  'beforeEach',
+  'describe',
+  'it',
+  'test',
+] as const;
+
+describe('compat.mod (test helpers stay on the ./test subpath)', () => {
+  it('the root barrel does not re-export them', () => {
+    const barrel = compat as unknown as Record<string, unknown>;
+    for (const name of TEST_HELPERS) {
+      asserts.assertEquals(
+        barrel[name],
+        undefined,
+        `'${name}' must not be reachable from the package root — it drags bun:test/node:test into every consumer bundle`,
+      );
+    }
+  });
+
+  it('the ./test subpath still exports them', async () => {
+    // Dynamic so this file keeps a single static import of './test.ts'.
+    const testModule = await import('./test.ts') as Record<string, unknown>;
+    for (const name of TEST_HELPERS) {
+      asserts.assertEquals(
+        typeof testModule[name],
+        'function',
+        `'${name}' must stay available on @tundralibs/compat/test`,
+      );
+    }
+  });
+
+  it('no shipped module imports test.ts', () => {
+    // The runtime check above passes for a type-only re-export too, but a
+    // bundler still has to resolve the specifier. Only the absence of the
+    // import keeps the build green, so pin that instead.
+    const offenders = sourceFiles(PACKAGE_DIR)
+      .map((file) => file.slice(PACKAGE_DIR.length + 1))
+      .filter((name) =>
+        name !== 'test.ts' &&
+        /from\s+'[^']*\/test\.ts'/.test(
+          readTextFileSync(join(PACKAGE_DIR, name)),
+        )
+      );
+    asserts.assertEquals(
+      offenders,
+      [],
+      `these modules pull test.ts into the shipped graph and break esbuild: ${
+        offenders.join(', ')
+      }`,
+    );
+  });
+});
+
+// =============================================================================
 // No top-level await
 // -----------------------------------------------------------------------------
 // One top-level await anywhere in a module graph makes esbuild (wrangler)

--- a/packages/compat/mod.ts
+++ b/packages/compat/mod.ts
@@ -8,8 +8,12 @@
  * - Path utilities
  * - Runtime detection
  * - Permissions
- * - Testing framework
  * - Fetch with TLS support
+ *
+ * The test helpers are deliberately NOT re-exported here: `test.ts`
+ * imports `bun:test` and `node:test`, which esbuild and wrangler cannot
+ * resolve, so a barrel that pulls them in fails every Cloudflare Workers
+ * build. Import them from `@tundralibs/compat/test` instead.
  *
  * @module
  *
@@ -222,19 +226,6 @@ export {
   type UpgradeTlsOptions,
 } from './net.ts';
 export { type UdpSocket, udpSocket, type UdpSocketOptions } from './udp.ts';
-export {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  type DescribeOptions,
-  type HookFn,
-  it,
-  type ItOptions,
-  type PermissionOptions,
-  test,
-} from './test.ts';
 export {
   type FsEvent,
   type FsEventKind,

--- a/packages/compat/path.test.ts
+++ b/packages/compat/path.test.ts
@@ -19,7 +19,7 @@ import {
   SEPARATOR,
   SEPARATOR_PATTERN,
 } from './path.ts';
-import { OS } from './runtime.ts';
+import { isDeno, OS } from './runtime.ts';
 import * as asserts from '@std/asserts';
 
 // =============================================================================
@@ -414,5 +414,90 @@ describe({
         asserts.assertStrictEquals(formatted, original);
       });
     });
+
+    // =========================================================================
+    // Unknown runtime (browser / workerd)
+    // =========================================================================
+    // The backend is picked once, at import time. A browser is neither Deno,
+    // Bun nor Node, so the picker has to have a fallback — without one every
+    // helper here threw `Cannot read properties of undefined` on the first
+    // call, which took RESTler (and the drivers riding on it) down with it.
+    //
+    // The flags are module-level constants evaluated at import time, so the
+    // only way to observe that branch is a child process that deletes the
+    // runtime globals *before* importing the module. Deno-gated because it
+    // spawns that child with `Deno.Command`; the branch it covers is
+    // runtime-independent.
+    if (isDeno) {
+      describe('unknown runtime', () => {
+        it('should resolve paths with no Deno, Bun or Node global', async () => {
+          // `fixtures/` is git-ignored and excluded from fmt/lint/test, and
+          // the script has to live inside the package for `@std/path` to
+          // resolve through the workspace import map.
+          const script = `// deno-lint-ignore-file no-explicit-any
+const g = globalThis as any;
+delete g.Deno;
+delete g.process;
+const p = await import('../path.ts');
+console.log(JSON.stringify({
+  runtime: (await import('../runtime.ts')).RUNTIME,
+  join: p.join('a', 'b', 'c.txt'),
+  dirname: p.dirname('/a/b/c'),
+  basename: p.basename('/a/b/c.txt'),
+  extname: p.extname('a.tar.gz'),
+  isAbsolute: p.isAbsolute('/a'),
+  normalize: p.normalize('/a/b/../c'),
+  relative: p.relative('/a/b', '/a/c'),
+  base: p.parse('/a/b/c.txt').base,
+  format: p.format({ dir: '/a', base: 'c.txt' }),
+  resolve: p.resolve('/base', 'sub'),
+}));
+`;
+          const scriptPath = join(
+            import.meta.dirname!,
+            'fixtures',
+            'unknown-runtime-path.ts',
+          );
+          await Deno.writeTextFile(scriptPath, script);
+          let out;
+          try {
+            out = await new Deno.Command(Deno.execPath(), {
+              args: ['run', '--allow-read', scriptPath],
+              stdout: 'piped',
+              stderr: 'piped',
+            }).output();
+          } finally {
+            await Deno.remove(scriptPath);
+          }
+
+          const stderr = new TextDecoder().decode(out.stderr);
+          asserts.assertEquals(
+            out.code,
+            0,
+            `child process failed — path is broken on unknown runtimes:\n${stderr}`,
+          );
+
+          // Windows dev boxes still get `\` here (@std/path sniffs
+          // `navigator.platform`), so compare separator-agnostically.
+          const posix = (s: string) => s.replaceAll('\\', '/');
+          const result = JSON.parse(new TextDecoder().decode(out.stdout));
+          asserts.assertEquals(
+            result.runtime,
+            'UNKNOWN',
+            'the child must actually look like a browser to the detector',
+          );
+          asserts.assertEquals(posix(result.join), 'a/b/c.txt');
+          asserts.assertEquals(posix(result.dirname), '/a/b');
+          asserts.assertEquals(result.basename, 'c.txt');
+          asserts.assertEquals(result.extname, '.gz');
+          asserts.assertEquals(result.isAbsolute, true);
+          asserts.assertEquals(posix(result.normalize), '/a/c');
+          asserts.assertEquals(posix(result.relative), '../c');
+          asserts.assertEquals(result.base, 'c.txt');
+          asserts.assertEquals(posix(result.format), '/a/c.txt');
+          asserts.assertEquals(posix(result.resolve), '/base/sub');
+        });
+      });
+    }
   },
 });

--- a/packages/compat/path.ts
+++ b/packages/compat/path.ts
@@ -1,14 +1,15 @@
 /**
- * @fileoverview Cross-runtime `node:path`-compatible API. On Deno
- * this delegates to `@std/path`; on Node/Bun to `node:path`. Each
- * helper is a pass-through with the same semantics as the underlying
- * implementation, so see the Node docs for behaviour details.
+ * @fileoverview Cross-runtime `node:path`-compatible API. On Node and
+ * Bun this delegates to `node:path`; everywhere else — Deno, browsers,
+ * workerd — to `@std/path`, which is pure JS and needs no host APIs.
+ * Each helper is a pass-through with the same semantics as the
+ * underlying implementation, so see the Node docs for behaviour details.
  *
  * @module
  */
 
 import * as stdPath from '@std/path';
-import { isBun, isDeno, isNode, OS } from './runtime.ts';
+import { isBun, isNode, OS } from './runtime.ts';
 import { loadBuiltin } from './_runtime-globals.ts';
 
 /** PATH-variable separator: `;` on Windows, `:` elsewhere. */
@@ -50,17 +51,18 @@ type NativePath = {
   }): string;
 };
 
-// `@std/path` is pure JS, so a static import is bundler-safe; `node:path`
-// comes through `process.getBuiltinModule` (see {@link loadBuiltin}).
+// `@std/path` is pure JS with no host dependencies, so it is the backend
+// everywhere except Node and Bun — including browsers and workerd, which
+// is what keeps every helper below callable there. Node and Bun use their
+// own `node:path` so results match the rest of the host's file APIs; it
+// comes through `process.getBuiltinModule` (see {@link loadBuiltin}) and
+// falls back to `@std/path` when that hook is missing.
 // Neither may be a top-level `await import()` — one TLA anywhere in a
 // module graph makes esbuild/Rollup lower every initializer in that graph
 // to an async function, which deadlocks legal circular imports downstream.
-let nativePath: NativePath;
-if (isDeno) {
-  nativePath = stdPath as NativePath;
-} else if (isBun || isNode) {
-  nativePath = loadBuiltin('node:path');
-}
+const nativePath: NativePath = isBun || isNode
+  ? loadBuiltin('node:path') ?? stdPath as NativePath
+  : stdPath as NativePath;
 
 /**
  * Last path segment.

--- a/packages/compat/udp.test.ts
+++ b/packages/compat/udp.test.ts
@@ -13,8 +13,8 @@
 
 import { describe, it } from './test.ts';
 import * as asserts from '@std/asserts';
-import { udpSocket } from './udp.ts';
-import { isDeno } from './runtime.ts';
+import { assertDatagramBackend, udpSocket } from './udp.ts';
+import { isDeno, isNode } from './runtime.ts';
 import { join } from './path.ts';
 
 /**
@@ -195,5 +195,41 @@ console.log(JSON.stringify({
         );
       });
     }
+  });
+
+  describe('assertDatagramBackend', () => {
+    // The guard is unreachable on a real Node (>= 22.3 always supplies
+    // node:dgram), so it is exercised through its `candidate` seam. What
+    // it prevents is the hang: without it the Node path builds a socket
+    // on `undefined` and awaits a bind callback that never fires.
+    it('throws when the runtime supplies no datagram backend', () => {
+      for (const absent of [undefined, null]) {
+        asserts.assertThrows(
+          () => assertDatagramBackend(absent),
+          Error,
+          'node:dgram',
+        );
+      }
+    });
+
+    it('accepts a backend that is present', () => {
+      assertDatagramBackend({ createSocket: () => {} });
+    });
+
+    it('defaults to the runtime backend', () => {
+      // `loadBuiltin('node:dgram', isNode)` only resolves on Node, so the
+      // default candidate is the real module there and `undefined` on
+      // Deno and Bun (both have native datagram sockets and never reach
+      // this guard in practice).
+      if (isNode) {
+        assertDatagramBackend();
+      } else {
+        asserts.assertThrows(
+          () => assertDatagramBackend(),
+          Error,
+          'node:dgram',
+        );
+      }
+    });
   });
 });

--- a/packages/compat/udp.test.ts
+++ b/packages/compat/udp.test.ts
@@ -1,7 +1,28 @@
+/**
+ * @fileoverview Tests for the cross-runtime UDP sender.
+ *
+ * Besides the happy path, this pins the failure mode on runtimes without
+ * datagram sockets: `udpSocket()` must REJECT, and reject immediately.
+ * On workerd it used to hang forever — `nodejs_compat` sets
+ * `process.versions.node`, so the Node branch ran and awaited a bind
+ * callback that the runtime's `node:dgram` stand-in never fired. A hang
+ * inside a Worker burns the request with no error to trace it by.
+ *
+ * @module
+ */
+
 import { describe, it } from './test.ts';
 import * as asserts from '@std/asserts';
 import { udpSocket } from './udp.ts';
 import { isDeno } from './runtime.ts';
+import { join } from './path.ts';
+
+/**
+ * How long the child gets before we call it hung. Generous next to an
+ * immediate throw and still far below any suite timeout, so a regression
+ * reports as a failed assertion rather than a stuck run.
+ */
+const HANG_LIMIT_MS = 3000;
 
 describe('compat.udp', () => {
   describe('udpSocket', () => {
@@ -69,6 +90,109 @@ describe('compat.udp', () => {
         } finally {
           receiver.close();
         }
+      });
+
+      // The workerd shape can't be reproduced in-process: `isNode` and the
+      // `node:dgram` handle are both resolved at import time, and this file
+      // has long since imported them. So build the shape in a child —
+      // no `Deno`, a `process` claiming a Node version, and a dgram
+      // stand-in that swallows the bind callback exactly like workerd's —
+      // and watch what `udpSocket()` does. Deno-gated because it spawns
+      // that child with `Deno.Command`.
+      it('rejects immediately on workerd instead of hanging', async () => {
+        const script = `// deno-lint-ignore-file no-explicit-any
+const g = globalThis as any;
+delete g.Deno;
+const stubSocket = {
+  on() {},
+  once() {},
+  removeListener() {},
+  send() {},
+  close() {},
+  bind() {/* never calls back — this is the hang */},
+};
+Object.defineProperty(g, 'process', {
+  value: {
+    versions: { node: '22.11.0' },
+    getBuiltinModule: (id: string) =>
+      id === 'node:dgram' ? { createSocket: () => stubSocket } : undefined,
+  },
+  configurable: true,
+});
+Object.defineProperty(g, 'navigator', {
+  value: { userAgent: 'Cloudflare-Workers' },
+  configurable: true,
+});
+
+const { RUNTIME } = await import('../runtime.ts');
+const { udpSocket } = await import('../udp.ts');
+
+let timer = 0;
+const hung = new Promise((resolve) => {
+  timer = setTimeout(() => resolve('HUNG'), ${HANG_LIMIT_MS});
+});
+const started = Date.now();
+let outcome = '';
+let message = '';
+try {
+  outcome = await Promise.race([
+    udpSocket({ port: 0 }).then(() => 'RESOLVED'),
+    hung,
+  ]) as string;
+} catch (err) {
+  outcome = (err as Error).name;
+  message = (err as Error).message;
+}
+clearTimeout(timer);
+console.log(JSON.stringify({
+  runtime: RUNTIME,
+  outcome,
+  message,
+  elapsed: Date.now() - started,
+}));
+`;
+        // `fixtures/` is git-ignored and excluded from fmt/lint/test.
+        const scriptPath = join(
+          import.meta.dirname!,
+          'fixtures',
+          'workerd-udp.ts',
+        );
+        await Deno.writeTextFile(scriptPath, script);
+        let out;
+        try {
+          out = await new Deno.Command(Deno.execPath(), {
+            args: ['run', '--allow-read', scriptPath],
+            stdout: 'piped',
+            stderr: 'piped',
+          }).output();
+        } finally {
+          await Deno.remove(scriptPath);
+        }
+
+        const stderr = new TextDecoder().decode(out.stderr);
+        asserts.assertEquals(out.code, 0, `child process failed:\n${stderr}`);
+        const result = JSON.parse(new TextDecoder().decode(out.stdout));
+
+        asserts.assertEquals(
+          result.runtime,
+          'NODE',
+          'workerd looks like Node to the detector — that is the trap this guards',
+        );
+        asserts.assertNotEquals(
+          result.outcome,
+          'HUNG',
+          `udpSocket() never settled in ${HANG_LIMIT_MS}ms — a hang is worse than a failure, especially inside a Worker request`,
+        );
+        asserts.assertEquals(
+          result.outcome,
+          'UnsupportedRuntimeError',
+          'an unsupported operation must throw, like connect/server/watch do',
+        );
+        asserts.assertStringIncludes(result.message, 'udpSocket');
+        asserts.assert(
+          result.elapsed < HANG_LIMIT_MS,
+          `the rejection must be immediate, took ${result.elapsed}ms`,
+        );
       });
     }
   });

--- a/packages/compat/udp.test.ts
+++ b/packages/compat/udp.test.ts
@@ -203,7 +203,11 @@ console.log(JSON.stringify({
     // it prevents is the hang: without it the Node path builds a socket
     // on `undefined` and awaits a bind callback that never fires.
     it('throws when the runtime supplies no datagram backend', () => {
-      for (const absent of [undefined, null]) {
+      // NOT `undefined` — that triggers the default parameter and
+      // resolves to the runtime's real module, so the call correctly
+      // does not throw on Node. `null` and the other falsy values are
+      // what an absent backend actually looks like through the seam.
+      for (const absent of [null, false, 0, '']) {
         asserts.assertThrows(
           () => assertDatagramBackend(absent),
           Error,
@@ -214,6 +218,30 @@ console.log(JSON.stringify({
 
     it('accepts a backend that is present', () => {
       assertDatagramBackend({ createSocket: () => {} });
+    });
+
+    it('an explicit undefined falls through to the runtime default', () => {
+      // Default parameters fire on `undefined`, so this is NOT a way to
+      // simulate an absent backend — it asks for the runtime's own. The
+      // outcome therefore has to match the no-argument call exactly.
+      const viaDefault = (() => {
+        try {
+          assertDatagramBackend();
+          return 'ok';
+        } catch {
+          return 'threw';
+        }
+      })();
+      const viaUndefined = (() => {
+        try {
+          assertDatagramBackend(undefined);
+          return 'ok';
+        } catch {
+          return 'threw';
+        }
+      })();
+      asserts.assertEquals(viaUndefined, viaDefault);
+      asserts.assertEquals(viaDefault, isNode ? 'ok' : 'threw');
     });
 
     it('defaults to the runtime backend', () => {

--- a/packages/compat/udp.ts
+++ b/packages/compat/udp.ts
@@ -10,6 +10,10 @@
  * UDP is best-effort: a successful `send` only means the kernel
  * accepted the bytes, not that the datagram was delivered.
  *
+ * Deno, Bun and Node have datagram sockets; browsers and Cloudflare
+ * Workers do not, and there {@link udpSocket} rejects immediately with
+ * an {@link UnsupportedRuntimeError}.
+ *
  * @module
  *
  * @example
@@ -21,7 +25,7 @@
  * sock.close();
  * ```
  */
-import { isBun, isDeno, isNode } from './runtime.ts';
+import { isBun, isDeno, isNode, RUNTIME } from './runtime.ts';
 import { UnsupportedRuntimeError } from './Error.ts';
 import { Bun, loadBuiltin } from './_runtime-globals.ts';
 
@@ -32,6 +36,26 @@ const nodeDgram: typeof import('node:dgram') = loadBuiltin(
   'node:dgram',
   isNode,
 );
+
+/** How workerd identifies itself. Cloudflare's documented detection. */
+const WORKERD_USER_AGENT = 'Cloudflare-Workers';
+
+/**
+ * Whether we are on workerd. `nodejs_compat` gives it
+ * `process.versions.node`, so {@link isNode} is true there and the Node
+ * branch below would be taken — but the `node:dgram` it gets back is a
+ * stand-in that accepts `bind()` and never calls back, so the bind
+ * `await` never settles. Workers have no UDP at all, and a hang is the
+ * worst possible failure inside a request, so this is checked first.
+ *
+ * Deliberately local to this module: the udp backend is the only place
+ * the misclassification bites today, and teaching `getRuntime()` about
+ * workerd would re-route every other module that branches on the
+ * runtime.
+ */
+const onWorkerd = (): boolean =>
+  (globalThis as { navigator?: { userAgent?: string } }).navigator
+    ?.userAgent === WORKERD_USER_AGENT;
 
 /**
  * Open UDP socket abstraction.
@@ -74,6 +98,11 @@ export type UdpSocketOptions = {
  * Open a UDP socket and return a sender-only handle. The local
  * binding (hostname/port) is incidental — most callers just want
  * `udpSocket()` and then `socket.send(...)`.
+ *
+ * @throws {@link UnsupportedRuntimeError} On any runtime without
+ *   datagram sockets — browsers and Cloudflare Workers among them. The
+ *   rejection is immediate; nothing here waits on a socket that cannot
+ *   exist.
  */
 export async function udpSocket(
   options: UdpSocketOptions = {},
@@ -85,6 +114,17 @@ export async function udpSocket(
   const port = options.port ?? 0;
 
   /* c8 ignore start */
+  // Before anything else — see {@link onWorkerd}. workerd passes the
+  // `isNode` test and then swallows the bind callback, so without this
+  // the call never settles and burns the whole request.
+  if (onWorkerd()) {
+    throw new UnsupportedRuntimeError(
+      'udpSocket',
+      RUNTIME,
+      'Cloudflare Workers has no UDP sockets',
+    );
+  }
+
   if (isDeno) {
     const sock = Deno.listenDatagram({
       transport: 'udp',
@@ -150,6 +190,17 @@ export async function udpSocket(
   }
 
   if (isNode) {
+    // No datagram backend means no socket — say so now rather than
+    // awaiting a bind that will never call back. Node < 22.3 has no
+    // `process.getBuiltinModule`, and Node-shaped edge runtimes stub the
+    // module out entirely.
+    if (!nodeDgram) {
+      throw new UnsupportedRuntimeError(
+        'udpSocket',
+        RUNTIME,
+        'node:dgram is unavailable in this runtime',
+      );
+    }
     // Pick the socket family from the bind address: an IPv6 literal
     // (contains ':', e.g. '::') needs 'udp6', else 'udp4'. Hardcoding
     // 'udp4' made the documented '::' IPv6 hostname fail on Node.

--- a/packages/compat/udp.ts
+++ b/packages/compat/udp.ts
@@ -37,6 +37,37 @@ const nodeDgram: typeof import('node:dgram') = loadBuiltin(
   isNode,
 );
 
+/**
+ * Assert the runtime actually provides `node:dgram` before the Node path
+ * tries to use it. Without this the socket is created against `undefined`
+ * and the bind callback never fires, so the promise never settles — a hang
+ * rather than an error.
+ *
+ * Node >= 22.3 always supplies it, so the throw is unreachable on a real
+ * Node; it is Node < 22.3 (no `process.getBuiltinModule`) and Node-shaped
+ * edge runtimes that stub the module out entirely.
+ *
+ * Exported (but not re-exported from the package root, so not public API)
+ * only so the otherwise-unreachable guard is unit-testable via the
+ * `candidate` seam — the same arrangement `@tundralibs/ambient` uses for
+ * {@link https://jsr.io/@tundralibs/ambient | assertAsyncLocalStorage}.
+ *
+ * @internal
+ * @param candidate - The module to validate; defaults to the runtime's.
+ * @throws {UnsupportedRuntimeError} When no datagram backend is available.
+ */
+export function assertDatagramBackend(
+  candidate: unknown = nodeDgram,
+): void {
+  if (!candidate) {
+    throw new UnsupportedRuntimeError(
+      'udpSocket',
+      RUNTIME,
+      'node:dgram is unavailable in this runtime',
+    );
+  }
+}
+
 /** How workerd identifies itself. Cloudflare's documented detection. */
 const WORKERD_USER_AGENT = 'Cloudflare-Workers';
 
@@ -190,17 +221,7 @@ export async function udpSocket(
   }
 
   if (isNode) {
-    // No datagram backend means no socket — say so now rather than
-    // awaiting a bind that will never call back. Node < 22.3 has no
-    // `process.getBuiltinModule`, and Node-shaped edge runtimes stub the
-    // module out entirely.
-    if (!nodeDgram) {
-      throw new UnsupportedRuntimeError(
-        'udpSocket',
-        RUNTIME,
-        'node:dgram is unavailable in this runtime',
-      );
-    }
+    assertDatagramBackend();
     // Pick the socket family from the bind address: an IPv6 literal
     // (contains ':', e.g. '::') needs 'udp6', else 'udp4'. Hardcoding
     // 'udp4' made the documented '::' IPv6 hostname fail on Node.

--- a/packages/crypt/JWT/errors/JWTError.test.ts
+++ b/packages/crypt/JWT/errors/JWTError.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { JWTError, type JWTErrorCode, JWTErrorCodes } from './mod.ts';
 
 describe('crypt.JWT.Error', () => {

--- a/packages/crypt/JWT/issue.test.ts
+++ b/packages/crypt/JWT/issue.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { issueJWT } from './issue.ts';
 import { verifyJWT } from './verify.ts';
 import { JWTError } from './errors/mod.ts';

--- a/packages/crypt/JWT/verify.test.ts
+++ b/packages/crypt/JWT/verify.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { issueJWT } from './issue.ts';
 import { JWTError } from './errors/mod.ts';
 import type { JWTPayload, JWTVerifyOptions } from './types/mod.ts';

--- a/packages/crypt/OTP/HOTP.test.ts
+++ b/packages/crypt/OTP/HOTP.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type DigestAlgorithms, generateHOTP, verifyHOTP } from './mod.ts';
 
 describe('crypt.HOTP', () => {

--- a/packages/crypt/OTP/TOTP.test.ts
+++ b/packages/crypt/OTP/TOTP.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type DigestAlgorithms, generateTOTP, verifyTOTP } from './mod.ts';
 
 describe('crypt.TOTP', () => {

--- a/packages/crypt/OTP/common.test.ts
+++ b/packages/crypt/OTP/common.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   constantTimeEqual,
   generate,

--- a/packages/crypt/OTP/otpauth.test.ts
+++ b/packages/crypt/OTP/otpauth.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   type DigestAlgorithms,
   generateHOTP,

--- a/packages/crypt/digest/digest.test.ts
+++ b/packages/crypt/digest/digest.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects } from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   digest,
   type DigestAlgorithms,

--- a/packages/crypt/generators/bip39.test.ts
+++ b/packages/crypt/generators/bip39.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertRejects } from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   BIP39_ENGLISH_WORDLIST,
   generate12WordSeed,

--- a/packages/crypt/generators/key.test.ts
+++ b/packages/crypt/generators/key.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertRejects } from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   generateECDHKeys,
   generateECDSAKeys,

--- a/packages/crypt/generators/random.test.ts
+++ b/packages/crypt/generators/random.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertThrows } from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { randomFloat, randomInt, randomNumber } from './random.ts';
 
 describe('crypt.random', () => {

--- a/packages/crypt/generators/secret.test.ts
+++ b/packages/crypt/generators/secret.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertMatch, assertThrows } from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   generateAlphanumericSecret,
   generateBase32Secret,

--- a/packages/crypt/sign/asn1.test.ts
+++ b/packages/crypt/sign/asn1.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { describeDerKey, sec1ToPkcs8 } from './asn1.ts';
 import { pemToDer } from './keys.ts';
 

--- a/packages/crypt/sign/keys.test.ts
+++ b/packages/crypt/sign/keys.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { describeKey, importSigningKey, resolveECCurve } from './keys.ts';
 import { generateECKeyPair, generateRSAKeyPair } from '../generators/key.ts';
 

--- a/packages/crypt/sign/sign.test.ts
+++ b/packages/crypt/sign/sign.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { signEC, signHMAC, signRSA } from './mod.ts';
 
 describe('crypt.sign', () => {

--- a/packages/crypt/sign/verify.test.ts
+++ b/packages/crypt/sign/verify.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   signEC,
   signHMAC,

--- a/packages/drivers/BaseEngine.test.ts
+++ b/packages/drivers/BaseEngine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { BaseEngine } from './BaseEngine.ts';
 import type { EngineCapabilities, EngineOptions } from './types/mod.ts';
 import { EngineError } from './errors/mod.ts';

--- a/packages/drivers/ConnectionEngine.test.ts
+++ b/packages/drivers/ConnectionEngine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { PooledConnectionEngine } from './ConnectionEngine.ts';
 import type { EngineCapabilities } from './types/mod.ts';
 import { EngineError } from './errors/mod.ts';

--- a/packages/drivers/ConnectionPool.test.ts
+++ b/packages/drivers/ConnectionPool.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   ConnectionPool,
   type ConnectionPoolOptions,

--- a/packages/drivers/SQLConnectionEngine.test.ts
+++ b/packages/drivers/SQLConnectionEngine.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { AbstractTranslator } from '@tundralibs/oql/translator';
 import type {
   AggregateMap,

--- a/packages/drivers/SQLEngine.test.ts
+++ b/packages/drivers/SQLEngine.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { AbstractTranslator } from '@tundralibs/oql/translator';
 import type {
   AggregateMap,

--- a/packages/drivers/SQLEngineLifecycle.test.ts
+++ b/packages/drivers/SQLEngineLifecycle.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import type { AbstractTranslator } from '@tundralibs/oql/translator';
 import { SQLEngine } from './SQLEngine.ts';
 import { EngineError } from './errors/mod.ts';

--- a/packages/drivers/engines/aliases.test.ts
+++ b/packages/drivers/engines/aliases.test.ts
@@ -7,7 +7,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   AlloyDBEngine,
   CitusEngine,

--- a/packages/drivers/engines/maria/Engine.test.ts
+++ b/packages/drivers/engines/maria/Engine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { envArgs } from '@tundralibs/utils';
 import { MariaEngine } from './Engine.ts';
 import { EngineError } from '../../errors/mod.ts';

--- a/packages/drivers/engines/memcached/Engine.test.ts
+++ b/packages/drivers/engines/memcached/Engine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import type { Connection } from '@tundralibs/compat';
 import { envArgs } from '@tundralibs/utils';
 import { MemcachedEngine } from './Engine.ts';

--- a/packages/drivers/engines/mongo/Engine.test.ts
+++ b/packages/drivers/engines/mongo/Engine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { envArgs } from '@tundralibs/utils';
 import { MongoEngine } from './Engine.ts';
 import { EngineError } from '../../errors/mod.ts';

--- a/packages/drivers/engines/postgres/Engine.test.ts
+++ b/packages/drivers/engines/postgres/Engine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { envArgs } from '@tundralibs/utils';
 import { PostgresEngine } from './Engine.ts';
 import { PgServerError } from './PgServerError.ts';

--- a/packages/drivers/engines/postgres/PgConnection.test.ts
+++ b/packages/drivers/engines/postgres/PgConnection.test.ts
@@ -11,7 +11,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import type { Connection } from '@tundralibs/compat';
 import { PgConnection } from './PgConnection.ts';
 import { EngineError } from '../../errors/mod.ts';

--- a/packages/drivers/engines/postgres/auth.test.ts
+++ b/packages/drivers/engines/postgres/auth.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   scramClientFinal,
   type ScramContext,

--- a/packages/drivers/engines/postgres/binary.test.ts
+++ b/packages/drivers/engines/postgres/binary.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { encodeParam, OID } from './binary.ts';
 import { EngineError } from '../../errors/mod.ts';
 

--- a/packages/drivers/engines/postgres/saslprep.test.ts
+++ b/packages/drivers/engines/postgres/saslprep.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { DriverError } from '../../errors/mod.ts';
 import { saslPrep } from './saslprep.ts';
 

--- a/packages/drivers/engines/postgres/values.test.ts
+++ b/packages/drivers/engines/postgres/values.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { decodeTextValue } from './values.ts';
 
 // OID constants used below (pg_type.oid).

--- a/packages/drivers/engines/redis/Engine.test.ts
+++ b/packages/drivers/engines/redis/Engine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { envArgs } from '@tundralibs/utils';
 import { RedisEngine } from './Engine.ts';
 import { RespError, type RespValue } from './resp.ts';

--- a/packages/drivers/engines/sqlite/Engine.test.ts
+++ b/packages/drivers/engines/sqlite/Engine.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   makeDir,
   makeTempDir,

--- a/packages/drivers/errors/Base.test.ts
+++ b/packages/drivers/errors/Base.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { DriverError } from './Base.ts';
 
 // =============================================================================

--- a/packages/drivers/errors/EngineError.test.ts
+++ b/packages/drivers/errors/EngineError.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { EngineError, type EngineErrorMeta } from './EngineError.ts';
 import { type EngineErrorCode, EngineErrorCodes } from './EngineErrorCodes.ts';
 

--- a/packages/drivers/errors/EngineErrorCodes.test.ts
+++ b/packages/drivers/errors/EngineErrorCodes.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type EngineErrorCode, EngineErrorCodes } from './EngineErrorCodes.ts';
 
 // =============================================================================

--- a/packages/guardian/tests/BaseGuardian.test.ts
+++ b/packages/guardian/tests/BaseGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../Guardian.ts';
 import { StringGuardian } from '../guards/StringGuardian.ts';
 import { NumberGuardian } from '../guards/NumberGuardian.ts';

--- a/packages/guardian/tests/Guardian.test.ts
+++ b/packages/guardian/tests/Guardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../Guardian.ts';
 import { GuardianError } from '../errors/Base.ts';
 

--- a/packages/guardian/tests/GuardianError.test.ts
+++ b/packages/guardian/tests/GuardianError.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { GuardianError } from '../errors/Base.ts';
 import type { GuardianErrorMeta } from '../types/mod.ts';
 

--- a/packages/guardian/tests/guardian-zod-comparison.test.ts
+++ b/packages/guardian/tests/guardian-zod-comparison.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { assertEquals, assertThrows } from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../mod.ts';
 
 // Dynamic import of zod with fallback

--- a/packages/guardian/tests/guards/ArrayGuardian.test.ts
+++ b/packages/guardian/tests/guards/ArrayGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../../Guardian.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/guards/BigIntGuardian.test.ts
+++ b/packages/guardian/tests/guards/BigIntGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { BigIntGuardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.BigIntGuardian', () => {

--- a/packages/guardian/tests/guards/BooleanGuardian.test.ts
+++ b/packages/guardian/tests/guards/BooleanGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { BooleanGuardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.BooleanGuardian', () => {

--- a/packages/guardian/tests/guards/DateGuardian.test.ts
+++ b/packages/guardian/tests/guards/DateGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { DateGuardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.DateGuardian', () => {

--- a/packages/guardian/tests/guards/DiscriminatedUnionGuardian.test.ts
+++ b/packages/guardian/tests/guards/DiscriminatedUnionGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   DiscriminatedUnionGuardian,
   Guardian,

--- a/packages/guardian/tests/guards/EnumGuardian.test.ts
+++ b/packages/guardian/tests/guards/EnumGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { EnumGuardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.EnumGuardian', () => {

--- a/packages/guardian/tests/guards/LazyGuardian.test.ts
+++ b/packages/guardian/tests/guards/LazyGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type BaseGuardian, Guardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.LazyGuardian', () => {

--- a/packages/guardian/tests/guards/MapGuardian.test.ts
+++ b/packages/guardian/tests/guards/MapGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.MapGuardian', () => {

--- a/packages/guardian/tests/guards/NumberGuardian.test.ts
+++ b/packages/guardian/tests/guards/NumberGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { GuardianError, NumberGuardian } from '../../mod.ts';
 
 describe('guardian.NumberGuardian', () => {

--- a/packages/guardian/tests/guards/ObjectGuardian.test.ts
+++ b/packages/guardian/tests/guards/ObjectGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../../Guardian.ts';
 import {
   BooleanGuardian,

--- a/packages/guardian/tests/guards/RecordGuardian.test.ts
+++ b/packages/guardian/tests/guards/RecordGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   BooleanGuardian,
   GuardianError,

--- a/packages/guardian/tests/guards/SetGuardian.test.ts
+++ b/packages/guardian/tests/guards/SetGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian, GuardianError } from '../../mod.ts';
 
 describe('guardian.SetGuardian', () => {

--- a/packages/guardian/tests/guards/StringGuardian.test.ts
+++ b/packages/guardian/tests/guards/StringGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { GuardianError, StringGuardian } from '../../mod.ts';
 
 describe('guardian.StringGuardian', () => {

--- a/packages/guardian/tests/guards/TupleGuardian.test.ts
+++ b/packages/guardian/tests/guards/TupleGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian, GuardianError, TupleGuardian } from '../../mod.ts';
 
 describe('guardian.TupleGuardian', () => {

--- a/packages/guardian/tests/guards/UnknownGuardian.test.ts
+++ b/packages/guardian/tests/guards/UnknownGuardian.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { UnknownGuardian } from '../../guards/UnknownGuardian.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/equals.test.ts
+++ b/packages/guardian/tests/helpers/equals.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { equals } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/getType.test.ts
+++ b/packages/guardian/tests/helpers/getType.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 
 import { getType } from '../../helpers/mod.ts';
 

--- a/packages/guardian/tests/helpers/isIn.test.ts
+++ b/packages/guardian/tests/helpers/isIn.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { isIn } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/isNotIn.test.ts
+++ b/packages/guardian/tests/helpers/isNotIn.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { isNotIn } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/isPromiseLike.test.ts
+++ b/packages/guardian/tests/helpers/isPromiseLike.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { isPromiseLike } from '../../helpers/mod.ts';
 
 /**

--- a/packages/guardian/tests/helpers/notEquals.test.ts
+++ b/packages/guardian/tests/helpers/notEquals.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { notEquals } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/nullable.test.ts
+++ b/packages/guardian/tests/helpers/nullable.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { nullable } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/optional.test.ts
+++ b/packages/guardian/tests/helpers/optional.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { optional } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/helpers/test.test.ts
+++ b/packages/guardian/tests/helpers/test.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { test } from '../../helpers/mod.ts';
 import { GuardianError } from '../../errors/Base.ts';
 

--- a/packages/guardian/tests/markdown.test.ts
+++ b/packages/guardian/tests/markdown.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../mod.ts';
 
 describe('guardian.Markdown', () => {

--- a/packages/guardian/tests/nestedAsyncValidation.test.ts
+++ b/packages/guardian/tests/nestedAsyncValidation.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../Guardian.ts';
 import { GuardianError } from '../mod.ts';
 

--- a/packages/guardian/tests/openapi.test.ts
+++ b/packages/guardian/tests/openapi.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../mod.ts';
 
 describe('guardian.OpenAPI', () => {

--- a/packages/guardian/tests/round3-review.test.ts
+++ b/packages/guardian/tests/round3-review.test.ts
@@ -6,7 +6,7 @@
  * whole review can be re-verified in one run.
  */
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian, GuardianError } from '../mod.ts';
 
 describe('guardian.round-3 review regressions', () => {

--- a/packages/guardian/tests/round4-review.test.ts
+++ b/packages/guardian/tests/round4-review.test.ts
@@ -10,7 +10,7 @@
  * Each test is RED on the pre-fix source and GREEN after the fix.
  */
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type BaseGuardian, Guardian, GuardianError } from '../mod.ts';
 
 describe('guardian.round-4 review regressions', () => {

--- a/packages/guardian/tests/round5-review.test.ts
+++ b/packages/guardian/tests/round5-review.test.ts
@@ -17,7 +17,7 @@
  * uniform across sync AND async chains.
  */
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian, GuardianError } from '../mod.ts';
 
 describe('guardian.round-5 review regressions', () => {

--- a/packages/guardian/tests/round6-review.test.ts
+++ b/packages/guardian/tests/round6-review.test.ts
@@ -27,7 +27,7 @@
  * point.
  */
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian, GuardianError } from '../mod.ts';
 
 // A thenable-shaped value: an object with a callable `then`. Promise

--- a/packages/guardian/tests/round7-review.test.ts
+++ b/packages/guardian/tests/round7-review.test.ts
@@ -41,7 +41,7 @@
  * adoption idiom itself rather than an upstream gate.
  */
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   ArrayGuardian,
   BaseGuardian,

--- a/packages/guardian/tests/toJSONSchema.test.ts
+++ b/packages/guardian/tests/toJSONSchema.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Guardian } from '../mod.ts';
 
 const DRAFT = 'https://json-schema.org/draft/2020-12/schema';

--- a/packages/guardian/types/Brand.test.ts
+++ b/packages/guardian/types/Brand.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type Brand } from './Brand.ts';
 import { Guardian } from '../Guardian.ts';
 

--- a/packages/oql/asserts/query/DDL/common.test.ts
+++ b/packages/oql/asserts/query/DDL/common.test.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import * as asserts from '@std/asserts';
 import {
   validateColumnDefinition,

--- a/packages/oql/asserts/query/DML/common.test.ts
+++ b/packages/oql/asserts/query/DML/common.test.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import * as asserts from '@std/asserts';
 import { validateDataEntry, validateExpressions } from './common.ts';
 

--- a/packages/pact/PACT.test.ts
+++ b/packages/pact/PACT.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { generateRSAKeyPair } from '@tundralibs/crypt';
 import { issueJWT } from '@tundralibs/crypt/JWT';
 import { PACT } from './PACT.ts';

--- a/packages/pact/Permissions.test.ts
+++ b/packages/pact/Permissions.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Permissions } from './Permissions.ts';
 import { PactDefinitionError, PactDeniedError } from './errors/mod.ts';
 

--- a/packages/pact/oauth/IdTokenVerifier.test.ts
+++ b/packages/pact/oauth/IdTokenVerifier.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { IdTokenVerifier } from './IdTokenVerifier.ts';
 import { PactOAuthError } from '../errors/mod.ts';
 

--- a/packages/utils/BaseError.test.ts
+++ b/packages/utils/BaseError.test.ts
@@ -1,7 +1,6 @@
 import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
 import {
-  describe,
-  it,
   makeTempDirSync,
   removeSync,
   writeTextFileSync,

--- a/packages/utils/Config.test.ts
+++ b/packages/utils/Config.test.ts
@@ -1,9 +1,8 @@
 import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
 import {
-  describe,
   FileAccessDenied,
   FileNotFound,
-  it,
   makeDir,
   remove,
   writeTextFile,

--- a/packages/utils/Events.test.ts
+++ b/packages/utils/Events.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type EventCallback, Events } from './Events.ts';
 
 /** Test harness: re-exposes the protected emission surface. */

--- a/packages/utils/Options.test.ts
+++ b/packages/utils/Options.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { type EventOptionKeys, Options } from './Options.ts';
 import type { EventCallback } from './Events.ts';
 

--- a/packages/utils/envArgs.test.ts
+++ b/packages/utils/envArgs.test.ts
@@ -1,11 +1,10 @@
 import * as asserts from '@std/asserts';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   cwd,
-  describe,
   isBun,
   isDeno,
   isNode,
-  it,
   makeDirSync,
   removeSync,
   writeTextFileSync,

--- a/packages/utils/ipUtils.test.ts
+++ b/packages/utils/ipUtils.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   expandIPv6,
   ipv4ToBinary,

--- a/packages/utils/isInSubnet.test.ts
+++ b/packages/utils/isInSubnet.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { isInSubnet } from './isInSubnet.ts';
 
 describe('utils.isInSubnet', () => {

--- a/packages/utils/isPublicIP.test.ts
+++ b/packages/utils/isPublicIP.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { isPublicIP } from './isPublicIP.ts';
 
 describe('utils.isPublicIP', () => {

--- a/packages/utils/memoize.test.ts
+++ b/packages/utils/memoize.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Memoize, memoize } from './memoize.ts';
 
 describe('utils.memoize', () => {

--- a/packages/utils/mod.test.ts
+++ b/packages/utils/mod.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 // Import the decorators from the package's PUBLIC entry point (mod.ts) — the
 // exact surface consumers get as `@tundralibs/utils`. If the decorators stop
 // being re-exported here, every documented decorator import

--- a/packages/utils/once.test.ts
+++ b/packages/utils/once.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Once, once } from './once.ts';
 
 describe('utils.once', () => {

--- a/packages/utils/privateObject.test.ts
+++ b/packages/utils/privateObject.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { privateObject } from './privateObject.ts';
 import type { PrivateObject } from './privateObject.ts';
 

--- a/packages/utils/singleton.test.ts
+++ b/packages/utils/singleton.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Singleton } from './singleton.ts';
 
 describe('utils.singleton', () => {

--- a/packages/utils/syslog.test.ts
+++ b/packages/utils/syslog.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import {
   parse,
   stringify,

--- a/packages/utils/templatize.test.ts
+++ b/packages/utils/templatize.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { templatize } from './templatize.ts';
 
 describe('utils.templatize', () => {

--- a/packages/utils/throttle.test.ts
+++ b/packages/utils/throttle.test.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { Throttle, throttle } from './throttle.ts';
 
 describe('utils.throttle', () => {

--- a/packages/utils/variableReplacer.test.ts
+++ b/packages/utils/variableReplacer.test.ts
@@ -1,5 +1,5 @@
 import * as asserts from '@std/asserts';
-import { describe, it } from '@tundralibs/compat';
+import { describe, it } from '@tundralibs/compat/test';
 import { variableReplacer } from './variableReplacer.ts';
 
 describe('utils.variableReplacer', () => {


### PR DESCRIPTION
Closes #276
Closes #278
Closes #279

Three related bugs found by testing the published tarballs on Cloudflare Workers and in a browser. One commit each.

---

## #276 — every `compat/path` function threw in a browser

`path.ts` assigned `nativePath` only for Deno / Bun / Node, so in any UNKNOWN runtime it stayed `undefined` and every export threw. Now: `node:path` on Node/Bun (falling back to `@std/path` if `process.getBuiltinModule` is absent), `@std/path` everywhere else. No new dependency, no dynamic import, and the no-top-level-await scanner still passes — that constraint matters here, since one TLA in this graph deadlocks legal circular imports downstream.

Verified in a child process with `Deno` and `process` deleted (`RUNTIME === 'UNKNOWN'`):
- before — `TypeError: Cannot read properties of undefined (reading 'join')`, the reported error verbatim
- after — `join`, `dirname`, `basename`, `extname`, `isAbsolute`, `normalize`, `relative`, `parse`, `format`, `resolve` all correct

**Blast radius:** in the same environment, importing `RESTler.ts` and running the exact failing call at `RESTler.ts:1214` went from that TypeError to a correct `/v1/users/42`. That is what unblocks `drivers/d1`, `/neon` and `/turso` in browsers.

## #278 — the barrel broke every Workers build

`mod.ts` re-exported `./test.ts`, which imports `bun:test` / `node:test`. esbuild cannot resolve them, so the whole Worker build failed. rolldown tolerates it, which is why this survived browser testing.

Confirmed fixed at the graph level: `compat/test.ts` is no longer reachable from the barrel, and no `bun:test` / `node:test` appears anywhere in it.

**This is a breaking change.** It removes `afterAll, afterEach, beforeAll, beforeEach, describe, it, test` and the types `DescribeOptions, HookFn, ItOptions, PermissionOptions` from the package root. The `./test` subpath already existed in both `deno.json` and `package.json`, so migration is a one-line specifier change.

The commit body describes this in prose but deliberately uses **neither** `feat!` nor a `BREAKING CHANGE:` footer, because either would make release-please cut **compat 2.0.0**. That is a release decision, not a code one — retitle or add the footer before merging if you want the major.

104 in-repo call sites updated, all `.test.ts`, no source or docs: guardian 38, drivers 21, utils 17, crypt 16, cacher 7, pact 3, oql 2. Three mixed imports were split. A repo-wide re-scan finds zero remaining barrel imports of test helpers.

## #279 — `udpSocket()` hung forever on Workers

**Diagnosis, now confirmed on real workerd** (wrangler 4.123.0 / workerd 1.20260811.1, compat date 2026-08-04, `nodejs_compat`):

```json
{"navigator_userAgent":"Cloudflare-Workers","process_versions_node":"22.19.0","hasDeno":false,"hasBun":false}
```

`nodejs_compat` supplies `process.versions.node`, so `isNode` is true and `getRuntime()` returns `NODE`. udp took the Node branch and awaited a `bind()` callback from a `node:dgram` stand-in that never fires it and never emits `error` — so the promise never settled.

**The fix is local to `udp.ts`.** A module-private `onWorkerd()` reads `navigator.userAgent === 'Cloudflare-Workers'` — verified present above — and throws `UnsupportedRuntimeError` before any branch. The Node branch also now refuses up front if `nodeDgram` never resolved, so a missing `getBuiltinModule` gives a proper error instead of a TypeError.

**Runtime detection is untouched; blast radius outside `udp.ts` is zero.** Adding `WORKERD` to `Runtime` or an `isWorkerd` flag was deliberately avoided: it would flip the branch every other module takes on workerd (file, net, watch, webserver, cli) from "works via nodejs_compat" to throw/fallback, and would widen an exported union. That is a design decision, not something a UDP fix should do as a side effect — the seam is one const if wanted later.

**Related hangs, reported not fixed** (same simulation, not observed on workerd): `watch()` hangs at *iteration* rather than at the call — an event stream that can never fire, a different shape; `file.readTextFile`/`stat`/`pathExists` hang while `writeTextFile` throws; `net.connect()` hangs with the same `await new Promise` shape as udp. None is the same line, so none was touched. Which of these actually hangs on real workerd depends on whether it returns a stub or nothing for `node:fs`/`node:net`.

---

## Verification

35 passed / 1027 steps / 0 failed / 1 ignored (baseline 34/1021). `deno check`, `fmt --check`, `lint` clean. `deno doc --lint` unchanged at 0 missing-jsdoc / 0 missing-explicit-type / 5 private-type-ref. Dependents `utils`, `restler`, `rpc`, `slogger` all type-check. `bun test` and `node --test` pass on the touched files. `deno publish --dry-run` succeeds.

**Each new test fails against the pre-fix code** — path with the original TypeError, barrel with two assertions, udp with `HUNG` after 3000 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)