### PR TITLE
docs(rpc): document worker compatibility

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -25,6 +25,19 @@ Built on top of [`@tundralibs/compat/websocket`](../compat/websocket/Compat-WebS
 It is transport-agnostic: the same `Server` instance can be mounted
 via `server.handlers()` or run standalone via `server.listen()`.
 
+## Browser / Worker compatibility
+
+`@tundralibs/rpc` is a WebSocket-oriented server package. The runtime is
+intended for Deno, Bun, and Node server environments, and the
+conformance adapter test path is intentionally excluded from the public
+barrel because it pulls in a test framework that browser and edge-worker
+bundlers cannot resolve.
+
+The supported runtime shape is a server process with real WebSocket
+lifecycle and socket state. Browser and worker bundles should use the
+package only for non-test client-side integrations, and should not rely
+on the internal test adapter or server-only path in a worker script.
+
 ## Modules
 
 | Module           | Description                                                                            | Documentation                                              |

--- a/packages/rpc/errors/mod.ts
+++ b/packages/rpc/errors/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Error surface for `@tundralibs/rpc` — the base {@link RpcError} plus the
+ * config, registration, and state error subclasses raised by Server/Client.
+ *
+ * @module
+ */
 export { RpcError } from './Base.ts';
 export { RpcConfigError } from './RpcConfigError.ts';
 export { RpcRegistrationError } from './RpcRegistrationError.ts';


### PR DESCRIPTION
## Summary

- document the WebSocket server-first runtime expectations for the RPC package
- note that the conformance/test adapter remains server-only and not browser/worker-safe

## Scope

This is documentation-only and kept to the RPC package.