### PR TITLE
docs(tracer): document OTLPExporter constructor

### DIFF
--- a/packages/tracer/exporters/otlp/OTLPExporter.ts
+++ b/packages/tracer/exporters/otlp/OTLPExporter.ts
@@ -71,6 +71,8 @@ export class OTLPExporter extends RESTler<OTLPExporterOptions>
   ) => void;
 
   /**
+   * Construct an OTLP/HTTP span exporter.
+   *
    * @param options - See {@link OTLPExporterOptions}. `baseURL` is the
    *   collector root (e.g. `http://localhost:4318`), NOT the signal path.
    * @throws {Error} When `baseURL` is missing or invalid (raised by RESTler's


### PR DESCRIPTION
## Summary

- add a description to the `OTLPExporter` constructor JSDoc so the exported symbol is fully documented (a `@param`-only block still triggers `missing-jsdoc`)

## Scope

Documentation-only, tracer package. Symbol docs only.