### PR TITLE
ci: close the ci-health issue automatically on a green weekly run

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -213,6 +213,29 @@ jobs:
       - name: Check shipped docs from a consumer install
         run: deno run -A .github/scripts/consumer-doc-check.ts
 
+  close-on-success:
+    name: Close health issue on a green run
+    needs: [drift, audit, consumer-docs]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close any open health issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --label ci-health --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "Resolved — this run passed: ${RUN_URL}"
+            echo "Closed issue #$existing"
+          else
+            echo "No open health issue to close"
+          fi
+
   report:
     name: File issue on failure
     needs: [drift, audit, consumer-docs]


### PR DESCRIPTION
Follow-up to the discussion on #335/#334 — the weekly health workflow's `report` job only ever creates or comments on the `ci-health` issue on `failure()`. There's no path that closes it, so once filed it stays open forever, even after the underlying problem is fixed and a later run is fully green — it needs a manual `gh issue close`.

## Fix

A sibling job, `close-on-success`, gated the opposite way from `report` (`if: success()` against the same `needs: [drift, audit, consumer-docs]`). Exactly one of the two jobs runs per invocation. On a pass, it closes any open `ci-health`-labeled issue with a comment linking the passing run.

Validated with `actionlint` against the whole `.github/workflows/` directory — zero findings.

Note: this does **not** retroactively close #334 — that issue reflects the utils 1.0.5 doc-check failure fixed in #335, which still needs a republish (utils 1.0.6, staged as #325) before a run will actually go green and exercise this new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)