### PR TITLE
docs(cacher): document worker compatibility

### DIFF
--- a/packages/cacher/README.md
+++ b/packages/cacher/README.md
@@ -10,6 +10,19 @@ A flexible caching library with support for Memory, Redis, and Memcached engines
 
 The Cacher package provides a unified caching abstraction that works with multiple backends. A singleton `Cacher` manager handles engine registration and instance lifecycle, while `AbstractEngine` defines the common API that all cache engines implement.
 
+## Browser / Worker compatibility
+
+`@tundralibs/cacher` is a server-side cache abstraction. The built-in
+Redis and Memcached engines, and the underlying socket / network
+lifecycle they rely on, are intended for Deno, Bun, and Node server
+runtimes. This package is not designed as a browser or worker-native
+cache runtime.
+
+Use the in-memory engine for local process-state caching in a browser
+or worker context only if the target environment supports the same
+runtime semantics; do not assume the networked engines are portable to
+edge or browser sandboxes.
+
 ## Modules
 
 | Module             | Description                                                           | Documentation                               |

--- a/packages/cacher/engines/mod.ts
+++ b/packages/cacher/engines/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Concrete cache engines and their option types — in-memory, Redis, and
+ * Memcached implementations registered with the {@link Cacher} manager.
+ *
+ * @module
+ */
 export { MemCacher, type MemCacherOptions } from './memcached/mod.ts';
 export { MemoryCacher, type MemoryCacherOptions } from './memory/mod.ts';
 export { RedisCacher, type RedisCacherOptions } from './redis/mod.ts';

--- a/packages/cacher/errors/mod.ts
+++ b/packages/cacher/errors/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Error surface for `@tundralibs/cacher` — the base {@link CacherError},
+ * the engine-level {@link CacherEngineError}, and its typed error codes.
+ *
+ * @module
+ */
 export { CacherError } from './Base.ts';
 export { CacherEngineError, type CacherErrorMeta } from './EngineError.ts';
 export {

--- a/packages/cacher/mod.ts
+++ b/packages/cacher/mod.ts
@@ -1,3 +1,18 @@
+/**
+ * @fileoverview `@tundralibs/cacher` entrypoint.
+ *
+ * Provides a unified cache abstraction over in-memory, Redis, and
+ * Memcached backends behind the same `Cacher` manager API. The package
+ * is designed for server runtimes and exposes the concrete engine
+ * constructors and option types needed to wire a cache into an app.
+ *
+ * Browser and worker bundles should only use the in-memory engine when
+ * the runtime supports equivalent process-local semantics; the networked
+ * Redis / Memcached engines depend on server-side socket lifecycles.
+ *
+ * @module
+ */
+
 // Core classes — canonical implementation files.
 export { AbstractEngine } from './AbstractEngine.ts';
 export { Cacher, type EngineConstructor } from './Cacher.ts';

--- a/packages/cacher/types/mod.ts
+++ b/packages/cacher/types/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared cache type surface — the base {@link CacherOptions} plus the
+ * stored {@link CacheValue} and per-entry {@link CacheValueOptions} shapes.
+ *
+ * @module
+ */
 export type { CacherOptions } from './CacherOptions.ts';
 export type { CacheValue } from './CacheValue.ts';
 export type { CacheValueOptions } from './CacheValueOptions.ts';


### PR DESCRIPTION
## Summary

- document the server-side runtime limits for the Cacher package
- clarify that networked cache engines are not browser/worker-safe by default

## Scope

This is documentation-only and kept to the Cacher package.