### PR TITLE
fix(compat): export InlineTLS and FileTLS so validateTLS stays callable

### DIFF
--- a/.github/scripts/consumer-doc-check.ts
+++ b/.github/scripts/consumer-doc-check.ts
@@ -70,6 +70,8 @@ const DOC_PEERS: Record<string, string[]> = {
   // Validation and token recipes.
   id: ['guardian'],
   pact: ['crypt'],
+  // getFreePort's test-fixture examples import the compat test harness.
+  utils: ['compat'],
   // compat's webserver docs show the raw `ws` npm client as an alternative;
   // `ws` ships no types, so a reader following that snippet also needs @types/ws.
   compat: ['npm:ws', 'npm:@types/ws'],

--- a/packages/compat/common.ts
+++ b/packages/compat/common.ts
@@ -82,8 +82,12 @@ export class FetchPathTraversalError extends CompatError {
   }
 }
 
-/** Inline PEM material. */
-type InlineTLS = {
+/**
+ * Inline PEM material. Exported so the published `.d.ts` for the exported
+ * {@link validateTLS} keeps a usable parameter type — a non-exported type in
+ * an exported signature degrades to `never` for consumers on the tarball.
+ */
+export type InlineTLS = {
   /** PEM-encoded certificate string. */
   cert?: string;
   /** PEM-encoded private key string. */
@@ -92,8 +96,8 @@ type InlineTLS = {
   ca?: string[];
 };
 
-/** Filesystem paths to PEM material. */
-type FileTLS = {
+/** Filesystem paths to PEM material. Exported for the same reason as {@link InlineTLS}. */
+export type FileTLS = {
   /** Path to PEM-encoded certificate file. */
   certFile?: string;
   /** Path to PEM-encoded private key file. */

--- a/packages/compat/mod.ts
+++ b/packages/compat/mod.ts
@@ -59,6 +59,8 @@ export {
   FetchInvalidPEMError,
   FetchPathTraversalError,
   FetchTLSError,
+  type FileTLS,
+  type InlineTLS,
   type TLSOptions,
   type ValidatedTLS,
   validateTLS,

--- a/packages/utils/docs/Utils-GetFreePort.md
+++ b/packages/utils/docs/Utils-GetFreePort.md
@@ -98,6 +98,7 @@ const ports = await Promise.all(services.map(async (service) => {
 ### Test Fixtures
 
 ```typescript
+// Needs a separate install: deno add @tundralibs/compat
 import { describe, it } from '@tundralibs/compat/test';
 import { getFreePort } from '@tundralibs/utils';
 
@@ -212,6 +213,7 @@ try {
 ✅ **Use in test setup/teardown:**
 
 ```typescript
+// Needs a separate install: deno add @tundralibs/compat
 import { beforeEach } from '@tundralibs/compat/test';
 import { getFreePort } from '@tundralibs/utils';
 


### PR DESCRIPTION
Follow-ups from the #297 / #299 review — two declaration/resolution bugs that only surface for a consumer who installed a single package.

### compat — degraded `.d.ts` (same class as #299)
`packages/compat/common.ts` (a published entry, `./common`, and re-exported through the root `mod.ts`) exports `validateTLS(tls: InlineTLS & FileTLS)`, but `InlineTLS` and `FileTLS` were **not** exported while the return type `ValidatedTLS` was. JSR's generated declarations degrade the parameter to `never` for anyone resolving via the tarball.

- Export both types.
- Re-export them through the root barrel next to `ValidatedTLS`.
- Verified with `deno publish --dry-run` (JSR slow-type check): clean.

### utils — consumer-doc check gap
`packages/utils/docs/Utils-GetFreePort.md` imports `@tundralibs/compat/test` in two fixtures, but utils had no `DOC_PEERS` entry in `.github/scripts/consumer-doc-check.ts`, so #297's checker installs only utils and the import can't resolve. The blocks also lacked the `// Needs a separate install:` note that #298's own convention requires.

- Add `utils: ['compat']` to `DOC_PEERS`.
- Add the install note to both fixture blocks.

Types and docs only; no behaviour change. Both package fixes fold into the held release (#289 compat, #292 utils).

🤖 Generated with [Claude Code](https://claude.com/claude-code)