### PR TITLE
docs(slogger): document worker compatibility

### DIFF
--- a/packages/slogger/README.md
+++ b/packages/slogger/README.md
@@ -67,6 +67,19 @@ deployment.
 See [docs/Slogger-Performance.md](docs/Slogger-Performance.md) for the
 honest per-call cost breakdown.
 
+## Browser / Worker compatibility
+
+`@tundralibs/slogger` is designed for server-side application logging
+and is not a browser/worker-first runtime. TCP, syslog, file, HTTP
+transport handlers, and the socket-backed lifecycle depend on server
+runtime capabilities that are not available in a browser sandbox.
+
+This package is intended for Deno, Bun, and Node server environments,
+with the socket and file-backed handlers used in process-local or
+network-local deployments. Browser or worker bundles should restrict
+usage to the in-memory or console-style paths and avoid relying on the
+server transport handlers.
+
 ## Modules
 
 | Module                                         | Description                                 | Documentation                            |

--- a/packages/slogger/formatters/mod.ts
+++ b/packages/slogger/formatters/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Record formatters for `@tundralibs/slogger` — JSON, logfmt, OTEL,
+ * RFC 5424 syslog, masking, and the human-readable text layouts used by
+ * handlers to serialize a log record.
+ *
+ * @module
+ */
 export { jsonFormatter, prettyJsonFormatter } from './jsonFormatter.ts';
 export { logfmtFormatter, type LogfmtOptions } from './logfmt.ts';
 export { otelLogFormatter, type OtelLogOptions } from './otel.ts';

--- a/packages/slogger/handlers/mod.ts
+++ b/packages/slogger/handlers/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Log transport handlers for `@tundralibs/slogger` — console, file, HTTP,
+ * TCP, syslog, stream, memory, and blackhole sinks, plus the
+ * {@link AbstractHandler} base and their option types.
+ *
+ * @module
+ */
 export {
   BlackholeHandler,
   type BlackholeHandlerOptions,


### PR DESCRIPTION
## Summary

- document that Slogger is server-side first
- clarify that TCP/syslog/file/HTTP transports are not browser/worker-safe by default

## Scope

This is documentation-only and kept to the Slogger package.