### PR TITLE
fix(utils): export GetFreePortOptions so the published .d.ts stays callable

### DIFF
--- a/packages/utils/getFreePort.ts
+++ b/packages/utils/getFreePort.ts
@@ -7,15 +7,22 @@
 
 import { listen } from '@tundralibs/compat/net';
 
-/** Range and exclusions for {@link getFreePort}. */
-interface GetFreePortOptions {
+/**
+ * Range and exclusions for {@link getFreePort}.
+ *
+ * Exported (and a `type`, not an `interface`) so it survives `.d.ts`
+ * generation — a non-exported interface referenced by an exported function
+ * degrades that function's parameter to `never` for consumers resolving via
+ * the published declarations.
+ */
+export type GetFreePortOptions = {
   /** Inclusive lower bound (0–65535). @default 1024 */
   min?: number;
   /** Inclusive upper bound (0–65535, ≥ `min`). @default 65535 */
   max?: number;
   /** Ports to skip even if they fall within the range. @default [] */
   exclude?: number[];
-}
+};
 
 /** Thrown by {@link getFreePort} for invalid ranges or exhausted attempts. */
 export class PortError extends Error {

--- a/packages/utils/mod.ts
+++ b/packages/utils/mod.ts
@@ -27,7 +27,11 @@ export {
 } from './Config.ts';
 export { envArgs } from './envArgs.ts';
 export { type EventCallback, Events } from './Events.ts';
-export { getFreePort, PortError } from './getFreePort.ts';
+export {
+  getFreePort,
+  type GetFreePortOptions,
+  PortError,
+} from './getFreePort.ts';
 export {
   expandIPv6,
   IPV4_BITS,


### PR DESCRIPTION
## The bug

`getFreePort` is unusable for Node/Bun consumers. Its options type was a **non-exported `interface`**:

```ts
interface GetFreePortOptions { min?: number; max?: number; exclude?: number[] }
export const getFreePort = async (opts: GetFreePortOptions = {}) => { … }
```

JSR fast-check can't name a non-exported type in an exported signature, so the emitted declaration degrades to:

```ts
export declare const getFreePort: (_dts_1: never) => Promise<number>;
```

A consumer resolving through the published `_dist/getFreePort.d.ts` then gets:

- `getFreePort({ min: 3000, max: 4000 })` → `TS2345: … not assignable to parameter of type 'never'`
- `getFreePort()` → `TS2554: Expected 1 arguments, but got 0`

Deno consumers reading source were fine — which is why the in-repo checks stayed green and this shipped.

## The fix

Make it an **exported `type`**, re-exported from `mod.ts` (matching how `EventCallback` / `ConfigType` are handled). One-line signature change, no runtime behaviour change.

Verified with `deno publish --dry-run` in `packages/utils`: the slow-type check passes, so the next published `.d.ts` emits a callable signature.

## How it surfaced

The consumer-install doc check (companion `ci:` PR) — the `getFreePort` doc example failed to compile from a clean install, which led here.

> Note: this only clears from the consumer-doc check once utils republishes; the check tests the published tarball, which still carries the pre-fix `.d.ts` until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)