### PR TITLE
docs(metro-man): add module docs to sub-entrypoints

### DIFF
--- a/packages/metro-man/errors/mod.ts
+++ b/packages/metro-man/errors/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Error surface for `@tundralibs/metro-man` — the base
+ * {@link MetroManError} and the typed errors raised on duplicate or
+ * misconfigured metric registration.
+ *
+ * @module
+ */
 export { MetroManError } from './Base.ts';
 export {
   type DuplicateMetricContext,

--- a/packages/metro-man/types/mod.ts
+++ b/packages/metro-man/types/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Public type surface for `@tundralibs/metro-man` — the option shapes for
+ * each metric kind (counter, gauge, histogram, and related).
+ *
+ * @module
+ */
 export type { CounterOptions } from './CounterOptions.ts';
 export type { GaugeOptions } from './GaugeOptions.ts';
 export type { HistogramOptions } from './HistogramOptions.ts';


### PR DESCRIPTION
## Summary

- add `@module` documentation to the metro-man `./errors` and `./types` sub-entrypoint barrels

## Scope

Documentation-only, metro-man package. Module docs only.