### PR TITLE
fix(drivers): stop echoing raw error.message in neon test proxy 500s

### DIFF
--- a/packages/drivers/engines/neon/_neonPgProxy.ts
+++ b/packages/drivers/engines/neon/_neonPgProxy.ts
@@ -203,9 +203,12 @@ async function _handleSql(
       // the engine maps `code` (SQLSTATE) → EngineError code.
       return _errorResponse(400, _pgErrorToNeonJson(error));
     }
-    return _errorResponse(500, {
-      message: error instanceof Error ? error.message : String(error),
-    });
+    // Unexpected (non-PgServerError) failure: log the real error to the test
+    // process's own console (the proxy runs in-process with the live test, so
+    // this reaches the same terminal/CI log) rather than echoing it back over
+    // HTTP.
+    console.error('[neon-pg-proxy] unexpected error handling /sql:', error);
+    return _errorResponse(500, { message: 'internal server error' });
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes `js/stack-trace-exposure` in `packages/drivers/engines/neon/_neonPgProxy.ts` — the test-only local Neon-over-HTTP proxy used by `Engine.live.test.ts`.

The catch-all 500 branch was echoing the caught error's raw `.message` back in the HTTP response body. Since `startNeonPgProxy` runs `Deno.serve` in-process with the live test itself, the fix routes the real error to `console.error` instead (landing in the exact same terminal/CI log) and returns a fixed generic message over HTTP.

No debuggability lost, no behavior change for the intentional error path (`PgServerError` → real SQLSTATE JSON, untouched — that's the path the error-mapping tests exercise).

## Verification

- `deno test --allow-all packages/drivers/engines/neon/Engine.live.test.ts` — 1 passed (10 steps), including the error-mapping suite, against a real local Postgres
- `deno lint` / `deno check` / `deno fmt` clean

## Scope

drivers package, single file, not part of any public entrypoint (`_neonPgProxy.ts` is test-only tooling, not exported in `deno.json`).