### PR TITLE
fix(ci): drop the .md suffix on wiki-internal links

### DIFF
--- a/.github/scripts/wiki-sync.ts
+++ b/.github/scripts/wiki-sync.ts
@@ -126,7 +126,10 @@ const main = () => {
         const suffix = anchor ? `#${anchor}` : '';
 
         const wiki = wikiNameOf(resolved);
-        if (wiki) return `](${wiki}${suffix})`;
+        // Drop the `.md`: a wiki page is served at `/wiki/<PageName>`, and a
+        // markdown link that keeps the extension (`](Ambient.md)`) resolves to
+        // the RAW file instead of the rendered page. Anchors still apply.
+        if (wiki) return `](${wiki.replace(/\.md$/, '')}${suffix})`;
 
         // Exists in the repo but is not a wiki page — deep-link to GitHub.
         try {


### PR DESCRIPTION
## Symptom
On the published wiki, links open **raw markdown** instead of the rendered page:
- Every package link on **Home** (Ambient, Cacher, …).
- In-page cross-references such as **Concepts** / **Integration** at the bottom of a package page.
- **Roadmap** already worked — because it points at `ROADMAP.md`, which is *not* a synced wiki page, so it takes the absolute blob-URL branch rather than the wiki-link branch.

## Cause
`wiki-sync.ts` rewrote a link to a synced page as `](Ambient.md)`. A GitHub wiki page is served at `/wiki/<PageName>`; a markdown link that keeps the `.md` extension resolves to the **raw** file. One line in the rewrite kept the extension.

## Fix
Strip `.md` when the target resolves to a synced wiki page. Anchors are preserved (`](Cacher#custom-engine)`); blob-URL links to non-synced files are untouched.

## Verified locally (`deno run … wiki-sync.ts`)
| | before | after |
|---|---|---|
| Home → package | `](Ambient.md)` | `](Ambient)` |
| Ambient → Concepts | `](Ambient-Concepts.md)` | `](Ambient-Concepts)` |
| Ambient → Roadmap | blob URL | blob URL (unchanged) |
| anchors | — | `](Cacher#custom-engine)` preserved |

93 pages sync clean; no wiki-internal link ends in `.md` afterward.

> Note: the separate **JSR** relative-link breakage (JSR resolves README links against the repo root, dropping `packages/<pkg>/`) is a different root cause and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)