### PR TITLE
docs(drivers): add module and symbol docs to engine entrypoints

### DIFF
--- a/packages/drivers/engines/d1/D1HttpError.ts
+++ b/packages/drivers/engines/d1/D1HttpError.ts
@@ -57,6 +57,11 @@ export class D1HttpError extends DriverError<D1HttpErrorMeta> {
   /** HTTP status, when the error came from a non-2xx response. */
   public readonly status?: number;
 
+  /**
+   * Construct a D1 HTTP error.
+   *
+   * @param meta Cloudflare error `code` and HTTP `status`, when present.
+   */
   constructor(message: string, meta: D1HttpErrorMeta = {}, cause?: Error) {
     super(message, meta, cause);
     this.name = 'D1HttpError';

--- a/packages/drivers/engines/maria/mod.ts
+++ b/packages/drivers/engines/maria/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * MariaDB/MySQL engine for `@tundralibs/drivers` — {@link MariaEngine}
+ * plus the PlanetScale/Vitess alias and its option types.
+ *
+ * @module
+ */
 export { MariaEngine } from './Engine.ts';
 // Alias engine for PlanetScale/Vitess (FK enforcement + advisory locks
 // off); MySQL/Aurora/TiDB/SingleStore use MariaEngine as-is.

--- a/packages/drivers/engines/memcached/mod.ts
+++ b/packages/drivers/engines/memcached/mod.ts
@@ -1,2 +1,8 @@
+/**
+ * Memcached key-value engine for `@tundralibs/drivers` —
+ * {@link MemcachedEngine} and its option types.
+ *
+ * @module
+ */
 export { MemcachedEngine } from './Engine.ts';
 export type { MemcachedEngineOptions } from './types/mod.ts';

--- a/packages/drivers/engines/mongo/mod.ts
+++ b/packages/drivers/engines/mongo/mod.ts
@@ -1,2 +1,8 @@
+/**
+ * MongoDB engine for `@tundralibs/drivers` — {@link MongoEngine} and its
+ * option types.
+ *
+ * @module
+ */
 export { MongoEngine } from './Engine.ts';
 export type { MongoEngineOptions } from './types/mod.ts';

--- a/packages/drivers/engines/neon/NeonHttpError.ts
+++ b/packages/drivers/engines/neon/NeonHttpError.ts
@@ -49,6 +49,11 @@ export class NeonHttpError extends DriverError<NeonHttpErrorMeta> {
   /** Postgres SQLSTATE code, when available. */
   public readonly code?: string;
 
+  /**
+   * Construct a Neon HTTP error.
+   *
+   * @param meta HTTP `status` and Postgres SQLSTATE `code`, when present.
+   */
   constructor(message: string, meta: NeonHttpErrorMeta, cause?: Error) {
     super(message, meta, cause);
     this.name = 'NeonHttpError';

--- a/packages/drivers/engines/postgres/PgConnection.ts
+++ b/packages/drivers/engines/postgres/PgConnection.ts
@@ -97,13 +97,16 @@ export class PgConnection {
   private __closed = false;
   /** Server-supplied parameters captured during startup. */
   public readonly serverParams: Map<string, string> = new Map();
-  /** Process id + secret key for cancel-request. */
+  /** Process id for cancel-request. */
   public processId = 0;
+  /** Secret key for cancel-request. */
   public secretKey = 0;
   /** Last-seen transaction status from ReadyForQuery: I/T/E. */
   public txStatus: 'I' | 'T' | 'E' = 'I';
 
   /**
+   * Wrap a raw TCP connection in the Postgres wire protocol.
+   *
    * @param __conn - The underlying TCP `Connection`.
    * @param __onNotice - Called for every backend NoticeResponse (NOT errors).
    * @param __instanceId - Engine instance id used in `EngineError` metadata.
@@ -114,6 +117,7 @@ export class PgConnection {
     private readonly __instanceId: string,
   ) {}
 
+  /** Whether this connection has been closed or poisoned. */
   get closed(): boolean {
     return this.__closed;
   }
@@ -558,6 +562,7 @@ export class PgConnection {
 
   //#region IO helpers
 
+  /** Write raw bytes; marks the connection closed on transport failure. */
   private async __write(bytes: Uint8Array): Promise<void> {
     if (this.__closed) {
       throw new EngineError('NO_CONNECTION', { instanceId: this.__instanceId });
@@ -576,6 +581,7 @@ export class PgConnection {
     }
   }
 
+  /** Read and decode the next backend message, buffering partial reads. */
   private async __read(): Promise<BackendMessage> {
     while (true) {
       if (this.__writeOff > this.__readOff) {
@@ -636,6 +642,7 @@ export class PgConnection {
     this.__writeOff += chunk.length;
   }
 
+  /** Forward a backend NoticeResponse to the notice callback. */
   private __emitNotice(fields: Map<string, string>): void {
     if (!this.__onNotice) return;
     const severity = fields.get('S') ?? 'NOTICE';

--- a/packages/drivers/engines/postgres/PgServerError.ts
+++ b/packages/drivers/engines/postgres/PgServerError.ts
@@ -17,9 +17,16 @@ type PgServerErrorMeta = {
 
 /** Errors raised by `PgConnection` carrying the server's ErrorResponse fields. */
 export class PgServerError extends DriverError<PgServerErrorMeta> {
+  /** SQLSTATE code from the server ErrorResponse. */
   public readonly code: string;
+  /** Full server ErrorResponse field map. */
   public readonly fields: Map<string, string>;
 
+  /**
+   * Construct a Postgres server error from an ErrorResponse.
+   *
+   * @param fields Server ErrorResponse fields; the `M` field is the message.
+   */
   constructor(code: string, fields: Map<string, string>) {
     super(fields.get('M') ?? 'Postgres server error', { code, fields });
     this.name = 'PgServerError';

--- a/packages/drivers/engines/postgres/mod.ts
+++ b/packages/drivers/engines/postgres/mod.ts
@@ -1,3 +1,10 @@
+/**
+ * PostgreSQL engine for `@tundralibs/drivers` — {@link PostgresEngine},
+ * the Postgres-wire-compatible aliases (CockroachDB, YugabyteDB, and
+ * more), the {@link PgConnection} wrapper, and {@link PgServerError}.
+ *
+ * @module
+ */
 export { PostgresEngine } from './Engine.ts';
 // Alias engines for Postgres-wire-compatible distributed SQL (CockroachDB,
 // YugabyteDB — advisory locks off); Aurora/AlloyDB/Supabase/Timescale use

--- a/packages/drivers/engines/redis/mod.ts
+++ b/packages/drivers/engines/redis/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Redis key-value engine for `@tundralibs/drivers` — {@link RedisEngine},
+ * the {@link RedisConnection} wrapper, and its option types.
+ *
+ * @module
+ */
 export { RedisEngine } from './Engine.ts';
 export { RedisConnection } from './RedisConnection.ts';
 export type { RedisEngineOptions } from './types/mod.ts';

--- a/packages/drivers/engines/sqlite/mod.ts
+++ b/packages/drivers/engines/sqlite/mod.ts
@@ -1,2 +1,8 @@
+/**
+ * SQLite engine for `@tundralibs/drivers` — {@link SQLiteEngine} and its
+ * option types. Uses the host runtime's native SQLite binding.
+ *
+ * @module
+ */
 export { SQLiteEngine } from './Engine.ts';
 export type { SQLiteEngineOptions } from './types/mod.ts';

--- a/packages/drivers/engines/turso/TursoHttpError.ts
+++ b/packages/drivers/engines/turso/TursoHttpError.ts
@@ -54,6 +54,11 @@ export class TursoHttpError extends DriverError<TursoHttpErrorMeta> {
   /** HTTP status, when the error came from a non-2xx response. */
   public readonly status?: number;
 
+  /**
+   * Construct a Turso HTTP error.
+   *
+   * @param meta SQLite `code` and HTTP `status`, when present.
+   */
   constructor(message: string, meta: TursoHttpErrorMeta = {}, cause?: Error) {
     super(message, meta, cause);
     this.name = 'TursoHttpError';

--- a/packages/drivers/errors/mod.ts
+++ b/packages/drivers/errors/mod.ts
@@ -1,3 +1,9 @@
+/**
+ * Error surface for `@tundralibs/drivers` — the base {@link DriverError},
+ * the {@link EngineError} raised by engines, and its typed error codes.
+ *
+ * @module
+ */
 export { DriverError } from './Base.ts';
 export { EngineError, type EngineErrorMeta } from './EngineError.ts';
 export { type EngineErrorCode, EngineErrorCodes } from './EngineErrorCodes.ts';


### PR DESCRIPTION
## Summary

- add `@module` docs to the drivers `./errors`, `./maria`, `./memcached`, `./mongo`, `./postgres`, `./redis`, and `./sqlite` sub-entrypoint barrels
- add symbol JSDoc to the flagged exports: `PgConnection` (secretKey, constructor, `closed`, `__write`, `__read`, `__emitNotice`), `PgServerError` (code, fields, constructor), and the `D1HttpError` / `NeonHttpError` / `TursoHttpError` constructors

## Scope

Documentation-only, drivers package. Module docs + symbol docs (no `private-type-ref` changes).