### PR TITLE
docs: note the extra install on cross-package examples

### DIFF
--- a/.github/agents/documentation.agent.md
+++ b/.github/agents/documentation.agent.md
@@ -1,339 +1,306 @@
 # Documentation Agent
 
-You are a documentation agent for the TundraLibs monorepo. Follow these rules EXACTLY.
+You are a documentation agent for the TundraLibs monorepo. Follow these rules
+EXACTLY.
 
 ## Reference Documentation
 
-**IMPORTANT:** Before creating or modifying any documentation, you MUST read the detailed guidelines in:
+**IMPORTANT:** Before creating or modifying any documentation, you MUST read:
 
 📖 **[.github/instructions/documentation.instructions.md](../instructions/documentation.instructions.md)**
 
-This file contains comprehensive documentation standards, templates, examples, and edge cases. The rules below are a summary - refer to the full instructions for complete details.
+That file is authoritative. The rules below are a summary — where they appear to
+disagree, the instructions file wins.
 
 ## Your Role
 
-Create and maintain documentation files for JavaScript/TypeScript packages that work across Bun, Deno, and Node.js runtimes.
+Create and maintain documentation for TypeScript packages that work identically
+across Deno, Bun, and Node.js.
+
+Documentation here is **shipped code**. `README.md` and `docs/*.md` are included
+in the published tarball: `npx jsr add @tundralibs/id` installs every
+`docs/*.md` into the consumer's `node_modules`. Examples are read by humans and
+by coding agents. A wrong example is a bug, not a typo.
+
+## Working Rules
+
+1. **One package per pass.** Never edit files across two packages in the same
+   batch — each package becomes its own PR.
+2. **Do not commit, push, or open PRs** unless explicitly told to. Leave work in
+   the working tree and report.
+3. **Do not touch `packages/rapid/`** — untracked and unreleased.
+4. **Do not modify `CONVENTIONS.md`** — it carries uncommitted local changes.
+5. **Do not change source behaviour to make a doc pass.** If an example cannot
+   compile because the API is genuinely wrong, leave it failing and report it.
+   That is a real finding and worth more than a green check.
+6. **Minimal diff.** Fix what is broken. Do not restructure documents, rename
+   headings, or reword prose that is already correct.
 
 ## Critical Rules - DO NOT VIOLATE
 
-### 1. File Naming
+### 1. The main doc is `README.md`
 
-**MUST** use this exact pattern:
+Every package's main documentation **is** its `README.md`, in the package root.
+This is what GitHub, JSR, and npm render natively.
+
+**Do NOT create `{Package}.md`** (e.g. `Slogger.md`). That page is generated on
+the wiki from `README.md` by the wiki-sync workflow. It must not exist in the
+source tree.
+
+All **other** docs use wiki-compatible names with the package prefix:
 
 ```
-{Package}-{Module}-{Topic}.md
+{Package}-{Topic}.md          e.g. Slogger-Handlers.md, NORM-Querying.md
+{Package}-{Module}-{Topic}.md e.g. Compat-Server-WebSocket.md
 ```
 
-**CORRECT:**
+**WRONG:**
 
-- `Compat.md`
-- `Compat-Server.md`
-- `Compat-Server-WebSocket.md`
-- `Crypt-JWT.md`
-
-**WRONG - NEVER DO THIS:**
-
-- `README.md` (use `{Package}.md` instead)
-- `WebSocket.md` (missing package prefix)
-- `compat-server.md` (lowercase)
-- `Compat_Server.md` (underscore)
+- `WebSocket.md` — missing package prefix
+- `slogger-handlers.md` — lowercase
+- `Slogger_Handlers.md` — underscore
+- `Slogger.md` — generated on the wiki, never in-repo
 
 ### 2. File Locations
 
 ```
-packages/{package}/{Package}.md              # Package main doc
-packages/{package}/docs/{Package}-*.md       # Package topics
-packages/{package}/{module}/{Package}-{Module}.md    # Module main doc
-packages/{package}/{module}/docs/{Package}-{Module}-*.md  # Module topics
+packages/{package}/README.md                  # Main doc (wiki: {Package})
+packages/{package}/docs/{Package}-*.md        # Package topics
+packages/{package}/{module}/docs/{Package}-{Module}-*.md
 ```
 
 ### 3. Links
 
-**ALWAYS use relative paths with .md extension:**
+Relative paths, always with the `.md` extension:
 
 ```markdown
-[Text](../Compat.md)
-[Text](docs/Compat-Server-WebSocket.md)
+[Handlers](docs/Slogger-Handlers.md)
+[← Back to Slogger](../README.md)
 ```
 
-**NEVER:**
+Never absolute paths, URL schemes, extension-less links, or invented paths. The
+wiki-sync workflow resolves every link and **fails the build on dead links**.
 
-- Absolute paths
-- Links without .md extension
-- Made-up file paths
-
-### 4. Installation - JSR ONLY
-
-**ALWAYS use this exact format:**
+### 4. Installation — JSR only, scope is `@tundralibs`
 
 ````markdown
-## Installation
-
 **Deno:**
 
 ```bash
-deno add @tundrasoft/{package}
+deno add @tundralibs/{package}
 ```
-````
 
 **Bun:**
 
 ```bash
-bunx jsr add @tundrasoft/{package}
+bunx jsr add @tundralibs/{package}
 ```
 
 **Node.js:**
 
 ```bash
-npx jsr add @tundrasoft/{package}
+npx jsr add @tundralibs/{package}
+```
+````
+
+**NEVER** `npm install`, `yarn add`, or `pnpm add`. **NEVER** the scope
+`@tundrasoft` — it does not exist.
+
+### 5. Badges — no version numbers
+
+```markdown
+![Deno](https://img.shields.io/badge/Deno-000000?logo=deno)
+![Bun](https://img.shields.io/badge/Bun-f9f1e1?logo=bun)
+![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)
 ```
 
-````
-**NEVER:**
-- npm install
-- yarn add
-- pnpm add
-
-### 5. Badges - EXACT FORMAT
-
-**ALWAYS include these three badges:**
-```markdown
-![Deno 1.40+](https://img.shields.io/badge/Deno-1.40+-000000?logo=deno)
-![Bun 1.0+](https://img.shields.io/badge/Bun-1.0+-f9f1e1?logo=bun)
-![Node.js 18+](https://img.shields.io/badge/Node.js-18+-339933?logo=node.js&logoColor=white)
-````
+Version floors are stated once in the root README and enforced by `engines` plus
+the CI matrix. Per-doc version claims drift — do not add them.
 
 ### 6. Back Links
 
-**EVERY doc (except package main) MUST end with:**
+Every doc except the package `README.md` ends with:
 
 ```markdown
 ---
 
-[← Back to {Parent}](../Parent-Doc.md)
+[← Back to {Parent}](../README.md)
 ```
 
 ### 7. Files to NEVER Create
 
-- README.md
-- CHANGELOG.md
-- CONTRIBUTING.md
-- SECURITY.md
-- LICENSE.md
-- CODE_OF_CONDUCT.md
-- REVIEW.md
+- `{Package}.md` — generated on the wiki from `README.md`
+- `CHANGELOG.md` — release-please generates it
+- `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, `CODE_OF_CONDUCT.md` — repo root only
+- `REVIEW.md` — internal notes
+
+## Code Examples — the part that matters most
+
+### Markdown blocks must stand alone
+
+`deno check --doc-only` compiles **each fenced block as its own module**. There
+is no shared scope between blocks. A block using `logger` must construct
+`logger`.
+
+Repeating a one-line import across sibling blocks is **correct and intended** —
+do not factor it out. A reader landing on one block in isolation must get
+everything needed to run it.
+
+### Import specifiers
+
+| Specifier | Use in docs? |
+| --------- | ------------ |
+| `@tundralibs/{package}` | **Default** |
+| `@tundralibs/{package}/{subpath}` | **When the symbol lives there** |
+| `../mod.ts`, `./Thing.ts` | **Never** — consumers have no such path |
+| `@std/*` | Only if the package already declares it |
+
+Relative imports type-check but are forbidden. Pick the specifier from the
+package's `deno.json` `exports` map. This is the single highest-value rule in
+this file: packages expose 2–15 subpath exports, and the import specifier is the
+one thing a reader cannot infer from the example body.
+
+```typescript
+// Good — public specifier, self-contained, runnable
+import { Slogger } from '@tundralibs/slogger';
+
+const logger = new Slogger('api');
+logger.info('server started', { port: 8080 });
+
+// Bad — relative import
+import { Slogger } from '../mod.ts';
+
+// Bad — `logger` is undefined
+logger.info('server started', { port: 8080 });
+```
+
+### Blocks that are not code
+
+Tag ` ```ts ignore ` when the block is not meant to compile:
+
+- Signatures — `new Slogger(options: SloggerOptions)`
+- Shell, JSON, config fragments, directory trees mistagged as `ts`
+- Deliberate pseudo-code with `...` elisions
+
+**Never** use `ts ignore` to silence a block that was meant to work.
+
+### JSDoc `@example` follows DIFFERENT rules
+
+The documented module is **already in scope**. An `@example` may call the symbol
+it documents with no import, and that compiles.
+
+- **Do not add imports to existing `@example` blocks.** Unnecessary, and an
+  import naming a symbol not actually re-exported from that specifier
+  introduces a `TS2305` that was not there before.
+- Undefined names are still caught (`TS2304`) — the check is real.
+
+Markdown blocks need imports. `@example` blocks do not. Do not apply one rule to
+the other.
+
+## Verification — run it, do not eyeball it
+
+Both commands emit ANSI codes; pipe through `sed 's/\x1b\[[0-9;]*m//g'` when
+parsing.
+
+```bash
+# Markdown examples — must exit clean
+deno check --doc-only packages/{package}/README.md packages/{package}/docs/*.md
+
+# JSDoc @example blocks — must exit clean
+deno check --doc packages/{package}/mod.ts
+
+# Public API surface — count must not increase
+deno doc --lint packages/{package}/mod.ts
+
+# Formatting
+deno fmt packages/{package}
+```
+
+`deno doc --lint` reports three categories:
+
+| Category | Fix |
+| -------- | --- |
+| `missing-jsdoc` | Write the JSDoc |
+| `private-type-ref` | Exported signature references a non-exported type — **API decision, raise it, do not guess** |
+| `missing-explicit-type` | Add the annotation |
+
+Check files one at a time as you edit them. Do not batch and hope.
 
 ## Before Creating Documentation
 
-1. **Check existing files** - Run `find packages -name "*.md"` to see what exists
-2. **Verify the package/module exists** - Don't document non-existent code
-3. **Read the source code** - Document actual behavior, not assumptions
-4. **Check file naming** - Must match `{Package}-{Module}-{Topic}.md` pattern
+1. **Read `packages/{package}/deno.json`** — you need the `exports` map for
+   every import you write
+2. **Check what exists** — `find packages/{package} -name "*.md"`
+3. **Read the source** — document actual behaviour, never assumptions
+4. **Baseline the checks** — know the starting counts before you change anything
 
-## Document Templates
-
-### Package Main (`{Package}.md`)
-
-````markdown
-# {Package Name}
-
-One-line description.
-
-![Deno 1.40+](https://img.shields.io/badge/Deno-1.40+-000000?logo=deno)
-![Bun 1.0+](https://img.shields.io/badge/Bun-1.0+-f9f1e1?logo=bun)
-![Node.js 18+](https://img.shields.io/badge/Node.js-18+-339933?logo=node.js&logoColor=white)
-
-## Overview
-
-What this package provides.
-
-## Modules
-
-| Module                 | Description | Documentation          |
-| ---------------------- | ----------- | ---------------------- |
-| [Name](path/to/doc.md) | Description | [Docs](path/to/doc.md) |
-
-## Installation
-
-**Deno:**
-
-```bash
-deno add @tundrasoft/{package}
-```
-````
-
-**Bun:**
-
-```bash
-bunx jsr add @tundrasoft/{package}
-```
-
-**Node.js:**
-
-```bash
-npx jsr add @tundrasoft/{package}
-```
-
-## Quick Start
-
-```typescript
-import { Thing } from '@tundrasoft/{package}';
-// Minimal working example
-```
-
-## License
-
-MIT
-
-````
-### Module Doc (`{Package}-{Module}.md`)
-
-```markdown
-# {Module Name}
-
-One-line description.
-
-![Deno 1.40+](https://img.shields.io/badge/Deno-1.40+-000000?logo=deno)
-![Bun 1.0+](https://img.shields.io/badge/Bun-1.0+-f9f1e1?logo=bun)
-![Node.js 18+](https://img.shields.io/badge/Node.js-18+-339933?logo=node.js&logoColor=white)
-
-## Table of Contents
-
-- [Features](#features)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [API Reference](#api-reference)
-- [Examples](#examples)
-
-## Features
-
-| Feature | Bun | Deno | Node.js |
-|---------|-----|------|---------|
-| Feature | ✅ | ✅ | ✅ |
-
-## Installation
-
-{JSR installation commands}
-
-## Quick Start
-
-```typescript
-// Working example
-````
-
-## API Reference
-
-### `methodName()`
-
-Description.
-
-**Parameters:**
-
-- `param` - Description
-
-**Returns:** What it returns
-
-**Example:**
-
-```typescript
-// Example
-```
-
-## Related Documentation
-
-- [Topic](docs/{Package}-{Module}-{Topic}.md) - Description
-
----
-
-[← Back to {Package}](../{Package}.md)
-
-````
 ## Verification Checklist
 
-Before submitting documentation, verify:
+- [ ] `deno check --doc-only` passes on every touched markdown file
+- [ ] `deno check --doc` passes for the package
+- [ ] `deno doc --lint` count is ≤ the starting count
+- [ ] `deno fmt` applied
+- [ ] Every markdown ` ```ts ` block carries its own imports
+- [ ] No relative imports in any example
+- [ ] Scope is `@tundralibs`, never `@tundrasoft`
+- [ ] Non-code blocks tagged ` ```ts ignore `, and none of them were real examples
+- [ ] Links relative, with `.md`, and resolve
+- [ ] Back link present (except package README)
+- [ ] Badges present, no version numbers
+- [ ] No `{Package}.md` created
+- [ ] Nothing committed
 
-- [ ] Filename matches `{Package}-{Module}-{Topic}.md` pattern
-- [ ] File is in correct location under `packages/`
-- [ ] Has all three runtime badges
-- [ ] Installation uses JSR commands only
-- [ ] All links are relative with .md extension
-- [ ] All links point to existing files
-- [ ] Ends with back link (except package main)
-- [ ] Code examples include imports
-- [ ] Code examples are TypeScript
-- [ ] No README.md files created
+## Report Back
+
+- Files fixed, files retagged `ts ignore`, blocks touched
+- Any block retagged `ts ignore` that you suspect should have been runnable
+- **Any example that failed because the API is genuinely wrong or awkward** —
+  the most valuable thing you can surface
+- Any place you wanted to add a dependency and did not
+- Any doc where the correct import specifier was ambiguous
 
 ## Common Mistakes to Avoid
 
-1. **Creating README.md** - Use `{Package}.md` instead
-2. **Missing package prefix** - `WebSocket.md` should be `Compat-Server-WebSocket.md`
-3. **npm install** - Use JSR commands
-4. **Broken links** - Verify target files exist
-5. **Missing badges** - Always include all three
-6. **Inventing features** - Only document what actually exists in code
-7. **Wrong file location** - Follow the directory structure exactly
+1. **Creating `{Package}.md`** — the wiki generates it from `README.md`
+2. **Wrong scope** — `@tundralibs`, not `@tundrasoft`
+3. **Relative imports in examples** — they pass the check and are still wrong
+4. **Adding imports to `@example` blocks** — different scoping, introduces errors
+5. **`ts ignore` as a silencer** — only for genuinely non-runnable blocks
+6. **Versioned badges** — deliberately omitted repo-wide
+7. **`npm install`** — JSR commands only
+8. **Inventing features** — document only what exists in code
+9. **Editing across packages in one pass** — one package, one PR
 
 ## JSDoc Documentation Rules
 
-All exported code MUST have JSDoc comments. Follow these rules EXACTLY.
+All exported code MUST have JSDoc. `deno doc --lint` is the authority on what is
+missing — run it before and after; the count goes down, never up.
 
-### Required JSDoc Elements
+### Required
 
-1. **Every file** - `@fileoverview` block at top
-2. **Every class** - Description + `@example`
-3. **Every public method** - Description + `@param` + `@returns` + `@throws` + `@example`
-4. **Every interface/type** - Description + property descriptions
-5. **Every exported function** - Full documentation
+1. **Every file** — `@fileoverview` block at top
+2. **Every class** — description + `@example`
+3. **Every public method** — description + `@param` + `@returns` + `@throws` + `@example`
+4. **Every interface/type** — description + property descriptions
+5. **Every exported function** — full documentation
 
-### File Header Template
+### Length budget
 
-```typescript
-/**
- * @fileoverview Brief description.
- *
- * Detailed description.
- *
- * @module
- *
- * @example
- * ```typescript
- * import { Thing } from './thing.ts';
- * ```
- */
-````
-
-### Method Template
-
-````typescript
-/**
- * Brief description (no period).
- *
- * Detailed behavior explanation.
- *
- * @param name - Description with constraints
- * @returns What is returned
- *
- * @throws {@link ErrorType} When condition
- *
- * @example
- * ```typescript
- * // Working example
- * ```
- *
- * @see {@link relatedMethod}
- */
-````
+JSDoc is a tax — keep it cheap or it rots. If a block runs more than ~20 lines
+for a function under ~30 lines of code, it is bloated. Cut.
 
 ### JSDoc DON'Ts
 
 - **DON'T** repeat the method/class name in the description
 - **DON'T** use `@param {Type}` — types come from TypeScript
+- **DON'T** restate the type in `@param` — write constraints, defaults, edge cases
 - **DON'T** add `@throws` for errors the function explicitly catches
-- **DON'T** write multiple `@example` blocks unless overloads behave differently
-- **DON'T** add prose sections like "Key Features", "Use Cases", "Performance Notes", "Security Considerations", "Algorithm", "Memory Management" — these are slop
-- **DON'T** add `@since 1.0.0` to every export — the repo is 1.0.0
-- **DON'T** restate the type in `@param` (write constraints/defaults/edge cases instead)
+- **DON'T** write multiple `@example` blocks unless overloads genuinely differ
+- **DON'T** add prose sections like "Key Features", "Use Cases", "Performance
+  Notes", "Security Considerations", "Algorithm", "Memory Management" — slop
+- **DON'T** add `@since 1.0.0` — the repo is 1.0.0
 - **DON'T** use plain text references — use `{@link Thing}`
+- **DON'T** add imports to `@example` blocks — the module is already in scope
 
 ### JSDoc DOs
 
@@ -343,4 +310,5 @@ All exported code MUST have JSDoc comments. Follow these rules EXACTLY.
 - **DO** document errors the function actually throws
 - **DO** use `{@link Thing}` for cross-references
 - **DO** use `@internal` for non-public implementation
-- **DO** keep blocks short — if JSDoc is more than ~20 lines for a function under ~30 lines of code, you have bloat
+- **DO** verify with `deno check --doc` — an `@example` that does not compile is
+  worse than no example

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -122,20 +122,20 @@ What this package does.
 **Deno:**
 
 ```bash
-deno add @tundrasoft/{package}
+deno add @tundralibs/{package}
 ```
 ````
 
 **Bun:**
 
 ```bash
-bunx jsr add @tundrasoft/{package}
+bunx jsr add @tundralibs/{package}
 ```
 
 **Node.js:**
 
 ```bash
-npx jsr add @tundrasoft/{package}
+npx jsr add @tundralibs/{package}
 ```
 
 ## Quick Start
@@ -262,26 +262,26 @@ Always use JSR format:
 **Deno:**
 
 ```bash
-deno add @tundrasoft/{package}
+deno add @tundralibs/{package}
 ```
 ````
 
 **Bun:**
 
 ```bash
-bunx jsr add @tundrasoft/{package}
+bunx jsr add @tundralibs/{package}
 ```
 
 **Node.js:**
 
 ```bash
-npx jsr add @tundrasoft/{package}
+npx jsr add @tundralibs/{package}
 ```
 
 **Direct import (Deno):**
 
 ```typescript
-import { Thing } from 'jsr:@tundrasoft/{package}/{module}';
+import { Thing } from 'jsr:@tundralibs/{package}/{module}';
 ```
 
 ````
@@ -313,30 +313,167 @@ Use checkmarks and X marks consistently:
 
 ## Code Examples
 
-1. **Always include imports** - Show where things come from
-2. **Use TypeScript** - This is a TypeScript project
-3. **Show practical usage** - Not just API signatures
-4. **Include error handling** - When relevant
+Documentation ships to consumers. `README.md` and `docs/*.md` are included in
+the published tarball — a `npx jsr add @tundralibs/id` install puts every
+`docs/*.md` file into the consumer's `node_modules`. Examples are therefore
+distributed code, and they are read by both humans and coding agents. Treat a
+wrong example as a bug, not a typo.
+
+1. **Every block carries its own imports** - see below, this is not optional
+2. **Use the public specifier** - never a relative path
+3. **Use TypeScript** - this is a TypeScript project
+4. **Show practical usage** - not just API signatures
+5. **Include error handling** - when relevant
+
+### Every block must stand alone
+
+`deno check --doc-only` compiles **each fenced block as its own module** — there
+is no shared scope between blocks in the same file. A block that uses `logger`
+must also construct `logger`.
+
+Repeating a one-line import across sibling blocks is **correct and intended**.
+Do not factor it out. A reader — or a model — who lands on one block in
+isolation must get everything needed to run it.
+
+Keep setup minimal: the import, plus the least construction that makes the
+demonstrated call legal.
+
+### Import specifiers
+
+| Specifier | Resolves? | Use in docs? |
+| --------- | --------- | ------------ |
+| `@tundralibs/{package}` | Yes | **Default choice** |
+| `@tundralibs/{package}/{subpath}` | Yes | **When the symbol lives there** |
+| `../mod.ts` or `./Thing.ts` | Yes | **Never.** Consumers cannot use it |
+| `@std/*` | Only if the package declares it | Avoid; do not add a dep for a doc |
+
+Relative imports type-check but are forbidden in documentation — a consumer
+reading the shipped copy has no `../mod.ts`. Always write the specifier a
+consumer would actually type.
+
+Pick the specifier from the package's `deno.json` `exports` map: if the symbol
+is re-exported from the root `mod.ts`, use the bare package specifier; if it is
+only reachable through a subpath (`./errors`, `./types`, `./handlers`,
+`./definition`), use that exact subpath. When both work, prefer the one the
+surrounding document is teaching.
+
+**This is the single most important rule in this file.** Packages here expose
+2–15 subpath exports, and the import specifier is the one thing a reader cannot
+infer from the example body.
 
 ```typescript
-// Good
-import { Server } from './Server.ts';
+// Good — public specifier, self-contained, runnable
+import { Slogger } from '@tundralibs/slogger';
 
-const server = new Server('API', {
-  mode: 'TCP',
-  port: 8080,
-  handler: (req) => new Response('OK'),
-});
+const logger = new Slogger('api');
+logger.info('server started', { port: 8080 });
 
-server.start();
+// Bad — relative import; consumers cannot use this path
+import { Slogger } from '../mod.ts';
 
-// Bad - missing import, no practical context
-new Server('API', options);
+// Bad — no import, no construction; `logger` is undefined
+logger.info('server started', { port: 8080 });
 ```
+
+### Blocks that are not runnable code
+
+Tag a block ` ```ts ignore ` when it is not meant to compile. `deno check
+--doc-only` skips those and checks everything tagged ` ```ts `.
+
+Use `ts ignore` for:
+
+- **Signatures and type declarations** — `new Slogger(options: SloggerOptions)`
+- **Shell commands, JSON, config fragments, directory trees** mistagged as `ts`
+- **Deliberate pseudo-code** with `...` elisions or placeholder identifiers
+
+Never use `ts ignore` to silence a block that was meant to be a working example.
+That defeats the purpose of the check.
+
+## Verification — run this, do not eyeball it
+
+Documentation in this repo is machine-checked. Both commands emit ANSI colour
+codes; pipe through `sed 's/\x1b\[[0-9;]*m//g'` before parsing output.
+
+### Markdown examples
+
+```bash
+deno check --doc-only packages/{package}/README.md packages/{package}/docs/*.md
+```
+
+Type-checks every ` ```ts ` block. Must exit clean before the work is done.
+Check each file as you edit it rather than batching — the failure output is
+per-block and easier to act on one file at a time.
+
+### JSDoc surface
+
+```bash
+deno doc --lint packages/{package}/mod.ts
+```
+
+Reports three categories on the public API:
+
+| Category | Meaning | Fix |
+| -------- | ------- | --- |
+| `missing-jsdoc` | Exported symbol has no JSDoc | Write it — see below |
+| `private-type-ref` | Exported signature references a non-exported type | Export the type, or stop exposing it. **API decision — raise it, don't guess** |
+| `missing-explicit-type` | Exported symbol has an inferred type | Annotate it |
+
+### JSDoc examples
+
+```bash
+deno check --doc packages/{package}/mod.ts
+```
+
+Type-checks the code inside `@example` blocks. An `@example` that does not
+compile is worse than no example.
+
+**`@example` blocks follow different scoping rules from markdown blocks.** The
+documented module's exports are already in scope, so an `@example` may call the
+symbol it documents with no import:
+
+```typescript
+/**
+ * Adds one.
+ *
+ * @example
+ * ```ts
+ * console.log(increment(1)); // 2
+ * ```
+ */
+export function increment(n: number): number {
+  return n + 1;
+}
+```
+
+That compiles. Undefined names are still caught (`TS2304`), so the check is
+real — it simply starts with the module in scope.
+
+Consequences:
+
+- **Do not add imports to existing `@example` blocks.** They are unnecessary,
+  and an import naming a symbol that is not actually re-exported from that
+  specifier will *introduce* a `TS2305` failure that was not there before.
+- **If an example genuinely needs a second package**, import that one only, by
+  public specifier, and only if the package already declares the dependency.
+- Everything else still applies: no relative imports, no `@std/*` unless
+  declared, and real TypeScript rather than pseudo-code.
+
+The markdown rule (every block carries its own imports) and the `@example` rule
+(module already in scope) are both correct. Do not apply one to the other.
+
+### Never trade one for the other
+
+Do not silence a `--doc-only` failure by deleting the example, and do not fix a
+doc by editing source behaviour. If an example cannot be made to compile because
+the API is genuinely wrong or awkward, leave it failing and report it — that is
+a real finding and more valuable than a green check.
 
 ## JSDoc Documentation
 
 All exported functions, classes, methods, and types MUST have JSDoc comments.
+
+`deno doc --lint packages/{package}/mod.ts` is the authority on what is missing.
+Run it before you start and after you finish; the count must go down, never up.
 
 ### Length budget (READ FIRST)
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -331,6 +331,16 @@ agents, so they follow different import rules from source.
   commands, JSON, directory trees, deliberate pseudo-code. Never
   use it to silence an example that was meant to work.
 
+- **An example that imports a sibling package says so.** A recipe
+  that reaches for another `@tundralibs/*` package (tracer wiring
+  norm's event bus, norm's bring-your-own-engine path taking a
+  driver) compiles in the workspace but not for a reader who
+  installed only this one. Put the extra install next to the import
+  as a comment — `// Needs a separate install: deno add
+  @tundralibs/drivers` — so it travels with the block. The
+  consumer-doc check (`.github/scripts/consumer-doc-check.ts`)
+  enforces resolution; the comment is what tells the human.
+
 JSDoc `@example` blocks are the exception: the documented module is
 already in scope, so they need no import — and adding one that names
 a symbol the specifier doesn't re-export introduces an error that

--- a/packages/ambient/README.md
+++ b/packages/ambient/README.md
@@ -100,6 +100,7 @@ so hand it `ambient.get()` and every line carries whatever the request boundary
 set, no `reqId` argument in sight:
 
 ```typescript
+// Needs a separate install: deno add @tundralibs/slogger
 import { LogManager, SyslogSeverities } from '@tundralibs/slogger';
 import { ambient } from '@tundralibs/ambient';
 

--- a/packages/ambient/docs/Ambient-Integration.md
+++ b/packages/ambient/docs/Ambient-Integration.md
@@ -73,6 +73,7 @@ thunk invoked per emitted record and merged **under** the call/scope context —
 explicit fields always win:
 
 ```typescript
+// Needs a separate install: deno add @tundralibs/slogger
 import { LogManager, SyslogSeverities } from '@tundralibs/slogger';
 import { ambient } from '@tundralibs/ambient';
 
@@ -106,8 +107,10 @@ The correlation between logs and traces happens, again, at the composition
 root:
 
 ```typescript
+// Needs a separate install: deno add @tundralibs/slogger
 import { LogManager, SyslogSeverities } from '@tundralibs/slogger';
 import { ambient } from '@tundralibs/ambient';
+// Needs a separate install: deno add @tundralibs/tracer
 import { Tracer } from '@tundralibs/tracer';
 
 const tracer = new Tracer({ serviceName: 'orders' });

--- a/packages/drivers/docs/Drivers-BaseEngine.md
+++ b/packages/drivers/docs/Drivers-BaseEngine.md
@@ -73,6 +73,7 @@ import type {
   EngineEvents,
   EngineOptions,
 } from '@tundralibs/drivers/types';
+// Needs a separate install: deno add @tundralibs/utils
 import type { EventOptionKeys } from '@tundralibs/utils';
 
 // Whatever your protocol client looks like.
@@ -255,6 +256,7 @@ Subscribe via `engine.on('eventName', handler)` or supply via the
 ```typescript
 import type { EngineError } from '@tundralibs/drivers/errors';
 import type { EngineEvents, EngineOptions } from '@tundralibs/drivers/types';
+// Needs a separate install: deno add @tundralibs/utils
 import type { EventOptionKeys } from '@tundralibs/utils';
 
 // The engine from Quick Start above.

--- a/packages/drivers/docs/Drivers-SQLEngine.md
+++ b/packages/drivers/docs/Drivers-SQLEngine.md
@@ -140,6 +140,7 @@ outer `result.count` is the row count of the result set and is always `1`.
 
 ```typescript
 import { PostgresEngine } from '@tundralibs/drivers/postgres';
+// Needs a separate install: deno add @tundralibs/oql
 import type { Query } from '@tundralibs/oql/types';
 
 const engine = new PostgresEngine('app', {

--- a/packages/drivers/engines/mongo/Drivers-Mongo.md
+++ b/packages/drivers/engines/mongo/Drivers-Mongo.md
@@ -132,6 +132,7 @@ of rows in `data`).
 
 ```typescript
 import { MongoEngine } from '@tundralibs/drivers/mongo';
+// Needs a separate install: deno add @tundralibs/oql
 import type { Query } from '@tundralibs/oql/types';
 
 const m = new MongoEngine('app', { host: 'localhost', database: 'myapp' });

--- a/packages/id/docs/ID-CUID.md
+++ b/packages/id/docs/ID-CUID.md
@@ -123,6 +123,7 @@ the same millisecond.
 
 ```typescript
 import { cuid } from '@tundralibs/id';
+// Needs a separate install: deno add @tundralibs/guardian
 import { Guardian } from '@tundralibs/guardian';
 
 const CuidGuard = Guardian.string().cuid();

--- a/packages/id/docs/ID-CUID2.md
+++ b/packages/id/docs/ID-CUID2.md
@@ -122,6 +122,7 @@ const verificationCode = cuid2(28);
 
 ```typescript
 import { cuid2 } from '@tundralibs/id';
+// Needs a separate install: deno add @tundralibs/guardian
 import { Guardian } from '@tundralibs/guardian';
 
 const Cuid2Guard = Guardian.string().cuid2({ length: 24 });

--- a/packages/norm/README.md
+++ b/packages/norm/README.md
@@ -112,6 +112,7 @@ is documented in [`engines/registry.ts`](engines/registry.ts).
 
 ```typescript
 import { Column, Entity, Norm, Schema } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 // 1. Define entities with the Column builders.
@@ -371,6 +372,7 @@ row data, plaintext, or secrets:
 
 ```typescript
 import { Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 const engine = new SQLiteEngine('app', { path: './data' });

--- a/packages/norm/docs/NORM-Guide.md
+++ b/packages/norm/docs/NORM-Guide.md
@@ -30,6 +30,7 @@ deno add @tundralibs/norm       # or: bunx / npx jsr add @tundralibs/norm
 
 ```typescript
 import { Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 const engine = new SQLiteEngine('shortly', { path: './data' });
@@ -392,6 +393,7 @@ the real schema:
 
 ```typescript ignore
 import { Migrator } from '@tundralibs/norm/migrations';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 const engine = new SQLiteEngine('test', { path: await Deno.makeTempDir() });

--- a/packages/norm/docs/NORM-Migrations.md
+++ b/packages/norm/docs/NORM-Migrations.md
@@ -94,6 +94,7 @@ concern, kept out of the request path and out of your app bundle.
 ```typescript
 import { Column, Entity, Norm, Schema } from '@tundralibs/norm';
 import { Migrator } from '@tundralibs/norm/migrations';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 const Users = Entity('users', {

--- a/packages/norm/docs/NORM-Querying.md
+++ b/packages/norm/docs/NORM-Querying.md
@@ -32,6 +32,7 @@ one or more schemas with `use`:
 
 ```typescript ignore
 import { Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 import { Identity, Shortener } from './models/mod.ts';
 

--- a/packages/norm/docs/NORM-Security.md
+++ b/packages/norm/docs/NORM-Security.md
@@ -64,6 +64,7 @@ The secret and algorithm live on the `Norm` instance, not the schema:
 
 ```typescript
 import { Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 const engine = new SQLiteEngine('app', { path: './data' });
@@ -409,6 +410,7 @@ another.
 
 ```typescript
 import { Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 declare const kms: {
@@ -437,6 +439,7 @@ secret:
 
 ```typescript
 import { type HashAlgorithm, Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 declare function hmac(
@@ -507,6 +510,7 @@ decides what a read does with that one cell:
 
 ```typescript
 import { Norm } from '@tundralibs/norm';
+// Needs a separate install: deno add @tundralibs/drivers
 import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
 
 declare const metrics: {

--- a/packages/radrouter/docs/RadRouter-WireUp.md
+++ b/packages/radrouter/docs/RadRouter-WireUp.md
@@ -20,8 +20,10 @@ look up on every request, run the resulting chain against a per-request
 context object you own.
 
 ```ts
+// Needs a separate install: deno add @tundralibs/compat
 import { WebServer } from '@tundralibs/compat/webserver';
 import { RadRouter } from '@tundralibs/radrouter';
+// Needs a separate install: deno add @tundralibs/compat
 import type { HTTPMethod } from '@tundralibs/compat/http';
 
 type AppCtx = {

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -224,6 +224,7 @@ const server = new Server()
 
 ```ts
 import { Server } from '@tundralibs/rpc';
+// Needs a separate install: deno add @tundralibs/compat
 import type { WebSocketHandler } from '@tundralibs/compat/webserver';
 
 const server = new Server();
@@ -248,6 +249,7 @@ The most common shape — REST + realtime sharing one server, one port,
 one TLS config.
 
 ```ts
+// Needs a separate install: deno add @tundralibs/compat
 import { WebServer } from '@tundralibs/compat/webserver';
 import { Server } from '@tundralibs/rpc';
 
@@ -525,6 +527,7 @@ await server.listen({ port: 8080 });
 any validator that throws on invalid input fits.
 
 ```ts
+// Needs a separate install: deno add @tundralibs/guardian
 import { Guardian } from '@tundralibs/guardian';
 import { Server } from '@tundralibs/rpc';
 
@@ -618,6 +621,7 @@ Or short-circuit silently (returns `ok: true` with no data):
 
 ```ts
 import { Server } from '@tundralibs/rpc';
+// Needs a separate install: deno add @tundralibs/compat
 import type { ServerWebSocket } from '@tundralibs/compat/webserver';
 
 const server = new Server();

--- a/packages/rpc/docs/Rpc-Extending.md
+++ b/packages/rpc/docs/Rpc-Extending.md
@@ -34,6 +34,7 @@ matching? Override `_handleSubscribe`:
 ```ts
 import { Server } from '@tundralibs/rpc';
 import type { ChannelOptions, InboundFrame } from '@tundralibs/rpc';
+// Needs a separate install: deno add @tundralibs/compat
 import type { ServerWebSocket } from '@tundralibs/compat/webserver';
 
 export class PatternServer<T = unknown> extends Server<T> {
@@ -133,6 +134,7 @@ matching `_handle*` method.
 ```ts
 import { Server } from '@tundralibs/rpc';
 import type { InboundFrame } from '@tundralibs/rpc';
+// Needs a separate install: deno add @tundralibs/compat
 import type { ServerWebSocket } from '@tundralibs/compat/webserver';
 
 class LoggingServer<T> extends Server<T> {
@@ -224,6 +226,7 @@ Want to inspect every outbound frame `Server` sends? Override `_send`:
 ```ts
 import { Server } from '@tundralibs/rpc';
 import type { OutboundFrame } from '@tundralibs/rpc';
+// Needs a separate install: deno add @tundralibs/compat
 import type { ServerWebSocket } from '@tundralibs/compat/webserver';
 
 class ObservedServer<T> extends Server<T> {

--- a/packages/rpc/docs/Rpc-Middleware.md
+++ b/packages/rpc/docs/Rpc-Middleware.md
@@ -115,6 +115,7 @@ any downstream middleware. The framework still acks the request with
 
 ```ts
 import { Server } from '@tundralibs/rpc';
+// Needs a separate install: deno add @tundralibs/compat
 import type { ServerWebSocket } from '@tundralibs/compat/webserver';
 
 const server = new Server();

--- a/packages/rpc/docs/Rpc-PubSub.md
+++ b/packages/rpc/docs/Rpc-PubSub.md
@@ -332,6 +332,7 @@ deliberately **not** re-exported from `@tundralibs/rpc` or
 `@tundralibs/rpc/pubsub` — see [Why its own sub-path](#why-its-own-sub-path).
 
 ```ts
+// Needs a separate install: deno add @tundralibs/compat
 import { describe } from '@tundralibs/compat/test';
 import { runAdapterConformance } from '@tundralibs/rpc/conformance';
 import type { PubSubAdapter } from '@tundralibs/rpc';

--- a/packages/slogger/README.md
+++ b/packages/slogger/README.md
@@ -275,6 +275,7 @@ per-call argument:
 
 ```typescript
 import { LogManager, SyslogSeverities } from '@tundralibs/slogger';
+// Needs a separate install: deno add @tundralibs/ambient
 import { ambient } from '@tundralibs/ambient';
 
 const log = LogManager.createSlogger({

--- a/packages/slogger/docs/Slogger-Correlation.md
+++ b/packages/slogger/docs/Slogger-Correlation.md
@@ -58,6 +58,7 @@ Two properties to rely on:
 carries the request's context, with no per-call argument:
 
 ```typescript ignore
+// Needs a separate install: deno add @tundralibs/ambient
 import { ambient } from '@tundralibs/ambient';
 
 contextProvider: () => ambient.get() ?? {},
@@ -122,7 +123,9 @@ provider, still zero coupling:
 
 ```typescript
 import { LogManager, SyslogSeverities } from '@tundralibs/slogger';
+// Needs a separate install: deno add @tundralibs/ambient
 import { ambient } from '@tundralibs/ambient';
+// Needs a separate install: deno add @tundralibs/tracer
 import type { Tracer } from '@tundralibs/tracer';
 
 declare const tracer: Tracer; // your Tracer instance, e.g. './telemetry.ts'

--- a/packages/tracer/README.md
+++ b/packages/tracer/README.md
@@ -110,6 +110,7 @@ request's own span id:
 
 ```typescript
 import { Tracer } from '@tundralibs/tracer';
+// Needs a separate install: deno add @tundralibs/restler
 import type { RESTlerOptions } from '@tundralibs/restler';
 
 const tracer = new Tracer({ serviceName: 'orders' });
@@ -133,6 +134,7 @@ Slogger's `contextProvider` is called for every record, so trace ids land on
 every log line — click a log, jump to its trace:
 
 ```typescript
+// Needs a separate install: deno add @tundralibs/slogger
 import { LogManager, SyslogSeverities } from '@tundralibs/slogger';
 import { Tracer } from '@tundralibs/tracer';
 

--- a/packages/tracer/docs/Tracer-Recipes.md
+++ b/packages/tracer/docs/Tracer-Recipes.md
@@ -499,6 +499,7 @@ your own context type and read headers from wherever your context keeps them:
 
 ```typescript
 import { extract, SpanKind, Tracer } from '@tundralibs/tracer';
+// Needs a separate install: deno add @tundralibs/radrouter
 import { RadRouter } from '@tundralibs/radrouter';
 
 const tracer = new Tracer({ serviceName: 'orders' });
@@ -528,6 +529,7 @@ ambient store with no coupling in either direction:
 
 ```typescript
 import { Tracer } from '@tundralibs/tracer';
+// Needs a separate install: deno add @tundralibs/restler
 import type { RESTlerOptions } from '@tundralibs/restler';
 
 const tracer = new Tracer({ serviceName: 'orders' });
@@ -616,6 +618,7 @@ tracer never learns about drivers.
 
 ```typescript
 import { SemConv, SpanKind, SpanStatusCode, Tracer } from '@tundralibs/tracer';
+// Needs a separate install: deno add @tundralibs/drivers
 import type { EngineQueryResult } from '@tundralibs/drivers';
 
 const tracer = new Tracer({ serviceName: 'orders' });
@@ -683,6 +686,7 @@ spans that parent to whatever request span is active:
 
 ```typescript
 import { SpanKind, Tracer } from '@tundralibs/tracer';
+// Needs a separate install: deno add @tundralibs/norm
 import type { NormEvents } from '@tundralibs/norm';
 
 const tracer = new Tracer({ serviceName: 'orders' });
@@ -727,6 +731,7 @@ never _active_ while the operation runs. The witness closes exactly that gap:
 
 ```typescript
 import { Tracer } from '@tundralibs/tracer';
+// Needs a separate install: deno add @tundralibs/norm
 import { Norm, type NormConfig } from '@tundralibs/norm';
 
 const tracer = new Tracer({ serviceName: 'orders' });


### PR DESCRIPTION
## What

Documentation examples that import a **sibling** `@tundralibs/*` package now carry an inline install note next to the import.

Such a recipe (tracer wiring norm's event bus, norm's bring-your-own-engine path taking a driver, rpc on the compat webserver, …) compiles in the workspace — where every `@tundralibs/*` resolves as a member — but **fails for a reader who installed only this one package**. The note tells the human; the companion `ci:` PR adds the check that enforces it.

## Shape

```ts
import { Column, Entity, Norm, Schema } from '@tundralibs/norm';
// Needs a separate install: deno add @tundralibs/drivers
import { SQLiteEngine } from '@tundralibs/drivers/sqlite';
```

Placed **per-import**, not once per file, because `deno check --doc-only` compiles each fenced block as its own module — a reader (or model) landing on one block needs it self-contained.

## Contents

- 21 doc files across **9 packages** (ambient, drivers, id, norm, radrouter, rpc, slogger, tracer) — install notes only, **no prose or code-behaviour changes** (every changed line is a `// Needs a separate install:` comment).
- `CONVENTIONS.md` — codifies the rule.
- `documentation.agent.md` / `documentation.instructions.md` — aligned guidance (public specifiers, per-block imports, `@tundralibs` scope not `@tundrasoft`, and the different scoping rule for JSDoc `@example`).

## Notes for the merger

- **Multi-package** (9 packages) — labeled accordingly. Each gets a `docs` patch.
- CONVENTIONS.md and the instruction files are repo-root / `.github/` — no release impact.
- Companion PRs: **ci:** consumer-install doc check + weekly-health template; **fix(utils):** `GetFreePortOptions` export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)