### PR TITLE
fix(norm): harden doc-emitter escaping and use crypto RNG for lock token

### DIFF
--- a/packages/norm/definition/docs.ts
+++ b/packages/norm/definition/docs.ts
@@ -34,16 +34,16 @@ function mmId(name: string): string {
  * sequence inside double quotes — substitute them, collapse every line-break
  * variant (a lone `\r` included, not just `\r\n`). */
 function mmText(v: string): string {
-  return v.replace(/"/g, "'").replace(/\r\n?|\n/g, ' ');
+  return v.replaceAll('"', "'").replaceAll(/\r\n?|\n/g, ' ');
 }
 
 /** Escape a value for a GFM table cell: backslash first (so it can't
  * collide with our own escape), then pipes, then every line-break variant. */
 function mdCell(v: string): string {
-  return v.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(
-    /\r\n?|\n/g,
-    ' ',
-  );
+  return v
+    .replaceAll('\\', String.raw`\\`)
+    .replaceAll('|', '\\|')
+    .replaceAll(/\r\n?|\n/g, ' ');
 }
 
 /** Render a column's SQL-ish type (`VARCHAR(255)`, `DECIMAL(12,2)`). */

--- a/packages/norm/definition/docs.ts
+++ b/packages/norm/definition/docs.ts
@@ -31,14 +31,19 @@ function mmId(name: string): string {
 }
 
 /** Mermaid quoted-string slot: the erDiagram grammar has NO escape
- * sequence inside double quotes — substitute them, collapse newlines. */
+ * sequence inside double quotes — substitute them, collapse every line-break
+ * variant (a lone `\r` included, not just `\r\n`). */
 function mmText(v: string): string {
-  return v.replace(/"/g, "'").replace(/\r?\n/g, ' ');
+  return v.replace(/"/g, "'").replace(/\r\n?|\n/g, ' ');
 }
 
-/** Escape a value for a GFM table cell (pipes and newlines). */
+/** Escape a value for a GFM table cell: backslash first (so it can't
+ * collide with our own escape), then pipes, then every line-break variant. */
 function mdCell(v: string): string {
-  return v.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+  return v.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(
+    /\r\n?|\n/g,
+    ' ',
+  );
 }
 
 /** Render a column's SQL-ish type (`VARCHAR(255)`, `DECIMAL(12,2)`). */

--- a/packages/norm/migrations/FileLock.ts
+++ b/packages/norm/migrations/FileLock.ts
@@ -84,6 +84,14 @@ function ownerLabel(): string {
   }
 }
 
+/** Cryptographically random suffix for the lock token (not a security
+ * boundary — just avoids the platform PRNG's predictability). */
+function randomSuffix(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 /**
  * Cross-process advisory lock backed by an exclusive `migrator.lock`
  * file in the migrations directory, so two machines can't run `apply()`
@@ -105,9 +113,7 @@ export class FileLock {
    */
   constructor(dir: string, staleMs: number = DEFAULT_STALE_MS) {
     this.#path = `${dir}/${LOCK_FILE}`;
-    this.#token = `${Date.now().toString(36)}-${
-      Math.random().toString(36).slice(2, 10)
-    }`;
+    this.#token = `${Date.now().toString(36)}-${randomSuffix()}`;
     this.#owner = ownerLabel();
     this.#staleMs = staleMs;
   }


### PR DESCRIPTION
## Summary

- **`packages/norm/definition/docs.ts`** — fixes `js/incomplete-sanitization`. `mmText`/`mdCell` collapsed only `\r\n`, missing a lone `\r` (old Mac line endings); `mdCell` also didn't escape a pre-existing backslash before adding its own pipe-escape backslash, letting the two collide. Both now: escape backslash first (in `mdCell`), then collapse any `\r`/`\n` variant.
- **`packages/norm/migrations/FileLock.ts`** — fixes `S2245` (insecure randomness). The lock token's random suffix used `Math.random()`; swapped to `crypto.getRandomValues()`. Not a security boundary (single-machine lock ownership is just an equality check on an opaque string), but removes the flagged weak-RNG pattern.

## Verification

- `deno test --allow-all` on the norm suites exercising these paths (`definition/schema.test.ts`, `definition/edges.test.ts`, `project.test.ts`, `migrations/migrations.test.ts`) — 10 passed (74 steps), 0 failed
- `deno lint` / `deno fmt` clean

## Scope

norm package only, two independent minor hardening fixes bundled in one PR (both `packages/norm`).