### PR TITLE
docs(utils): add module docs to entrypoints

### DIFF
--- a/packages/utils/BaseError.ts
+++ b/packages/utils/BaseError.ts
@@ -1,3 +1,9 @@
+/**
+ * Structured, serializable base error with typed metadata and message
+ * templating, shared by every TundraLibs package's error hierarchy.
+ *
+ * @module
+ */
 import { readTextFileSync } from '@tundralibs/compat/file';
 import { variableReplacer } from './variableReplacer.ts';
 

--- a/packages/utils/Options.ts
+++ b/packages/utils/Options.ts
@@ -1,3 +1,10 @@
+/**
+ * Typed option-store plus {@link Events} emitter base class — subclasses
+ * validate values through `_processOption` and expose specific getters
+ * over a private, credential-safe store.
+ *
+ * @module
+ */
 import { type EventCallback, Events } from './Events.ts';
 import { type PrivateObject, privateObject } from './privateObject.ts';
 

--- a/packages/utils/memoize.ts
+++ b/packages/utils/memoize.ts
@@ -13,6 +13,8 @@
  * - Memory management and automatic cache cleanup
  * - Safe handling of non-serializable arguments
  * - TypeScript-first design with full type safety
+ *
+ * @module
  */
 
 /**

--- a/packages/utils/mod.ts
+++ b/packages/utils/mod.ts
@@ -1,3 +1,12 @@
+/**
+ * `@tundralibs/utils` — shared cross-runtime primitives used across the
+ * TundraLibs packages: the {@link BaseError} foundation, the
+ * {@link Options}/{@link Events} bases, config loading, memoization and
+ * throttling helpers, IP/subnet utilities, syslog parsing, and small
+ * decorators.
+ *
+ * @module
+ */
 export type {
   DeepReadOnly,
   DeepWritable,


### PR DESCRIPTION
## Summary

- add `@module` documentation to the utils entrypoints missing it: root `mod.ts`, `BaseError.ts`, `Options.ts`, `memoize.ts`

## Scope

Documentation-only, utils package. Module docs only (no `private-type-ref` changes).