### PR TITLE
fix(utils): stop getFreePort's published .d.ts degrading to never

### DIFF
--- a/.github/scripts/consumer-doc-check.ts
+++ b/.github/scripts/consumer-doc-check.ts
@@ -26,8 +26,18 @@
  * generated `_dist/*.d.ts`, which the overlay does not regenerate. So a fix
  * whose only effect is in the emitted declaration (e.g. exporting a type that
  * was previously inlined, which stops a parameter degrading to `never`) will
- * NOT show green under `--local` even when correct — verify those with
- * `deno publish --dry-run` in the package instead.
+ * NOT show green under `--local` even when correct.
+ *
+ * ⚠️ `deno publish --dry-run` does NOT reliably catch this class of bug
+ * either — its "slow types" check verifies the package is fast-check
+ * COMPATIBLE, not that the emitted `.d.ts` is CORRECT. Confirmed
+ * 2026-08-17: `getFreePort`'s destructured-in-the-signature parameter
+ * passed `--dry-run` clean while the real published tarball (utils
+ * 1.0.5) still emitted `(_dts_1: never)` for it — a signature-position
+ * destructuring pattern JSR's npm-compat generator mishandles even when
+ * "slow types" has nothing to flag. The only fully reliable
+ * verification for a declaration-emission fix is: republish, then
+ * re-run this check (without `--local`) against the real thing.
  *
  * @module
  */
@@ -176,9 +186,10 @@ for (const pkg of packages) {
       // for) is exercised faithfully. But a symbol's TYPES still resolve through
       // the installed `_dist/*.d.ts`, which the overlay does not regenerate. A
       // fix whose only effect is in the emitted declaration therefore stays red
-      // under `--local` until the package republishes — verify that class with
-      // `deno publish --dry-run` in the package instead (it runs JSR's
-      // slow-type check, the exact thing that shapes the `.d.ts`).
+      // under `--local` until the package republishes — `deno publish --dry-run`
+      // is NOT a substitute (its slow-type check misses at least one real bug
+      // class; see the module docstring). Republish, then re-run this check
+      // WITHOUT `--local` to confirm.
       await overlay(`packages/${pkg}`, installed);
       version = `${version}+worktree`;
     }

--- a/packages/utils/getFreePort.ts
+++ b/packages/utils/getFreePort.ts
@@ -54,11 +54,17 @@ export class PortError extends Error {
  * const port = await getFreePort({ min: 3000, max: 3999 });
  * ```
  */
-export const getFreePort = async ({
-  min = 1024,
-  max = 65535,
-  exclude = [],
-}: GetFreePortOptions = {}): Promise<number> => {
+export const getFreePort = async (
+  options: GetFreePortOptions = {},
+): Promise<number> => {
+  // Destructured in the BODY, not the signature — JSR's npm-compat
+  // `.d.ts` generation degrades a signature-position destructuring
+  // pattern to an unusable `(_dts_1: never)`, even though the pattern
+  // is otherwise "fast-check" clean (`deno publish --dry-run` does not
+  // catch it — confirmed 2026-08-17 against a real consumer install of
+  // utils 1.0.5). A plain named parameter has no pattern to mis-emit.
+  const { min = 1024, max = 65535, exclude = [] } = options;
+
   // Validate input parameters
   if (min < 0 || min > 65535) {
     throw new PortError('Minimum port must be between 0 and 65535');


### PR DESCRIPTION
## Root cause of the weekly health check failure

The failing job is `Shipped doc examples (consumer install)` — every other job (runtime drift ×6, dependency audit) passed. Only `utils v1.0.5` failed, with the exact same `never`-degradation symptom #299 fixed, but from a different cause.

Reproduced locally against the REAL published package (`npx jsr add @tundralibs/utils`, not a simulation):

```
export declare const getFreePort: (_dts_1: never) => Promise<number>;
```

`GetFreePortOptions` is correctly exported (#299's fix held). The new cause: `getFreePort`'s parameter is destructured directly in the function signature —

```ts
export const getFreePort = async ({ min = 1024, max = 65535, exclude = [] }: GetFreePortOptions = {}) => { ... }
```

TypeScript's own `isolatedDeclarations` handles this fine (verified locally with `tsc`), but JSR's npm-compat `.d.ts` generator does not — it synthesizes an unusable placeholder parameter (`_dts_1: never`) for a signature-position destructuring pattern. `getFreePort` was the *only* exported function anywhere in the suite using this pattern; everywhere else already destructures in the function body.

## Fix

Take a plain named `options` parameter and destructure inside the body instead. No behavior change — 15 test steps green, `deno check`/`fmt`/`lint` clean.

## Also fixed: `consumer-doc-check.ts`'s own guidance was wrong

Its comments pointed at `deno publish --dry-run` as sufficient verification for exactly this class of fix. I confirmed that's false: `deno publish --dry-run`'s "slow types" check passed cleanly for the *broken* signature — it verifies fast-check compatibility, not that the emitted `.d.ts` is correct. Corrected the guidance so this doesn't get trusted again.

## ⚠️ This needs a republish to actually close the loop

The check tests the *published tarball*, so merging this alone won't turn the weekly job green — `utils` needs to release again (1.0.6) and then the check needs a rerun against the real thing. Flagging for the merge/release decision rather than doing it myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)