### PR TITLE
docs(oql): add module doc to ./errors entrypoint

### DIFF
--- a/packages/oql/errors/mod.ts
+++ b/packages/oql/errors/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Error surface for `@tundralibs/oql` — the base {@link OqlError}, its
+ * typed error codes, and the dialect-unsupported error raised when a
+ * query construct has no translation for the target dialect.
+ *
+ * @module
+ */
 export { OqlError, type OqlErrorMeta } from './Base.ts';
 export { type OqlErrorCode, OqlErrorCodes } from './OqlErrorCodes.ts';
 export { DialectUnsupportedError } from './DialectUnsupportedError.ts';


### PR DESCRIPTION
## Summary

- add `@module` documentation to the oql `./errors` sub-entrypoint barrel

## Scope

Documentation-only, oql package. Module docs only.