### PR TITLE
docs(norm): document worker compatibility and module entry

### DIFF
--- a/packages/norm/README.md
+++ b/packages/norm/README.md
@@ -31,6 +31,21 @@ The same typed code runs against seven engines — four self-hosted
 edge/serverless runtimes (`neon`, `turso`, `d1`). The four self-hosted
 dialects are exercised end-to-end by the live test suite.
 
+## Browser / Worker compatibility
+
+This package is intentionally **server-side first**. The root barrel,
+`@tundralibs/norm`, registers all dialects and pulls in the native
+SQLite adapter for local file-backed databases; that is not a browser or
+worker-safe bundle target. Use `@tundralibs/norm/core` plus the single
+fetch-only engine you need (`neon`, `turso`, or `d1`) when targeting an
+edge worker or Cloudflare-style runtime, and avoid importing the root
+barrel in browser-only code.
+
+The self-hosted engines (`postgres`, `maria`, `sqlite`, `mongo`) are
+for Deno, Bun, and Node server runtimes and rely on native or networked
+connections. Only the fetch-only dialects are intended for the worker/
+edge footprint.
+
 ## Modules
 
 | Module                          | Import                               | Description                                                                                                |

--- a/packages/norm/errors/MigrationError.ts
+++ b/packages/norm/errors/MigrationError.ts
@@ -27,7 +27,11 @@ export type MigrationErrorMeta = {
 
 /** A migration operation failed or was refused. */
 export class NormMigrationError extends NormError<MigrationErrorMeta> {
-  /** @param meta Migration context (dir, version, subject, code). */
+  /**
+   * Construct a migration error.
+   *
+   * @param meta Migration context (dir, version, subject, code).
+   */
   constructor(message: string, meta: MigrationErrorMeta = {}, cause?: Error) {
     super(message, meta, cause);
   }

--- a/packages/norm/errors/MigrationError.ts
+++ b/packages/norm/errors/MigrationError.ts
@@ -27,6 +27,7 @@ export type MigrationErrorMeta = {
 
 /** A migration operation failed or was refused. */
 export class NormMigrationError extends NormError<MigrationErrorMeta> {
+  /** @param meta Migration context (dir, version, subject, code). */
   constructor(message: string, meta: MigrationErrorMeta = {}, cause?: Error) {
     super(message, meta, cause);
   }

--- a/packages/norm/errors/mod.ts
+++ b/packages/norm/errors/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Error surface for `@tundralibs/norm` — the base {@link NormError} and
+ * the typed subclasses for definition, validation, query, crypto, hook,
+ * migration, advisory-lock, and unsupported-operation failures.
+ *
+ * @module
+ */
 export { NormError } from './Base.ts';
 export type { NormErrorCode } from './NormErrorCodes.ts';
 export {

--- a/packages/norm/migrations/FileLock.ts
+++ b/packages/norm/migrations/FileLock.ts
@@ -97,6 +97,8 @@ export class FileLock {
   #held = false;
 
   /**
+   * Bind a lock to a migrations directory's `migrator.lock` file.
+   *
    * @param dir - Migrations directory the `migrator.lock` file lives in.
    * @param staleMs - Age at which an untouched lock file is considered
    *   abandoned and may be reclaimed (default

--- a/packages/norm/migrations/Migrator.ts
+++ b/packages/norm/migrations/Migrator.ts
@@ -72,6 +72,7 @@ const ADVISORY_LOCK_KEY = 'norm:migrator';
 /** Rows per page/INSERT during a crypto-transforming rebuild copy. */
 const REBUILD_CHUNK = 500;
 
+/** Options for {@link Migrator}. */
 export type MigratorOptions = {
   /** Migrations directory (versioned snapshots + migrator.lock). */
   dir: string;
@@ -106,6 +107,7 @@ export type MigratorOptions = {
   transactionTimeoutMs?: number;
 };
 
+/** Outcome of a {@link Migrator.snapshot} call. */
 export type SnapshotResult = {
   version: number;
   path: string;
@@ -113,6 +115,7 @@ export type SnapshotResult = {
   written: boolean;
 };
 
+/** Applied-versus-disk migration state. */
 export type MigratorStatus = {
   /** Highest applied version (0 = fresh database). */
   dbVersion: number;
@@ -124,6 +127,7 @@ export type MigratorStatus = {
   hashOk: boolean;
 };
 
+/** One version's planned DDL, suppressed drops, and warnings. */
 export type PlannedStep = {
   version: number;
   queries: ReadonlyArray<MigrationAction>;
@@ -133,6 +137,7 @@ export type PlannedStep = {
   warnings: ReadonlyArray<string>;
 };
 
+/** Options for {@link Migrator.apply}. */
 export type ApplyOptions = {
   /** Emit DROP TABLE/COLUMN (default false — data-loss guard). */
   allowDrop?: boolean;
@@ -144,6 +149,7 @@ export type ApplyOptions = {
   dryRun?: boolean;
 };
 
+/** Outcome of a {@link Migrator.apply} call. */
 export type ApplyResult = {
   applied: ReadonlyArray<number>;
   durationMs: number;
@@ -189,7 +195,11 @@ export class Migrator {
    * writes a new version file. */
   #versionsCache: number[] | undefined;
 
-  /** @param db The handle returned by `norm.use(...)`. */
+  /**
+   * Bind a migrator to a `norm.use(...)` handle and migrations directory.
+   *
+   * @param db The handle returned by `norm.use(...)`.
+   */
   constructor(db: object, options: MigratorOptions) {
     this.#runtime = runtimeOf(db);
     // Trailing slashes are trimmed by scanning back from the end rather than

--- a/packages/norm/migrations/plans.ts
+++ b/packages/norm/migrations/plans.ts
@@ -80,6 +80,7 @@ function ddlStatements(t: AnyTranslator, q: DdlQuery): string[] {
   }
 }
 
+/** A rendered per-dialect plan artifact plus its verification hash. */
 export type RenderedPlan = {
   /** Executable statements only (comments excluded) — the hash input. */
   readonly statements: string[];

--- a/packages/norm/mod.ts
+++ b/packages/norm/mod.ts
@@ -1,25 +1,21 @@
 /**
- * @tundralibs/norm — definition layer (builders, entities, named
- * schemas, docs, snapshots) + runtime (Norm facade, generated-Guardian
- * validation, repos over the executor seam).
+ * @fileoverview `@tundralibs/norm` entrypoint.
  *
- * ```ts ignore
- * const norm = new Norm({ database: {...}, secret });
- * const db = norm.use(Blog, Stats);
- * await db.repo('Users').insert({ email: 'a@b.c', ... });
- * ```
+ * This barrel exposes the full definition layer and runtime surface for
+ * the ORM: entity builders, schema declarations, generated Guardian
+ * validation, migration tooling, and repo/executor access over the
+ * configured database engine.
  *
- * **Server-only.** This barrel registers all seven dialects
- * (`postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`, `d1`) so
- * that any `database` config constructs with no extra import. The price
- * is the native SQLite adapter, whose per-runtime bindings
- * (`$sqlite_deno` / `bun:sqlite` / `node:sqlite` / `better-sqlite3`) an
- * edge bundler cannot resolve: importing this module means the bundle
- * cannot be built for Cloudflare Workers or a browser.
+ * The root module is intentionally server-first. It registers all seven
+ * dialects (`postgres`, `maria`, `sqlite`, `mongo`, `neon`, `turso`,
+ * `d1`) so consumer code can construct a `Norm` instance with no extra
+ * import. That also loads the native SQLite bindings for local
+ * file-backed databases, which browser and Cloudflare Worker bundles
+ * cannot resolve.
  *
- * There, import {@link module:core} (`@tundralibs/norm/core`) plus the
- * one `@tundralibs/norm/engines/<dialect>` module you need; the export
- * surface is otherwise identical.
+ * For worker or browser targets, import `@tundralibs/norm/core` plus a
+ * single engine module such as `@tundralibs/norm/engines/d1` or
+ * `@tundralibs/norm/engines/neon` instead.
  *
  * @module
  */


### PR DESCRIPTION
## Summary

- document the server-first / worker-browser compatibility caveat in the Norm README
- clarify the root barrel's runtime limits in the module doc comment

## Scope

This is documentation-only and kept to the Norm package.