### PR TITLE
docs(doctor): add module and symbol docs

### DIFF
--- a/packages/doctor/decorators/Vial.ts
+++ b/packages/doctor/decorators/Vial.ts
@@ -34,6 +34,7 @@ import type { VialModes, VialOptions } from '../types/mod.ts';
  * ```
  */
 export function Vial(mode: VialModes): ClassDecorator;
+/** Register the class with explicit {@link VialOptions}. */
 export function Vial(options: VialOptions): ClassDecorator;
 export function Vial(arg: VialModes | VialOptions): ClassDecorator {
   // deno-lint-ignore no-explicit-any

--- a/packages/doctor/decorators/mod.ts
+++ b/packages/doctor/decorators/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Dependency-injection decorators for `@tundralibs/doctor` — {@link Vial}
+ * to register a class with the container, plus {@link Dose} and
+ * {@link Inoculate} for declaring and receiving injected dependencies.
+ *
+ * @module
+ */
 export { Dose } from './Dose.ts';
 export { Inoculate } from './Inoculate.ts';
 export { Vial } from './Vial.ts';

--- a/packages/doctor/errors/Base.ts
+++ b/packages/doctor/errors/Base.ts
@@ -19,6 +19,7 @@ import { BaseError } from '@tundralibs/utils';
 export class DoctorError<
   M extends Record<string, unknown> = Record<string, unknown>,
 > extends BaseError<M> {
+  /** Emit the message verbatim; Doctor errors are written whole at the throw site. */
   protected override get _messageTemplate(): string {
     return '${message}';
   }

--- a/packages/doctor/errors/mod.ts
+++ b/packages/doctor/errors/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Error surface for `@tundralibs/doctor` — the base {@link DoctorError}
+ * and the typed errors raised on circular or unresolved dependencies.
+ *
+ * @module
+ */
 export { DoctorError } from './Base.ts';
 export {
   type CircularDependencyContext,

--- a/packages/doctor/types/Prescription.ts
+++ b/packages/doctor/types/Prescription.ts
@@ -1,4 +1,5 @@
 import type { Vial } from './Vial.ts';
+/** A single injection descriptor: which key resolves to which {@link Vial}. */
 // deno-lint-ignore no-explicit-any
 export type Prescription<T = any> = {
   key: string | symbol;

--- a/packages/doctor/types/Vial.ts
+++ b/packages/doctor/types/Vial.ts
@@ -1,2 +1,3 @@
+/** Constructor type for an injectable class registered with the container. */
 // deno-lint-ignore no-explicit-any
 export type Vial<T = any> = new (...args: any[]) => T;

--- a/packages/doctor/types/VialModes.ts
+++ b/packages/doctor/types/VialModes.ts
@@ -1,1 +1,2 @@
+/** Lifetime of a registered dependency: one instance, per-scope, or per-resolve. */
 export type VialModes = 'SINGLETON' | 'TRANSIENT' | 'SCOPED';

--- a/packages/doctor/types/mod.ts
+++ b/packages/doctor/types/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * Public type surface for `@tundralibs/doctor` — the {@link Prescription}
+ * injection descriptor, the {@link Vial} constructor type, and the
+ * {@link VialModes} lifetime union.
+ *
+ * @module
+ */
 export type { Prescription } from './Prescription.ts';
 export type { Vial } from './Vial.ts';
 export type { VialModes } from './VialModes.ts';


### PR DESCRIPTION
## Summary

- add `@module` docs to the doctor `./decorators`, `./errors`, and `./types` sub-entrypoint barrels
- add symbol JSDoc to the flagged exports: the second `Vial` overload, the `DoctorError` message-template getter, and the `Prescription` / `Vial` / `VialModes` types

## Scope

Documentation-only, doctor package. Module docs + symbol docs.