### PR TITLE
docs(guardian): add module docs to sub-entrypoints

### DIFF
--- a/packages/guardian/guards/mod.ts
+++ b/packages/guardian/guards/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Concrete guard classes for `@tundralibs/guardian` — one per primitive
+ * and composite type (string, number, object, array, union, and more),
+ * each a chainable validator produced via the {@link Guardian} factory.
+ *
+ * @module
+ */
 export { ArrayGuardian } from './ArrayGuardian.ts';
 export { BigIntGuardian } from './BigIntGuardian.ts';
 export { BooleanGuardian } from './BooleanGuardian.ts';

--- a/packages/guardian/types/mod.ts
+++ b/packages/guardian/types/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Public type surface for `@tundralibs/guardian` — branding, inference
+ * helpers ({@link GuardianInfer}), transform and result shapes used to
+ * derive static types from a guard.
+ *
+ * @module
+ */
 // Export from individual type files
 export type { Brand } from './Brand.ts';
 export type { FinishedGuardian } from './FinishedGuardian.ts';


### PR DESCRIPTION
## Summary

- add `@module` documentation to the guardian `./guards` and `./types` sub-entrypoint barrels

## Scope

Documentation-only, guardian package. Module docs only.