### PR TITLE
fix(guardian): encode instead of regex-strip in sanitize(), tighten noXss()

### DIFF
--- a/packages/guardian/guards/StringGuardian.ts
+++ b/packages/guardian/guards/StringGuardian.ts
@@ -990,7 +990,8 @@ export class StringGuardian extends BaseGuardian<string> {
   }
 
   /**
-   * Validates that string does not contain common XSS patterns.
+   * Best-effort heuristic check for common XSS markers; rejects rather than
+   * cleans, and is not a substitute for context-aware output encoding.
    *
    * @param errorMessage - Optional custom error message
    * @returns A new StringGuardian with the validation applied (the receiver is never mutated)
@@ -998,14 +999,14 @@ export class StringGuardian extends BaseGuardian<string> {
   noXss(errorMessage?: string): this {
     return this.process((value: string) => {
       const xssPatterns = [
-        /<script[^>]*>.*?<\/script>/gi, // Script tags
-        /<iframe[^>]*>.*?<\/iframe>/gi, // Iframe tags
+        /<script\b[^>]*>/gi, // Script tag (opening tag alone is sufficient signal)
+        /<iframe\b[^>]*>/gi, // Iframe tag
         /on\w+\s*=\s*["'][^"']*["']/gi, // Event handlers
         /javascript:/gi, // JavaScript protocol
-        /<(img|svg)[^>]*on\w+/gi, // Image/SVG with events
+        /<(img|svg)\b[^>]*\bon\w+/gi, // Image/SVG with events
         /expression\s*\(/gi, // CSS expressions
-        /<\s*link[^>]*>/gi, // Link tags
-        /<\s*meta[^>]*>/gi, // Meta tags
+        /<\s*link\b[^>]*>/gi, // Link tags
+        /<\s*meta\b[^>]*>/gi, // Meta tags
       ];
 
       for (const pattern of xssPatterns) {
@@ -2134,7 +2135,9 @@ export class StringGuardian extends BaseGuardian<string> {
   }
 
   /**
-   * Sanitizes the string by removing/escaping dangerous characters.
+   * HTML-entity encodes `& < > " '`. Encoding, not tag-stripping, is the
+   * complete defense for HTML text/attribute context — a regex tag filter
+   * is trivially bypassed, so this method no longer attempts one.
    *
    * @returns A new StringGuardian with the validation applied (the receiver is never mutated)
    */
@@ -2142,15 +2145,6 @@ export class StringGuardian extends BaseGuardian<string> {
     return this.process(
       (value: string) =>
         value
-          // Remove script tags and their content
-          .replaceAll(/<script[^>]*>.*?<\/script>/gi, '')
-          // Remove iframe tags and their content
-          .replaceAll(/<iframe[^>]*>.*?<\/iframe>/gi, '')
-          // Remove event handlers
-          .replaceAll(/on\w+\s*=\s*["'][^"']*["']/gi, '')
-          // Remove javascript: protocol
-          .replaceAll(/javascript:/gi, '')
-          // Escape HTML entities
           .replaceAll('&', '&amp;')
           .replaceAll('<', '&lt;')
           .replaceAll('>', '&gt;')

--- a/packages/guardian/tests/guards/StringGuardian.test.ts
+++ b/packages/guardian/tests/guards/StringGuardian.test.ts
@@ -876,12 +876,18 @@ describe('guardian.StringGuardian', () => {
       const schema = new StringGuardian().sanitize();
 
       asserts.assertEquals(schema.parse('normal text'), 'normal text');
-      asserts.assertEquals(schema.parse("<script>alert('bad')</script>"), '');
+      asserts.assertEquals(
+        schema.parse("<script>alert('bad')</script>"),
+        '&lt;script&gt;alert(&#x27;bad&#x27;)&lt;/script&gt;',
+      );
       asserts.assertEquals(
         schema.parse('Hello & <world>'),
         'Hello &amp; &lt;world&gt;',
       );
-      asserts.assertEquals(schema.parse('onclick="alert(1)"'), '');
+      asserts.assertEquals(
+        schema.parse('onclick="alert(1)"'),
+        'onclick=&quot;alert(1)&quot;',
+      );
     });
 
     it('normalizeSpace transformation', () => {


### PR DESCRIPTION
## Summary

Fixes 4 high-severity CodeQL alerts in `packages/guardian/guards/StringGuardian.ts` (`js/bad-tag-filter` x2, `js/incomplete-multi-character-sanitization` x3, `js/incomplete-url-scheme-check`).

- **`sanitize()`**: now HTML-entity encodes only (`& < > " '`). Removed the regex-based tag/event-handler/protocol stripping — regex tag filtering is trivially bypassed (nested/malformed tags, obfuscated schemes) and CodeQL flagged it as such. Full entity encoding is the correct, complete defense for HTML text/attribute context.
- **`noXss()`**: kept as a heuristic, best-effort reject validator (it throws, it doesn't clean), but the script/iframe patterns now match the opening tag only, dropping the paired open/close-tag regex CodeQL flags as an unreliable filter shape. Behavior for the existing test cases is unchanged.

Both methods are used only in their own two unit tests — no other package depends on them, so blast radius is contained to this package.

## Behavior change (breaking, semver-relevant)

`sanitize()` no longer strips `<script>`/`<iframe>`/event-handler content — it encodes it, so it remains present as inert escaped text. This is the recommended fix: encoding is complete/correct, whereas the old removal was incomplete/bypassable. `noXss()`'s public behavior (throws on the same three test cases) is unchanged.

## Verification

- `deno test --allow-all packages/guardian` — 38 passed (2092 steps), 0 failed
- `deno lint packages/guardian/guards/StringGuardian.ts` — clean
- `deno fmt` applied

## Scope

Guardian package only. Does not touch the pre-existing `private-type-ref` doc-lint issues (out of scope, tracked separately).