### PR TITLE
docs(radrouter): add module docs to sub-entrypoints

### DIFF
--- a/packages/radrouter/errors/mod.ts
+++ b/packages/radrouter/errors/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Error surface for `@tundralibs/radrouter` — the base
+ * {@link RadRouterError} and the typed errors raised on duplicate or
+ * invalid route registration.
+ *
+ * @module
+ */
 // Re-export every error class from one barrel. Consumers do
 // `import { DuplicateRouteError } from '@tundralibs/radrouter/errors'`.
 export { RadRouterError } from './Base.ts';

--- a/packages/radrouter/types/mod.ts
+++ b/packages/radrouter/types/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Public type surface for `@tundralibs/radrouter` — route registration,
+ * HTTP method, match, and clear-option shapes used by the router API.
+ *
+ * @module
+ */
 // Export from individual type files
 export type { ClearOptions } from './ClearOptions.ts';
 export type { HTTPMethod } from './HTTPMethod.ts';


### PR DESCRIPTION
## Summary

- add `@module` documentation to the radrouter `./types` and `./errors` sub-entrypoint barrels

## Scope

Documentation-only, radrouter package. Module docs only.