### PR TITLE
docs(norm): document the server-only barrel and the edge-safe core entry point

### DIFF
--- a/packages/norm/README.md
+++ b/packages/norm/README.md
@@ -35,55 +35,13 @@ dialects are exercised end-to-end by the live test suite.
 
 | Module                          | Import                               | Description                                                                                                |
 | ------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| Root                            | `@tundralibs/norm`                   | `Norm`, `NormDb`, repos, `Column`, `Entity`, `Schema`, `use` — plus every dialect.                         |
+| Root                            | `@tundralibs/norm`                   | `Norm`, `NormDb`, repos, `Column`, `Entity`, `Schema`, `use` — plus every dialect. Server-only.            |
 | [Core](core.ts)                 | `@tundralibs/norm/core`              | The same surface with NO dialect registered — the edge/serverless entry point.                             |
 | [Definition](definition/mod.ts) | `@tundralibs/norm/definition`        | Builders, entity/schema types, doc + snapshot emitters.                                                    |
 | [Migrations](migrations/mod.ts) | `@tundralibs/norm/migrations`        | The `Migrator` — snapshot / plan / apply / rollback.                                                       |
 | [Asserts](asserts/mod.ts)       | `@tundralibs/norm/asserts`           | Validate hand-built definitions with the same rules `Entity()` uses.                                       |
 | [Engines](engines/mod.ts)       | `@tundralibs/norm/engines`           | `registerEngine` / `resolveEngineFactory` — the dialect registry.                                          |
 | Engine (one per dialect)        | `@tundralibs/norm/engines/<dialect>` | Side-effect module registering one dialect: `postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`, `d1`. |
-
-### Running on the edge
-
-`@tundralibs/norm` (the root barrel) registers all seven dialects, so
-any `database` config works with no extra import. The cost is that every
-driver — including the **native** SQLite adapter — is in the bundle, and
-its `bun:sqlite` / `@db/sqlite` specifiers cannot be resolved by an edge
-bundler.
-
-On Cloudflare Workers, Vercel Edge, or Vite, import `@tundralibs/norm/core`
-(identical exports, zero dialects registered) plus the one engine module
-you need:
-
-```typescript
-import '@tundralibs/norm/engines/d1'; // or /neon, or /turso
-import { Column, Entity, Norm, Schema } from '@tundralibs/norm/core';
-
-declare const env: Record<string, string>; // the Worker's bindings
-
-const norm = new Norm({
-  database: {
-    dialect: 'd1',
-    accountId: env.CF_ACCOUNT_ID,
-    databaseId: env.D1_DATABASE_ID,
-    apiToken: env.CF_API_TOKEN,
-  },
-});
-```
-
-A dialect whose module was never imported throws a `NormError`
-(`ENGINE_NOT_REGISTERED`) at construction, naming the import to add.
-That matters most for `sqlite`: Cloudflare's `unenv` polyfill _resolves_
-`node:sqlite` and even exposes `DatabaseSync`, but constructing one
-throws `Illegal constructor` on workerd — so without the registry a
-native-SQLite build would sail through CI and fail in production. Native
-SQLite cannot work on Workers at all; `d1` and `turso` (both SQLite over
-HTTP) are the supported paths, and `neon` is the Postgres one.
-
-The edge engines are one-shot HTTP: no pooling and no transactions, which
-`executor.capabilities` reports honestly. They reuse the same OQL
-translators as their self-hosted counterparts (`neon` → Postgres,
-`turso` / `d1` → SQLite), so the SQL norm generates is unchanged.
 
 ## Installation
 
@@ -104,6 +62,51 @@ bunx jsr add @tundralibs/norm
 ```bash
 npx jsr add @tundralibs/norm
 ```
+
+## Choosing an entry point
+
+**`@tundralibs/norm` — server (Deno, Bun, Node).** The root barrel
+registers all seven dialects, so any `database` config constructs with
+no extra import. The price is that it pulls the **native** SQLite
+adapter, whose per-runtime bindings no edge bundler can resolve: the
+barrel cannot be built for Cloudflare Workers or a browser.
+
+```typescript
+import { Norm } from '@tundralibs/norm';
+
+const norm = new Norm({
+  database: { dialect: 'sqlite', path: './data' },
+  secret: process.env.SECRET,
+});
+```
+
+**`@tundralibs/norm/core` — edge/serverless.** Identical exports with
+nothing registered; you import the one engine you need and no other
+driver enters the bundle. `core` + `engines/d1` is verified running on
+workerd.
+
+```typescript
+import '@tundralibs/norm/engines/d1'; // or /neon, or /turso
+import { Norm } from '@tundralibs/norm/core';
+
+declare const env: Record<string, string>; // the Worker's bindings
+
+const norm = new Norm({
+  database: {
+    dialect: 'd1',
+    accountId: env.CF_ACCOUNT_ID,
+    databaseId: env.D1_DATABASE_ID,
+    apiToken: env.CF_API_TOKEN,
+  },
+});
+```
+
+Only `neon` (Postgres over HTTP) and `turso` / `d1` (SQLite over HTTP)
+run on an edge runtime, and they are one-shot fetch calls — no pooling,
+no transactions, as `executor.capabilities` reports. A dialect whose
+module was never imported throws `ENGINE_NOT_REGISTERED` at
+construction, naming the import to add; the registry behind all of this
+is documented in [`engines/registry.ts`](engines/registry.ts).
 
 ## Quick Start
 

--- a/packages/norm/core.ts
+++ b/packages/norm/core.ts
@@ -2,18 +2,14 @@
  * `@tundralibs/norm/core` — norm's ENTIRE surface (definition layer +
  * runtime), with NO engine registered.
  *
- * Identical to the root `@tundralibs/norm` barrel except for one thing:
- * the root barrel also imports all seven `engines/<dialect>` modules, so
- * `new Norm({ database: { dialect } })` works out of the box for every
- * dialect — and, as a consequence, every driver (including the native
- * SQLite adapter and its `bun:sqlite` / `@db/sqlite` specifiers) is in
- * the bundle. That is fine on a server and fatal on an edge runtime.
- *
- * Import from here on Cloudflare Workers / Vercel Edge / Vite, and add
- * only the engine you actually use:
+ * Exports exactly what the root `@tundralibs/norm` barrel exports, minus
+ * that barrel's seven side-effect engine imports — so no driver reaches
+ * the bundle but the one you register yourself. That makes this the
+ * entry point for Cloudflare Workers / Vercel Edge / Vite: `core` plus
+ * the single `engines/<dialect>` module you actually use.
  *
  * ```ts ignore
- * import '@tundralibs/norm/engines/d1';
+ * import '@tundralibs/norm/engines/d1'; // or /neon, or /turso
  * import { Norm } from '@tundralibs/norm/core';
  *
  * const norm = new Norm({ database: { dialect: 'd1', accountId, databaseId, apiToken } });

--- a/packages/norm/docs/NORM-Errors.md
+++ b/packages/norm/docs/NORM-Errors.md
@@ -145,7 +145,8 @@ All three are thrown as a plain `NormError`.
 
 `ENGINE_NOT_REGISTERED` is the one you meet on edge runtimes, where you
 deliberately import `@tundralibs/norm/core` plus a single engine module
-to keep the bundle small.
+because the root barrel will not bundle there — see
+**[Choosing an entry point](../README.md#choosing-an-entry-point)**.
 
 ## Definition and registry codes
 

--- a/packages/norm/docs/NORM-Guide.md
+++ b/packages/norm/docs/NORM-Guide.md
@@ -56,12 +56,11 @@ const norm = new Norm({
 ```
 
 `dialect` is one of `postgres`, `maria`, `sqlite`, `mongo` (self-hosted)
-or `neon`, `turso`, `d1` (fetch-only, for edge/serverless runtimes). The
-root `@tundralibs/norm` barrel registers all seven. On an edge runtime,
-import `@tundralibs/norm/core` — the same surface with nothing registered
-— plus the single `@tundralibs/norm/engines/<dialect>` module you need, so
-no native driver ever enters the bundle. See the package README for the
-full rationale.
+or `neon`, `turso`, `d1` (fetch-only, for edge/serverless runtimes). This
+guide imports the root `@tundralibs/norm` barrel throughout, which
+registers all seven and is server-only; on an edge runtime import
+`@tundralibs/norm/core` plus the single engine module you need — see
+**[Choosing an entry point](../README.md#choosing-an-entry-point)**.
 
 ## 2. Model the schema
 

--- a/packages/norm/mod.ts
+++ b/packages/norm/mod.ts
@@ -9,14 +9,17 @@
  * await db.repo('Users').insert({ email: 'a@b.c', ... });
  * ```
  *
- * This barrel is the batteries-included entry point: it registers every
- * dialect (`postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`,
- * `d1`), so any `database` config works with no extra import — and every
- * driver, native SQLite binding included, is therefore in the bundle.
+ * **Server-only.** This barrel registers all seven dialects
+ * (`postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`, `d1`) so
+ * that any `database` config constructs with no extra import. The price
+ * is the native SQLite adapter, whose per-runtime bindings
+ * (`$sqlite_deno` / `bun:sqlite` / `node:sqlite` / `better-sqlite3`) an
+ * edge bundler cannot resolve: importing this module means the bundle
+ * cannot be built for Cloudflare Workers or a browser.
  *
- * On an edge runtime import {@link module:core} (`@tundralibs/norm/core`)
- * plus the one `@tundralibs/norm/engines/<dialect>` module you need; the
- * export surface is otherwise identical.
+ * There, import {@link module:core} (`@tundralibs/norm/core`) plus the
+ * one `@tundralibs/norm/engines/<dialect>` module you need; the export
+ * surface is otherwise identical.
  *
  * @module
  */


### PR DESCRIPTION
Companion to #277. **Docs and comments only** — verified: zero non-comment lines changed in the `.ts` files.

## Why

`norm/mod.ts:27-33` performs seven side-effect imports registering every dialect, so `new Norm({ database })` works by dialect string alone. That convenience reaches the native SQLite adapter (`$sqlite_deno`, `bun:sqlite`, `node:sqlite`, `better-sqlite3`), which means **the barrel cannot be built for Cloudflare Workers or a browser** — the `$sqlite_deno` alias exists only in Deno's import map and cannot resolve from a published tarball.

`@tundralibs/norm/core` registers nothing and is edge-safe. Verified empirically on real workerd: `core` + `engines/d1` emitted real SQL and returned rows.

The old text said the drivers are "therefore in the bundle" but never named the consequence. A reader could conclude it was a size problem. It is a build failure.

## Deliberately not changing the eager barrel

norm dispatches on a dialect **string** at runtime. Dropping the registrations would convert a build error into a **runtime** `ENGINE_NOT_REGISTERED` at first query whenever someone forgets a side-effect import — the wrong trade in the package where a wrong answer costs most. This documents the design as it is.

That is why norm is treated differently from `drivers` in #277, where engines are imported by name and the compiler enforces it.

## Real drift found and corrected

`docs/NORM-Errors.md:146-148` motivated `core` as being "to keep the bundle small". That is materially wrong and would mislead exactly the reader trying to deploy to an edge runtime — the barrel does not bloat the bundle, it fails to build. Corrected.

`docs/NORM-Guide.md` already covered the topic and ended with an untargeted "see the package README"; that is now a real link rather than a third copy of the explanation.

## Consolidation, not addition

The README's new `## Choosing an entry point` sits between Installation and Quick Start — where a reader actually hits it — and **replaces** the 41-line `### Running on the edge` subsection buried under `## Modules`, which restated mechanism that `engines/registry.ts` and `engines/sqlite.ts` already own (including the `unenv` / `Illegal constructor` story, which stays where it belongs). Net −41/+47.

Dialect strings are lowercase (`'postgres'`, `'d1'`) per `engines/registry.ts:37-44` — worth noting, as they are easy to get wrong.

## Gates

`deno check --doc-only` exit 0 — both new README blocks type-check, neither needed `ignore`. `deno doc --lint` unmoved at 0 missing-jsdoc / 111 private-type-ref. `@example` sweep 0 errors. `fmt`/`lint` clean. Tests at the pre-existing baseline (34 passed / 303 steps; the 2 failures are the live-DB suites).

Also ran `wiki-sync.ts`, which fails on dead links: 93 pages synced clean, both new cross-doc links resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)