### PR TITLE
fix(restler): CUSTOM-auth signing, query encoding, FORM urlencoded, BASIC empty password, skipAuth, and responseSchema

### DIFF
--- a/packages/restler/README.md
+++ b/packages/restler/README.md
@@ -223,16 +223,26 @@ Set `contentType` (and `payload`) on a body-bearing endpoint. The body is
 serialized and a default `Content-Type` header is set when you haven't
 provided one.
 
-| `contentType` | `payload` type            | Serialized as / `Content-Type`               |
-| ------------- | ------------------------- | -------------------------------------------- |
-| `JSON`        | `Record<string, unknown>` | `JSON.stringify` / `application/json`        |
-| `XML`         | `Record<string, unknown>` | XML string / `application/xml`               |
-| `FORM`        | `FormData`                | `FormData` (the runtime sets the boundary)\* |
-| `TEXT`        | `string`                  | raw string / `text/plain`                    |
-| `BLOB`        | `Blob`                    | the `Blob` as-is                             |
+| `contentType` | `payload` type                    | Serialized as / `Content-Type`                              |
+| ------------- | --------------------------------- | ----------------------------------------------------------- |
+| `JSON`        | `Record<string, unknown>`         | `JSON.stringify` / `application/json`                       |
+| `XML`         | `Record<string, unknown>`         | XML string / `application/xml`                              |
+| `FORM`        | `FormData`                        | `FormData` (the runtime sets the boundary)\*                |
+| `FORM`        | `URLSearchParams` or plain object | urlencoded string / `application/x-www-form-urlencoded`\*\* |
+| `TEXT`        | `string`                          | raw string / `text/plain`                                   |
+| `BLOB`        | `Blob`                            | the `Blob` as-is                                            |
 
-\* For `FORM`, any inherited `Content-Type` header is removed so `fetch` can
-set the correct `multipart/form-data` boundary.
+\* For a `FormData` payload, any inherited `Content-Type` header is removed
+so `fetch` can set the correct `multipart/form-data` boundary.
+
+\*\* `FORM`'s wire format is decided by the payload's SHAPE — a `URLSearchParams`
+or plain object sends `application/x-www-form-urlencoded`, the format
+essentially every OAuth2 token exchange (and Stripe's whole API) requires.
+`URLSearchParams`'s own serializer (space → `+`) is used here, which is
+correct for this media type — note this is DIFFERENT from `endpoint.query`
+(the URL's query string), which is percent-encoded per RFC 3986
+(space → `%20`) instead, since a `+` there breaks any signing-based auth
+that re-derives a canonical query string (e.g. AWS SigV4).
 
 The response body is parsed from its `Content-Type`: `*/json` → object,
 `*/xml` → object, `*/*text*` → string; an unknown/empty type is best-effort
@@ -275,8 +285,10 @@ console.log(res.body?.size, res.body?.type); // Blob size and MIME type
 `RESTlerOptions`) or per request (on the endpoint — the endpoint wins).
 
 ```typescript ignore
-// Basic — sends `Authorization: Basic base64(user:pass)`
+// Basic — sends `Authorization: Basic base64(user:pass)`. An EMPTY password
+// is valid (RFC 7617) — e.g. Stripe's `sk_live_...:` pattern.
 { type: 'BASIC', username: 'user', password: 'secret' }
+{ type: 'BASIC', username: 'sk_live_abc123', password: '' }
 
 // Bearer — sends `Authorization: <prefix> <token>` (prefix defaults to "BEARER")
 { type: 'BEARER', token: 'abc123' }
@@ -318,6 +330,94 @@ class WeatherAPI extends RESTler {
       method: 'GET',
       query: { q: city, units: 'metric' },
     });
+  }
+}
+```
+
+### Signing-based auth (HMAC, SigV4-style)
+
+By the time `_authInjector` runs, `endpoint.headers` already holds the
+**full** outbound header set — instance-level defaults, `headerProvider()`'s
+output, and the caller's own explicit headers, already merged (the caller's
+own entries win on a collision). A signature computed over `endpoint.headers`
+therefore covers everything actually sent, not just whatever the caller
+happened to pass to one particular call. The one exception: the default
+`Content-Type` for JSON/XML/TEXT payloads is computed later, in `_buildBody`
+— to sign it, set `Content-Type` explicitly on `endpoint.headers` yourself
+before calling `_makeRequest`.
+
+`_base64Utf8(value: string): string` is `protected`, not `private` — reuse
+it for Basic-style header encoding in your own scheme instead of
+reimplementing UTF-8-correct base64.
+
+```typescript
+import { RESTler } from '@tundralibs/restler';
+import type { RESTlerEndpoint } from '@tundralibs/restler';
+
+class SignedAPI extends RESTler {
+  public readonly vendor = 'signed-vendor';
+
+  constructor(private secret: string) {
+    super({ baseURL: 'https://api.example.com' });
+  }
+
+  protected override _authInjector(endpoint: RESTlerEndpoint): void {
+    // endpoint.headers is already the FULL set — sign it as-is.
+    const signature = this.sign(endpoint.headers ?? {}, this.secret);
+    endpoint.headers = { ...endpoint.headers, 'X-Signature': signature };
+  }
+
+  private sign(_headers: Record<string, string>, _secret: string): string {
+    return 'computed-signature'; // real HMAC/SigV4 canonicalization goes here
+  }
+}
+```
+
+### OAuth2 token exchange (`skipAuth`)
+
+A `CUSTOM` auth that fetches its own token needs to make a request as part
+of `_authInjector` — but `_authInjector` runs unconditionally on every
+`_makeRequest` call, so a token-fetch that itself called `_makeRequest`
+would recurse into its own `_authInjector` before the token exists.
+`skipAuth: true` on that ONE call breaks the recursion while keeping
+everything else `_makeRequest` normally provides — timeout/abort, the
+`call` event, error normalization, witness/tracing:
+
+```typescript
+import { RESTler } from '@tundralibs/restler';
+import type { RESTlerEndpoint } from '@tundralibs/restler';
+
+class OAuth2API extends RESTler {
+  public readonly vendor = 'oauth2-vendor';
+  private token: string | undefined;
+
+  constructor(private clientId: string, private clientSecret: string) {
+    super({ baseURL: 'https://api.example.com' });
+  }
+
+  protected override async _authInjector(
+    endpoint: RESTlerEndpoint,
+  ): Promise<void> {
+    if (this.token === undefined) {
+      const res = await this._makeRequest<{ access_token: string }>(
+        {
+          path: '/oauth/token',
+          method: 'POST',
+          contentType: 'FORM',
+          payload: {
+            grant_type: 'client_credentials',
+            client_id: this.clientId,
+            client_secret: this.clientSecret,
+          },
+        },
+        { skipAuth: true }, // <- breaks the recursion
+      );
+      this.token = res.body?.access_token;
+    }
+    endpoint.headers = {
+      ...endpoint.headers,
+      Authorization: `Bearer ${this.token}`,
+    };
   }
 }
 ```
@@ -557,19 +657,47 @@ RESTler — see
 
 Some APIs report failures inside a successful HTTP response — a `200` whose
 body is `{ "ok": false, "error": "…" }`, or a success envelope wrapping the
-real data. A **response handler** translates that vendor convention in one
-place. It runs after the body has been parsed (so it is independent of
-JSON/XML/TEXT handling), on every response — error statuses and empty bodies
-included. In the handler you can:
+real data. Others just don't guarantee their response actually matches what
+you expect — a vendor's contract can silently change. `_makeRequest`'s second
+argument is an OPTIONS bag with two independently optional hooks that compose
+into one pipeline, plus `skipAuth` (see
+[OAuth2 token exchange](#oauth2-token-exchange-skipauth)):
+
+```typescript ignore
+_makeRequest(endpoint, {
+  responseHandler?: (response) => H | Promise<H>,
+  responseSchema?: (data: H) => B | Promise<B>,
+  skipAuth?: boolean,
+})
+```
+
+```
+raw parsed body
+  → if responseHandler present: data = await responseHandler(response)   // full response — status/headers visible, not just body
+  → if responseSchema present:  data = await responseSchema(data)        // data = raw body if no handler ran, handler's output otherwise
+  → response.body = data
+```
+
+Neither present → today's default (the parsed body, untouched). Only one
+present → its result is final. Both present → the handler's output feeds the
+schema.
+
+### `responseHandler`
+
+Runs on every response — error statuses and empty bodies included — so it
+can translate a vendor convention. It receives the FULL `RESTlerResponse`
+(status/headers included, not just the body):
 
 - **throw** to reject the request (throw a `RESTlerError` subclass to surface
   it unwrapped; other errors are wrapped in `RESTlerRequestError` with the
   original as `cause`), or
-- **mutate `response.body`** to unwrap an envelope.
+- **return** the value the request resolves to — an unwrapped envelope, or
+  simply `response.body` unchanged if nothing needs transforming. There is
+  no mutate-in-place channel; the return value IS the result.
 
 Set a vendor-wide default via the protected `_responseHandler` field, or pass
-a handler per call as the second argument of `_makeRequest` (which takes
-precedence).
+`responseHandler` per call (which takes precedence entirely — it does not
+compose with the vendor default; only one of the two ever runs).
 
 ```typescript
 import { RESTler, RESTlerRequestError } from '@tundralibs/restler';
@@ -589,7 +717,7 @@ class PaymentAPI extends RESTler {
         request: { url: response.url, method: 'GET', timeout: 30 },
       });
     }
-    response.body = body?.data; // unwrap: callers see the payload directly
+    return body?.data; // unwrap: callers see the payload directly
   };
 
   constructor() {
@@ -604,31 +732,106 @@ class PaymentAPI extends RESTler {
   }
 
   // A per-call handler overrides the vendor default when one endpoint
-  // deviates from the convention.
+  // deviates from the convention. Must return `response.body` explicitly
+  // to leave it unchanged.
   rawHealth() {
-    return this._makeRequest({ path: '/health', method: 'GET' }, () => {});
+    return this._makeRequest({ path: '/health', method: 'GET' }, {
+      responseHandler: (response) => response.body,
+    });
   }
 }
 ```
+
+### `responseSchema`
+
+A plain runtime validator/parser — `(data: H) => B | Promise<B>` — for the
+value the request ultimately resolves to. `B` is INFERRED from the schema's
+return type, so you no longer separately write out (and manually keep in
+sync) a type argument that nothing actually checked against the wire.
+
+**No coupling to any particular validation library** — a
+[`@tundralibs/guardian`](https://jsr.io/@tundralibs/guardian) schema's own
+`.parse` satisfies the signature directly, and so does any hand-rolled
+function:
+
+```typescript
+import { RESTler } from '@tundralibs/restler';
+
+class UserAPI extends RESTler {
+  public readonly vendor = 'users';
+
+  constructor() {
+    super({ baseURL: 'https://api.example.com' });
+  }
+
+  getUser(id: string) {
+    return this._makeRequest(
+      { path: `/users/${id}`, method: 'GET' },
+      {
+        responseSchema: (data) => {
+          // A real schema would be e.g. `(d) => UserSchema.parse(d)`.
+          const d = data as { id: string; name: string };
+          if (typeof d.id !== 'string') throw new Error('missing id');
+          return { id: d.id, name: d.name };
+        },
+      },
+    );
+  }
+}
+```
+
+A thrown validation error (a `GuardianError`, or whatever your schema
+throws) surfaces as `RESTlerResponseValidationError` — distinct from a
+transport failure or timeout: the request SUCCEEDED, but what came back
+didn't match what you declared to expect. See
+[Error Handling](#error-handling).
+
+### Wrapped envelopes: a schema alone, no handler needed
+
+`responseHandler` is not required to unwrap an envelope — a schema that
+itself encodes the "wrapped or not" shape (e.g. via a discriminated union)
+can validate the RAW body directly:
+
+```typescript ignore
+import { Guardian } from '@tundralibs/guardian';
+
+const Envelope = <T>(inner: ReturnType<typeof Guardian.object>) =>
+  Guardian.discriminatedUnion('status', [
+    Guardian.object({ status: Guardian.literal('ok'), data: inner }),
+    Guardian.object({ status: Guardian.literal('error'), error: ErrorSchema }),
+  ]);
+
+this._makeRequest(endpoint, {
+  responseSchema: (data) => Envelope(UserSchema).parse(data),
+});
+```
+
+A non-throw no longer implies success here — it means the response matched
+ONE of the declared shapes. `response.body` is the real discriminated union;
+narrow on it afterward (`if (response.body.status === 'error')`) with full
+type safety, instead of being forced into exception-based control flow for
+an expected error shape.
 
 ## Error Handling
 
 `_makeRequest` rejects on transport failures (it attaches the error to
 `response.error` and re-throws it). HTTP error statuses do not reject —
 unless a [response handler](#vendor-response-handling) inspects the body and
-throws.
+throws, or a [response schema](#responseschema) rejects the response.
 
-| Error                 | Thrown when                                                                |
-| --------------------- | -------------------------------------------------------------------------- |
-| `RESTlerConfigError`  | Invalid client options or endpoint config (bad `baseURL`/`port`/`auth`/…). |
-| `RESTlerTimeoutError` | The request exceeded `timeout`.                                            |
-| `RESTlerRequestError` | Any other failure while making the request.                                |
-| `RESTlerError`        | Base class for all of the above.                                           |
+| Error                            | Thrown when                                                                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RESTlerConfigError`             | Invalid client options or endpoint config (bad `baseURL`/`port`/`auth`/…).                                                                             |
+| `RESTlerTimeoutError`            | The request exceeded `timeout`.                                                                                                                        |
+| `RESTlerResponseValidationError` | `responseSchema` threw — the request succeeded, but the response didn't match what you declared to expect. The original error is preserved as `cause`. |
+| `RESTlerRequestError`            | Any other failure while making the request. `RESTlerTimeoutError` and `RESTlerResponseValidationError` are both subclasses.                            |
+| `RESTlerError`                   | Base class for all of the above.                                                                                                                       |
 
 ```typescript
 import {
   RESTlerError,
   type RESTlerResponse,
+  RESTlerResponseValidationError,
   RESTlerTimeoutError,
 } from '@tundralibs/restler';
 
@@ -648,6 +851,12 @@ try {
 } catch (err) {
   if (err instanceof RESTlerTimeoutError) {
     console.error('timed out');
+  } else if (err instanceof RESTlerResponseValidationError) {
+    // Retrying won't fix this the way retrying a timeout might — the
+    // vendor's response no longer matches its declared contract.
+    console.error(
+      `response schema rejected it: ${(err.cause as Error)?.message}`,
+    );
   } else if (err instanceof RESTlerError) {
     console.error(`request failed: ${err.message}`);
   } else {
@@ -671,14 +880,22 @@ validates and stores options; `defaults` are applied where `options` omit them.
 
 **Protected members (used by / overridable in your subclass):**
 
-- `_makeRequest<T>(endpoint: RESTlerEndpoint, responseHandler?: RESTlerResponseHandler): Promise<RESTlerResponse<T>>`
-  — perform a request. Throws `RESTlerTimeoutError` / `RESTlerRequestError` /
-  `RESTlerConfigError`. The optional `responseHandler` interprets the parsed
-  response (see [Vendor Response Handling](#vendor-response-handling)).
+- `_makeRequest<H, B>(endpoint: RESTlerEndpoint, options?: RESTlerRequestOptions<H, B>): Promise<RESTlerResponse<B>>`
+  — perform a request. Throws `RESTlerTimeoutError` / `RESTlerResponseValidationError` /
+  `RESTlerRequestError` / `RESTlerConfigError`. `options.responseHandler` and
+  `options.responseSchema` compose into one pipeline; `options.skipAuth`
+  skips `_authInjector` for this one call (see
+  [Vendor Response Handling](#vendor-response-handling)).
 - `_responseHandler?: RESTlerResponseHandler` — vendor-wide default response
-  handler; a per-call handler overrides it.
+  handler; `options.responseHandler` overrides it entirely (the two do not
+  compose with each other).
 - `_authInjector(endpoint): void | Promise<void>` — inject auth. Override for
-  custom schemes; may be async.
+  custom schemes; may be async. By the time it runs, `endpoint.headers`
+  already holds the FULL outbound set (defaults + `headerProvider` +
+  caller-explicit), so a signing scheme can sign everything actually sent.
+- `_base64Utf8(value: string): string` — UTF-8-correct base64 encoding,
+  identical across Deno/Bun/Node; reuse it in a `CUSTOM` auth override
+  instead of reimplementing it.
 - `_fetch: typeof fetch` — the `fetch` implementation (compat's by default).
   Override to supply a custom transport or a stub; plain `fetch` works for any
   request that doesn't use `socketPath` or `tls`.
@@ -695,16 +912,26 @@ validates and stores options; `defaults` are applied where `options` omit them.
   optional `baseURL`, `port`, `version`, `auth`, `query`, `headers`, `timeout`,
   `responseType` (`'BLOB' | 'ARRAY_BUFFER'`, see
   [Binary Responses](#binary-responses)), and (for body methods)
-  `contentType` + `payload`.
+  `contentType` + `payload`. `path` is NORMALIZED via `path.join` against the
+  base URL (`//` collapses, `.`/`..` resolve) — percent-encode an opaque,
+  caller-controlled segment (an object-storage key, a filename) yourself
+  first if it could plausibly contain those sequences.
 - `RESTlerResponse<T>` — `{ url, status, statusText, headers?, body?, error?, timeTaken }`.
-- `RESTlerResponseHandler` —
-  `(response: RESTlerResponse<unknown>) => void | Promise<void>`; the vendor
-  hook described in [Vendor Response Handling](#vendor-response-handling).
+- `RESTlerRequestOptions<H, B>` — `_makeRequest`'s options bag:
+  `{ responseHandler?, responseSchema?, skipAuth? }`. See
+  [Vendor Response Handling](#vendor-response-handling).
+- `RESTlerResponseHandler<H>` —
+  `(response: RESTlerResponse<unknown>) => H | Promise<H>`; the vendor hook
+  described in [Vendor Response Handling](#vendor-response-handling).
+- `RESTlerResponseSchema<H, B>` — `(data: H) => B | Promise<B>`; the runtime
+  validator described in [`responseSchema`](#responseschema). Plain
+  function, no coupling to any particular validation library.
 - `RESTlerAuth` — `BASIC | BEARER | CUSTOM` discriminated union.
   `RESTlerAuthTypes` is the discriminator; `RESTlerAuthBasic`
-  (`{ username, password }`) and `RESTlerAuthBearer` (`{ token, prefix? }`)
-  are the per-scheme payloads.
-- `RESTlerContentType` — `'JSON' | 'XML' | 'FORM' | 'TEXT' | 'BLOB'`.
+  (`{ username, password }` — password may be empty, RFC 7617) and
+  `RESTlerAuthBearer` (`{ token, prefix? }`) are the per-scheme payloads.
+- `RESTlerContentType` — `'JSON' | 'XML' | 'FORM' | 'TEXT' | 'BLOB'`. `FORM`'s
+  wire format depends on the payload's shape — see [Content Types](#content-types).
 - `RESTlerMethod` — `'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS'`.
 - `RESTlerEvents` — the event handler signatures.
 - `RESTlerErrorMeta` — metadata carried by every `RESTlerError`: `vendor` plus

--- a/packages/restler/RESTler.ts
+++ b/packages/restler/RESTler.ts
@@ -18,6 +18,7 @@ import type {
   RESTlerEvents,
   RESTlerOptions,
   RESTlerRequest,
+  RESTlerRequestOptions,
   RESTlerResponse,
   RESTlerResponseHandler,
 } from './types/mod.ts';
@@ -25,6 +26,7 @@ import {
   RESTlerConfigError,
   RESTlerError,
   RESTlerRequestError,
+  RESTlerResponseValidationError,
   RESTlerTimeoutError,
 } from './errors/mod.ts';
 
@@ -102,10 +104,13 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
   protected _fetch: typeof globalThis.fetch = fetch;
 
   /**
-   * Vendor-wide default response handler, applied to every request unless a
-   * per-call handler is passed to {@link _makeRequest}. Use it when the
-   * vendor has one response convention (e.g. errors inside a 200 envelope)
-   * that every endpoint shares.
+   * Vendor-wide default response handler, applied to every request unless
+   * `options.responseHandler` is passed to {@link _makeRequest} (which
+   * takes precedence entirely — it does not compose with this default).
+   * Use it when the vendor has one response convention (e.g. errors inside
+   * a 200 envelope) that every endpoint shares. Must RETURN the value the
+   * request resolves to (see {@link RESTlerResponseHandler}) — return
+   * `response.body` unchanged if nothing needs transforming.
    */
   protected _responseHandler?: RESTlerResponseHandler;
 
@@ -367,6 +372,17 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * endpoint object. This is what keeps a shared or reused endpoint object
    * from accumulating one call's credentials and leaking them into the next.
    *
+   * By the time this runs, `endpoint.headers` already holds the FULL
+   * outbound header set — instance-level defaults, `headerProvider()`'s
+   * output, and the caller's own explicit headers, already merged (caller
+   * wins on a collision). A signing-based `CUSTOM` auth override (HMAC,
+   * SigV4-style) can read and sign the actual set that goes out, not just
+   * whatever the caller happened to pass on this one call. The one
+   * exception: the default `Content-Type` for JSON/XML/TEXT payloads is
+   * computed later, in `_buildBody` — a signature that must cover it still
+   * needs the caller to set `Content-Type` explicitly on `endpoint.headers`
+   * before calling `_makeRequest`.
+   *
    * @param endpoint - Per-request endpoint copy to mutate with auth headers
    *
    * @throws {@link RESTlerConfigError} If the endpoint's auth config is invalid
@@ -389,7 +405,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
       endpoint.headers = endpoint.headers || {};
       if (auth.type === 'BASIC') {
         const { username, password } = auth;
-        const encoded = this.__base64Utf8(`${username}:${password}`);
+        const encoded = this._base64Utf8(`${username}:${password}`);
         endpoint.headers['Authorization'] = `Basic ${encoded}`;
       } else if (auth.type === 'BEARER') {
         const { token, prefix = 'BEARER' } = auth;
@@ -726,10 +742,15 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * its UTF-8 bytes via {@link TextEncoder} first, then mapping each byte into
    * the binary string `btoa` expects, avoids both problems.
    *
+   * PROTECTED (not private): a `CUSTOM`-auth subclass that wants
+   * Basic-style header encoding for some other purpose (a vendor's own
+   * non-standard Basic-shaped scheme) can reuse this rather than
+   * reimplementing UTF-8-correct base64 from scratch.
+   *
    * @param value - The string to encode.
    * @returns The base64 encoding of `value`'s UTF-8 bytes.
    */
-  private __base64Utf8(value: string): string {
+  protected _base64Utf8(value: string): string {
     const bytes = new TextEncoder().encode(value);
     let binary = '';
     for (const byte of bytes) {
@@ -797,12 +818,15 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * error, nor disables the listeners registered after it.
    *
    * @param endpoint - Endpoint configuration (path, method, baseURL, payload, etc.)
-   * @param responseHandler - Vendor hook that interprets the parsed response
-   *   (e.g. a 200 whose body carries an error envelope): throw to reject, or
-   *   mutate `response.body` to unwrap. Overrides {@link _responseHandler}.
+   * @param options - `responseHandler` overrides {@link _responseHandler};
+   *   `responseSchema` runs after it (or on the raw parsed body, if no
+   *   handler ran); `skipAuth` skips {@link _authInjector} for this one
+   *   request. See {@link RESTlerRequestOptions}.
    * @returns The response, with `status`, `headers`, parsed `body`, and `timeTaken`
    *
    * @throws {@link RESTlerTimeoutError} If the request exceeds its timeout
+   * @throws {@link RESTlerResponseValidationError} If `responseSchema`
+   *   rejects the response
    * @throws {@link RESTlerRequestError} If the request fails for any other
    *   reason, or wrapping (as `cause`) a non-{@link RESTlerError} thrown by
    *   the response handler
@@ -810,13 +834,13 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * @throws {@link RESTlerError} Subclasses thrown by the response handler
    *   surface unwrapped (with the `request` in their `context` redacted)
    */
-  protected _makeRequest<B = ResponseBody>(
+  protected _makeRequest<H = ResponseBody, B = H>(
     endpoint: RESTlerEndpoint,
-    responseHandler?: RESTlerResponseHandler,
+    options: RESTlerRequestOptions<H, B> = {},
   ): Promise<RESTlerResponse<B>> {
     const witness = this._getOption('witness');
     if (witness === undefined) {
-      return this.__request<B>(endpoint, responseHandler);
+      return this.__request<H, B>(endpoint, options);
     }
     // The whole request — endpoint resolution, headerProvider, fetch, body
     // parsing — runs inside the witnessed window, so a tracer's span is
@@ -833,17 +857,24 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
           'url.path': endpoint.path,
         },
       },
-      () => this.__request<B>(endpoint, responseHandler),
+      () => this.__request<H, B>(endpoint, options),
     );
   }
 
   /** The request pipeline {@link _makeRequest} runs (witnessed or not). */
-  private async __request<B = ResponseBody>(
+  private async __request<H = ResponseBody, B = H>(
     endpoint: RESTlerEndpoint,
-    responseHandler?: RESTlerResponseHandler,
+    options: RESTlerRequestOptions<H, B> = {},
   ): Promise<RESTlerResponse<B>> {
-    const handler = responseHandler ?? this._responseHandler;
-    const request = await this._processEndpoint(endpoint);
+    // The vendor-wide default is declared `RESTlerResponseHandler` (H =
+    // unknown) because a class field can't be parameterized per-call —
+    // this cast bridges that the same way `response.body = ... as B` casts
+    // already do throughout this method.
+    const handler = options.responseHandler ??
+      (this._responseHandler as RESTlerResponseHandler<H> | undefined);
+    const request = await this._processEndpoint(endpoint, {
+      skipAuth: options.skipAuth,
+    });
     const response: RESTlerResponse<B> = {
       url: request.url,
       status: null,
@@ -938,10 +969,34 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
       }
 
       // Vendor response hook — runs on every response (any status, empty
-      // body included) so it can translate vendor conventions: throw on an
-      // error-in-body envelope, or mutate `response.body` to unwrap it.
+      // body included) so it can translate vendor conventions: throw to
+      // reject, or RETURN the value that becomes the request's result (raw
+      // `response.body` unchanged, or an unwrapped envelope). Its output
+      // feeds `responseSchema` next, if also given; if only one of the two
+      // is present, its result is final; if neither, the raw parsed body
+      // stands as `response.body` already does.
       if (handler) {
-        await handler(response);
+        response.body = await handler(
+          response as RESTlerResponse<unknown>,
+        ) as B;
+      }
+      if (options.responseSchema) {
+        try {
+          response.body = await options.responseSchema(
+            response.body as unknown as H,
+          ) as B;
+        } catch (schemaError) {
+          // Propagates to the catch below exactly like a vendor
+          // `responseHandler` throwing a `RESTlerError` directly does —
+          // `request` here is passed RAW (unredacted), relying on that
+          // catch's existing generic `__redactedError` handling.
+          throw new RESTlerResponseValidationError(
+            { vendor: this.vendor, request },
+            schemaError instanceof Error
+              ? schemaError
+              : new Error(String(schemaError)),
+          );
+        }
       }
 
       return response;
@@ -1041,14 +1096,38 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
       case 'XML':
         if (!hasContentType) headers['Content-Type'] = 'application/xml';
         return XMLStringify(payload as Record<string, unknown>);
-      case 'FORM':
-        // Let fetch set multipart/form-data with the correct boundary.
-        Object.keys(headers).forEach((key) => {
-          if (key.toLowerCase() === 'content-type') {
-            delete headers[key];
-          }
-        });
-        return payload as FormData;
+      case 'FORM': {
+        if (payload instanceof FormData) {
+          // Let fetch set multipart/form-data with the correct boundary.
+          Object.keys(headers).forEach((key) => {
+            if (key.toLowerCase() === 'content-type') {
+              delete headers[key];
+            }
+          });
+          return payload;
+        }
+        // A `URLSearchParams` or plain object -> `application/x-www-form-
+        // urlencoded` — the wire format essentially every OAuth2 token
+        // exchange (and e.g. Stripe's whole API) requires, and multipart
+        // is the wrong shape for. `URLSearchParams`'s own serializer
+        // (space -> `+`) is CORRECT here — unlike a URL query string
+        // (see the query-building block above), `+` for space is the
+        // `application/x-www-form-urlencoded` media type's own convention
+        // for a request BODY, not something to route around.
+        if (!hasContentType) {
+          headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        }
+        const params = payload instanceof URLSearchParams
+          ? payload
+          : new URLSearchParams(
+            Object.fromEntries(
+              Object.entries(payload as Record<string, unknown>).map((
+                [key, value],
+              ) => [key, String(value)]),
+            ),
+          );
+        return params.toString();
+      }
       case 'TEXT':
         if (!hasContentType) headers['Content-Type'] = 'text/plain';
         return payload as string;
@@ -1141,7 +1220,13 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    * or query params written by {@link _authInjector} do not persist on it or
    * bleed into later requests that reuse the same object.
    *
+   * `endpoint.path` is joined onto the base URL's pathname via `path.join`,
+   * which normalizes it — see {@link RESTlerEndpoint.path} for what that
+   * means for a caller-controlled path segment.
+   *
    * @param endpoint - Endpoint configuration to process (not mutated)
+   * @param options - `skipAuth` skips the {@link _authInjector} call for
+   *   this one request — see `RESTlerRequestOptions.skipAuth`.
    * @returns A request ready to be sent
    *
    * @throws {@link RESTlerConfigError} If the endpoint's `baseURL`, `port`,
@@ -1150,6 +1235,7 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
    */
   protected async _processEndpoint(
     endpoint: RESTlerEndpoint,
+    options: { skipAuth?: boolean } = {},
   ): Promise<RESTlerRequest> {
     // Work on a copy — with its own `headers`/`query` objects — so neither the
     // base `_authInjector` nor a subclass override can mutate the caller's
@@ -1203,12 +1289,29 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
         // contained by design — see the option's contract
       }
     }
-    // Handle auth (may be async — e.g. token refresh before the request)
-    await this._authInjector(endpoint);
+    // Fold the accumulated defaults+headerProvider set INTO endpoint.headers
+    // — the caller's own entries still win on a collision — BEFORE auth
+    // runs, not after. A signing-based CUSTOM `_authInjector` mutates
+    // `endpoint.headers` directly (see its default implementation below);
+    // running this merge first means that's now the FULL outbound set, so
+    // a signature computed over it covers everything actually sent, not
+    // just whatever the caller happened to pass on this one call.
+    endpoint.headers = {
+      ...headers,
+      ...Object.fromEntries(
+        Object.entries(endpoint.headers ?? {}).map((
+          [key, value],
+        ) => [key, this._replaceVersion(value, version)]),
+      ),
+    };
+    // Handle auth (may be async — e.g. token refresh before the request) —
+    // skipped for a CUSTOM auth's own token-exchange request, which would
+    // otherwise recurse into _authInjector before the token exists.
+    if (!options.skipAuth) {
+      await this._authInjector(endpoint);
+    }
     if (endpoint.headers) {
-      Object.entries(endpoint.headers).forEach(([key, value]) => {
-        headers[key] = this._replaceVersion(value, version);
-      });
+      Object.assign(headers, endpoint.headers);
     }
     const url = new URL(this._replaceVersion(baseURL, version));
     url.pathname = path.join(
@@ -1216,9 +1319,19 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
       this._replaceVersion(endpoint.path, version),
     );
     if (endpoint.query) {
-      Object.entries(endpoint.query).forEach(([key, value]) => {
-        url.searchParams.set(key, this._replaceVersion(value, version));
-      });
+      // Built manually with `encodeURIComponent` (RFC 3986: space -> `%20`)
+      // rather than `URLSearchParams.set`, which follows the WHATWG
+      // `application/x-www-form-urlencoded` serializer and encodes a space
+      // as `+` — real, verified platform behavior that breaks any
+      // signing-based auth re-deriving a canonical query string server-side
+      // (a `+` does not round-trip as a space there).
+      url.search = Object.entries(endpoint.query)
+        .map(([key, value]) =>
+          `${encodeURIComponent(key)}=${
+            encodeURIComponent(this._replaceVersion(value, version))
+          }`
+        )
+        .join('&');
     }
     if (port) {
       url.port = port.toString();
@@ -1593,8 +1706,11 @@ export abstract class RESTler<O extends RESTlerOptions = RESTlerOptions>
     const v = value as Record<string, unknown>;
     switch (v.type) {
       case 'BASIC':
+        // An EMPTY password is valid per RFC 7617 — and a real, common
+        // pattern (Stripe's own documented primary auth is `sk_live_...:`
+        // with nothing after the colon). Only the username is required.
         return typeof v.username === 'string' && v.username.length > 0 &&
-          typeof v.password === 'string' && v.password.length > 0;
+          typeof v.password === 'string';
       case 'BEARER':
         return typeof v.token === 'string' && v.token.length > 0 &&
           (v.prefix === undefined || typeof v.prefix === 'string');

--- a/packages/restler/errors/RESTlerResponseValidationError.ts
+++ b/packages/restler/errors/RESTlerResponseValidationError.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Error raised when a response fails its `responseSchema`.
+ *
+ * @module
+ */
+
+import type { RESTlerRequest } from '../types/mod.ts';
+import { RESTlerRequestError } from './RESTlerRequestError.ts';
+import { RESTlerErrorMeta } from './Base.ts';
+
+/**
+ * Thrown when the `responseSchema` passed to `_makeRequest` rejects a
+ * response
+ *
+ * A {@link RESTlerRequestError} subclass — distinct from a transport
+ * failure or timeout: the request itself SUCCEEDED, but what came back
+ * didn't match what the caller declared to expect (a `GuardianError`, or
+ * whatever the schema function threw, preserved as `cause`). Callers can
+ * `instanceof` this to handle "the vendor's response doesn't match its
+ * contract anymore" differently from a network failure — retrying a
+ * validation failure won't fix it the way retrying a timeout might.
+ */
+export class RESTlerResponseValidationError extends RESTlerRequestError {
+  /**
+   * Build the error with a fixed message and the request whose response
+   * failed validation
+   *
+   * @param meta - Metadata carrying `vendor` and the `request`
+   * @param cause - The error `responseSchema` threw
+   */
+  constructor(
+    meta: RESTlerErrorMeta & { request: RESTlerRequest },
+    cause: Error,
+  ) {
+    super('Response failed schema validation', meta, cause);
+  }
+}

--- a/packages/restler/errors/mod.ts
+++ b/packages/restler/errors/mod.ts
@@ -8,4 +8,5 @@ export { RESTlerError } from './Base.ts';
 export type { RESTlerErrorMeta } from './Base.ts';
 export { RESTlerConfigError } from './RESTlerConfigError.ts';
 export { RESTlerRequestError } from './RESTlerRequestError.ts';
+export { RESTlerResponseValidationError } from './RESTlerResponseValidationError.ts';
 export { RESTlerTimeoutError } from './RESTlerTimeoutError.ts';

--- a/packages/restler/mod.ts
+++ b/packages/restler/mod.ts
@@ -26,8 +26,10 @@ export type {
   RESTlerMethodPayload,
   RESTlerOptions,
   RESTlerRequest,
+  RESTlerRequestOptions,
   RESTlerResponse,
   RESTlerResponseHandler,
+  RESTlerResponseSchema,
   Witness,
   WitnessInfo,
 } from './types/mod.ts';
@@ -36,6 +38,7 @@ export {
   RESTlerError,
   type RESTlerErrorMeta,
   RESTlerRequestError,
+  RESTlerResponseValidationError,
   RESTlerTimeoutError,
 } from './errors/mod.ts';
 // Re-exported from `@tundralibs/compat/http` (the net-free subpath, not the

--- a/packages/restler/tests/RESTler.test.ts
+++ b/packages/restler/tests/RESTler.test.ts
@@ -5,12 +5,14 @@ import { RESTler } from '../mod.ts';
 import {
   RESTlerConfigError,
   RESTlerRequestError,
+  RESTlerResponseValidationError,
   RESTlerTimeoutError,
 } from '../errors/mod.ts';
 import type {
   ResponseBody,
   RESTlerEndpoint,
   RESTlerOptions,
+  RESTlerRequestOptions,
   RESTlerResponseHandler,
 } from '../types/mod.ts';
 
@@ -29,11 +31,11 @@ class TestRESTler extends RESTler {
   }
 
   // Make protected methods public for testing
-  public makeRequest<T extends ResponseBody>(
+  public makeRequest<H = ResponseBody, B = H>(
     endpoint: RESTlerEndpoint,
-    responseHandler?: RESTlerResponseHandler,
+    options?: RESTlerRequestOptions<H, B>,
   ) {
-    return this._makeRequest<T>(endpoint, responseHandler);
+    return this._makeRequest<H, B>(endpoint, options);
   }
 
   public async processEndpoint(
@@ -104,6 +106,26 @@ class TestRESTler extends RESTler {
   // Expose the resolved (post-_processOption) option value for assertions.
   public readOption<K extends keyof RESTlerOptions>(key: K) {
     return this._getOption(key);
+  }
+
+  // #341: proves _base64Utf8 is reachable from a subclass (protected, not
+  // private) — a CUSTOM-auth override can reuse it instead of
+  // reimplementing UTF-8-correct base64.
+  public base64Utf8(value: string) {
+    return this._base64Utf8(value);
+  }
+}
+
+// CUSTOM auth injector that records the header set it saw — proves #338:
+// signing-based auth sees the FULL outbound set (defaults + headerProvider
+// + caller-explicit), not just whatever the caller passed to this one call.
+class SigningAuthTestRESTler extends TestRESTler {
+  public seenHeaders: Record<string, string> | undefined;
+
+  protected override _authInjector(endpoint: RESTlerEndpoint): void {
+    this.seenHeaders = { ...endpoint.headers };
+    endpoint.headers = endpoint.headers ?? {};
+    endpoint.headers['X-Signature'] = 'signed';
   }
 }
 
@@ -401,6 +423,25 @@ describe('restler.core', () => {
       asserts.assert(request.url.includes('apiVersion=2'));
     });
 
+    it('#339: query values are RFC 3986 percent-encoded (%20), not form-urlencoded (+)', async () => {
+      const request = await client.processEndpoint({
+        path: '/search',
+        method: 'GET',
+        query: {
+          q: 'two words',
+          'k&v': 'a=b',
+          reserved: '?/#',
+        },
+      });
+      asserts.assert(request.url.includes('q=two%20words'));
+      asserts.assert(!request.url.includes('+'));
+      asserts.assert(request.url.includes('k%26v=a%3Db'));
+      asserts.assert(request.url.includes('reserved=%3F%2F%23'));
+      // Round-trips correctly back to the original value:
+      const parsed = new URL(request.url);
+      asserts.assertEquals(parsed.searchParams.get('q'), 'two words');
+    });
+
     it('should handle bearer token auth', async () => {
       const request = await client.processEndpoint(
         {
@@ -464,6 +505,30 @@ describe('restler.core', () => {
       );
     });
 
+    it("#341: BASIC auth with an EMPTY password is valid (RFC 7617; e.g. Stripe's sk_live_...: pattern)", async () => {
+      const request = await client.processEndpoint({
+        path: '/users',
+        method: 'GET',
+        auth: { type: 'BASIC', username: 'sk_live_abc123', password: '' },
+      });
+      asserts.assertEquals(
+        request.headers!['Authorization'],
+        `Basic ${btoa('sk_live_abc123:')}`,
+      );
+    });
+
+    it('#341: _base64Utf8 is reachable from a subclass (protected)', () => {
+      // UTF-8 round-trip (a Latin1-only `btoa` would throw or corrupt this):
+      asserts.assertEquals(
+        client.base64Utf8('café:pass'),
+        btoa(
+          Array.from(new TextEncoder().encode('café:pass'))
+            .map((b) => String.fromCharCode(b))
+            .join(''),
+        ),
+      );
+    });
+
     it('should handle request-specific headers', async () => {
       const request = await client.processEndpoint(
         {
@@ -481,6 +546,47 @@ describe('restler.core', () => {
       asserts.assertEquals(request.headers!['X-Custom'], 'value');
       asserts.assertEquals(request.headers!['X-Version'], 'v2');
       asserts.assertEquals(request.headers!['X-API-Key'], 'default-key');
+    });
+
+    it('#338: a CUSTOM _authInjector sees defaults + headerProvider + explicit headers, not just what the caller passed', async () => {
+      const signingClient = new SigningAuthTestRESTler({
+        baseURL: 'https://api.example.com',
+        headers: { 'X-API-Key': 'default-key' },
+        headerProvider: () => ({ 'X-Trace': 'trace-123' }),
+      });
+      const request = await signingClient.processEndpoint({
+        path: '/orders',
+        method: 'GET',
+        headers: { 'X-Custom': 'explicit-value' },
+      });
+      // What _authInjector SAW, before it added its own signature header:
+      asserts.assertEquals(signingClient.seenHeaders, {
+        'X-API-Key': 'default-key',
+        'X-Trace': 'trace-123',
+        'X-Custom': 'explicit-value',
+      });
+      // And its signature made it onto the final outbound request too:
+      asserts.assertEquals(request.headers!['X-Signature'], 'signed');
+      asserts.assertEquals(request.headers!['X-API-Key'], 'default-key');
+      asserts.assertEquals(request.headers!['X-Trace'], 'trace-123');
+      asserts.assertEquals(request.headers!['X-Custom'], 'explicit-value');
+    });
+
+    it('#338: explicit endpoint headers still win over defaults after the reorder', async () => {
+      const signingClient = new SigningAuthTestRESTler({
+        baseURL: 'https://api.example.com',
+        headers: { 'X-API-Key': 'default-key' },
+      });
+      const request = await signingClient.processEndpoint({
+        path: '/orders',
+        method: 'GET',
+        headers: { 'X-API-Key': 'overridden-key' },
+      });
+      asserts.assertEquals(
+        signingClient.seenHeaders?.['X-API-Key'],
+        'overridden-key',
+      );
+      asserts.assertEquals(request.headers!['X-API-Key'], 'overridden-key');
     });
 
     it('should handle custom port', async () => {
@@ -1294,6 +1400,79 @@ describe('restler.core', () => {
       asserts.assertEquals(capturedBody instanceof FormData, true);
     });
 
+    it('#340: a URLSearchParams FORM payload sends application/x-www-form-urlencoded', async () => {
+      let capturedContentType: string | null = null;
+      let capturedBody = '';
+
+      const client = new TestRESTler({ baseURL: 'https://api.example.com' });
+      client.setFetch(async (_input, init) => {
+        await 1;
+        capturedContentType = new Headers(
+          init?.headers as HeadersInit | undefined,
+        ).get('Content-Type');
+        capturedBody = init?.body as string;
+        return new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+      await client.makeRequest({
+        path: '/oauth/token',
+        method: 'POST',
+        contentType: 'FORM',
+        payload: new URLSearchParams({
+          grant_type: 'client_credentials',
+          scope: 'read write',
+        }),
+      });
+
+      asserts.assertEquals(
+        capturedContentType,
+        'application/x-www-form-urlencoded',
+      );
+      // application/x-www-form-urlencoded's OWN convention is space -> `+`
+      // — correct here, unlike a URL query string (see #339's test).
+      asserts.assertEquals(
+        capturedBody,
+        'grant_type=client_credentials&scope=read+write',
+      );
+    });
+
+    it('#340: a plain-object FORM payload also sends application/x-www-form-urlencoded', async () => {
+      let capturedContentType: string | null = null;
+      let capturedBody = '';
+
+      const client = new TestRESTler({ baseURL: 'https://api.example.com' });
+      client.setFetch(async (_input, init) => {
+        await 1;
+        capturedContentType = new Headers(
+          init?.headers as HeadersInit | undefined,
+        ).get('Content-Type');
+        capturedBody = init?.body as string;
+        return new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+      await client.makeRequest({
+        path: '/oauth/token',
+        method: 'POST',
+        contentType: 'FORM',
+        payload: { grant_type: 'refresh_token', refresh_token: 'abc123' },
+      });
+
+      asserts.assertEquals(
+        capturedContentType,
+        'application/x-www-form-urlencoded',
+      );
+      asserts.assertEquals(
+        capturedBody,
+        'grant_type=refresh_token&refresh_token=abc123',
+      );
+    });
+
     it('should make request with text payload', async () => {
       let capturedBody = '';
 
@@ -1460,9 +1639,11 @@ describe('restler.core', () => {
         client.validateAuth({ type: 'BASIC', username: '', password: 'pass' }),
         false,
       );
+      // #341: an EMPTY password is valid per RFC 7617 (e.g. Stripe's
+      // `sk_live_...:` pattern) — only username is required.
       asserts.assertEquals(
         client.validateAuth({ type: 'BASIC', username: 'user', password: '' }),
-        false,
+        true,
       );
       asserts.assertEquals(
         client.validateAuth({ type: 'BASIC', username: '', password: '' }),
@@ -1952,25 +2133,29 @@ describe('restler.responseHandler', () => {
           },
         );
       }
+      return response.body;
     };
     await asserts.assertRejects(
-      () => client.makeRequest({ path: '/pay', method: 'GET' }, handler),
+      () =>
+        client.makeRequest({ path: '/pay', method: 'GET' }, {
+          responseHandler: handler,
+        }),
       RESTlerRequestError,
       'Vendor error: insufficient funds',
     );
   });
 
-  it('unwraps an envelope by mutating response.body', async () => {
+  it('unwraps an envelope by RETURNING the unwrapped value', async () => {
     const client = new TestRESTler({ baseURL: 'https://api.example.com' });
     client.setFetch(
       envelopeFetch({ ok: true, data: { id: 7, name: 'thing' } }),
     );
     const unwrap: RESTlerResponseHandler = (response) => {
-      response.body = (response.body as { data: unknown }).data;
+      return (response.body as { data: unknown }).data;
     };
     const res = await client.makeRequest(
       { path: '/thing/7', method: 'GET' },
-      unwrap,
+      { responseHandler: unwrap },
     );
     asserts.assertEquals(res.body, { id: 7, name: 'thing' });
   });
@@ -1980,7 +2165,7 @@ describe('restler.responseHandler', () => {
       protected override _responseHandler: RESTlerResponseHandler = (
         response,
       ) => {
-        response.body = (response.body as { data: unknown }).data;
+        return (response.body as { data: unknown }).data;
       };
     }
     const client = new EnvelopeRESTler({ baseURL: 'https://api.example.com' });
@@ -1989,7 +2174,7 @@ describe('restler.responseHandler', () => {
     asserts.assertEquals(res.body, { id: 1 });
   });
 
-  it('per-call handler takes precedence over the class default', async () => {
+  it('per-call handler takes precedence over the class default (does not compose with it)', async () => {
     class EnvelopeRESTler extends TestRESTler {
       protected override _responseHandler: RESTlerResponseHandler = () => {
         throw new RESTlerRequestError('class default ran', {
@@ -2007,8 +2192,11 @@ describe('restler.responseHandler', () => {
     let perCallRan = false;
     const res = await client.makeRequest(
       { path: '/x', method: 'GET' },
-      () => {
-        perCallRan = true;
+      {
+        responseHandler: (response) => {
+          perCallRan = true;
+          return response.body;
+        },
       },
     );
     asserts.assert(perCallRan);
@@ -2020,8 +2208,10 @@ describe('restler.responseHandler', () => {
     client.setFetch(envelopeFetch({ ok: false }));
     const err = await asserts.assertRejects(
       () =>
-        client.makeRequest({ path: '/x', method: 'GET' }, () => {
-          throw new Error('plain vendor failure');
+        client.makeRequest({ path: '/x', method: 'GET' }, {
+          responseHandler: () => {
+            throw new Error('plain vendor failure');
+          },
         }),
       RESTlerRequestError,
       'Unknown error processing the request',
@@ -2035,9 +2225,12 @@ describe('restler.responseHandler', () => {
     client.setFetch(() => Promise.resolve(new Response(null, { status: 404 })));
     let sawStatus: number | null = null;
     let sawBody: unknown = 'unset';
-    await client.makeRequest({ path: '/gone', method: 'GET' }, (response) => {
-      sawStatus = response.status;
-      sawBody = response.body;
+    await client.makeRequest({ path: '/gone', method: 'GET' }, {
+      responseHandler: (response) => {
+        sawStatus = response.status;
+        sawBody = response.body;
+        return response.body;
+      },
     });
     asserts.assertEquals(sawStatus, 404);
     asserts.assertEquals(sawBody, undefined);
@@ -3178,6 +3371,172 @@ describe('restler.responseHandler', () => {
       asserts.assertEquals(
         client.replaceVersion('{version}', '$$'),
         '$$',
+      );
+    });
+  });
+});
+
+describe('restler.requestOptions (#342/#344: skipAuth, responseSchema)', () => {
+  const jsonFetch = (body: unknown): typeof fetch => () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+  describe('skipAuth', () => {
+    it('#342: skipAuth:true skips _authInjector entirely', async () => {
+      const client = new SigningAuthTestRESTler({
+        baseURL: 'https://api.example.com',
+      });
+      client.setFetch(jsonFetch({ ok: true }));
+      const res = await client.makeRequest(
+        {
+          path: '/token',
+          method: 'POST',
+          auth: { type: 'BEARER', token: 'unused' },
+        },
+        { skipAuth: true },
+      );
+      // _authInjector never ran: seenHeaders stays unset, and its
+      // signature header never made it onto the request.
+      asserts.assertEquals(client.seenHeaders, undefined);
+      asserts.assertEquals(res.status, 200);
+    });
+
+    it('#342: skipAuth is false/absent by default — auth still runs', async () => {
+      const client = new SigningAuthTestRESTler({
+        baseURL: 'https://api.example.com',
+      });
+      client.setFetch(jsonFetch({ ok: true }));
+      await client.makeRequest({ path: '/x', method: 'GET' });
+      asserts.assertNotEquals(client.seenHeaders, undefined);
+    });
+
+    it("#342: a CUSTOM auth's own token-exchange request can skip auth to avoid recursing into itself", async () => {
+      // Simulates the OAuth2 token-exchange case from the issue: a
+      // token-fetch that itself goes through _makeRequest, with skipAuth
+      // so it does not recurse into _authInjector before the token exists
+      // — while still getting the timeout/event/error machinery every
+      // other request gets (unlike calling `_fetch` raw).
+      class TokenExchangeRESTler extends TestRESTler {
+        public tokenFetchCount = 0;
+        protected override async _authInjector(
+          endpoint: RESTlerEndpoint,
+        ): Promise<void> {
+          this.tokenFetchCount++;
+          const tokenResponse = await this.makeRequest<{ token: string }>(
+            { path: '/oauth/token', method: 'POST' },
+            { skipAuth: true },
+          );
+          endpoint.headers = endpoint.headers ?? {};
+          endpoint.headers['Authorization'] =
+            `Bearer ${tokenResponse.body?.token}`;
+        }
+      }
+      const client = new TokenExchangeRESTler({
+        baseURL: 'https://api.example.com',
+      });
+      client.setFetch(jsonFetch({ token: 'exchanged-token' }));
+      const res = await client.processEndpoint({
+        path: '/data',
+        method: 'GET',
+      });
+      // No infinite recursion — the token exchange ran exactly once.
+      asserts.assertEquals(client.tokenFetchCount, 1);
+      asserts.assertEquals(
+        res.headers!['Authorization'],
+        'Bearer exchanged-token',
+      );
+    });
+  });
+
+  describe('responseSchema', () => {
+    it('#344: responseSchema alone (no handler) validates the raw parsed body', async () => {
+      const client = new TestRESTler({ baseURL: 'https://api.example.com' });
+      client.setFetch(jsonFetch({ id: '7', name: 'Ada' }));
+      const res = await client.makeRequest(
+        { path: '/users/7', method: 'GET' },
+        {
+          responseSchema: (data) => {
+            const d = data as { id: string; name: string };
+            // A real caller would pass e.g. `(d) => UserSchema.parse(d)` —
+            // this hand-rolled check exercises the same contract without
+            // coupling restler's OWN tests to guardian either.
+            return { id: Number(d.id), name: d.name };
+          },
+        },
+      );
+      asserts.assertEquals(res.body, { id: 7, name: 'Ada' });
+    });
+
+    it('#344: responseHandler runs FIRST, its return value feeds responseSchema', async () => {
+      const client = new TestRESTler({ baseURL: 'https://api.example.com' });
+      client.setFetch(jsonFetch({ data: { id: '9', name: 'Grace' } }));
+      const res = await client.makeRequest(
+        { path: '/users/9', method: 'GET' },
+        {
+          responseHandler: (response) =>
+            (response.body as { data: unknown }).data,
+          responseSchema: (data) => {
+            const d = data as { id: string; name: string };
+            return { id: Number(d.id), name: d.name };
+          },
+        },
+      );
+      asserts.assertEquals(res.body, { id: 9, name: 'Grace' });
+    });
+
+    it('#344: a throwing responseSchema surfaces as RESTlerResponseValidationError, cause preserved', async () => {
+      const client = new TestRESTler({ baseURL: 'https://api.example.com' });
+      client.setFetch(jsonFetch({ id: 'not-a-number' }));
+      const err = await asserts.assertRejects(
+        () =>
+          client.makeRequest({ path: '/users/x', method: 'GET' }, {
+            responseSchema: () => {
+              throw new Error('id must be numeric');
+            },
+          }),
+        RESTlerResponseValidationError,
+        'Response failed schema validation',
+      );
+      asserts.assertEquals((err.cause as Error).message, 'id must be numeric');
+    });
+
+    it('#344: a schema-encoded "wrapped or not" envelope needs no responseHandler at all', async () => {
+      // The pattern from the design discussion: compose a discriminated
+      // shape yourself (a real caller would use
+      // `Guardian.discriminatedUnion`) and pass it alone.
+      type Envelope =
+        | { status: 'ok'; data: { id: number } }
+        | { status: 'error'; error: string };
+      const envelopeSchema = (data: unknown): Envelope => {
+        const d = data as Record<string, unknown>;
+        if (d.status === 'ok' || d.status === 'error') return d as Envelope;
+        throw new Error('does not match either envelope shape');
+      };
+
+      const okClient = new TestRESTler({ baseURL: 'https://api.example.com' });
+      okClient.setFetch(jsonFetch({ status: 'ok', data: { id: 3 } }));
+      const ok = await okClient.makeRequest({ path: '/x', method: 'GET' }, {
+        responseSchema: envelopeSchema,
+      });
+      // A non-throw no longer implies success — the caller narrows:
+      asserts.assertEquals(ok.body, { status: 'ok', data: { id: 3 } });
+
+      const errClient = new TestRESTler({ baseURL: 'https://api.example.com' });
+      errClient.setFetch(jsonFetch({ status: 'error', error: 'not found' }));
+      const errResult = await errClient.makeRequest({
+        path: '/x',
+        method: 'GET',
+      }, {
+        responseSchema: envelopeSchema,
+      });
+      // The error variant is a VALID parse, not a thrown rejection:
+      asserts.assertEquals(
+        errResult.body,
+        { status: 'error', error: 'not found' },
       );
     });
   });

--- a/packages/restler/tests/WeatherAPI.test.ts
+++ b/packages/restler/tests/WeatherAPI.test.ts
@@ -188,7 +188,9 @@ const vendorErrorFetch: typeof fetch = () =>
 class PerCallWeatherAPI extends WeatherAPI {
   getCurrentWeatherWith(
     city: string,
-    handler: RESTlerResponseHandler,
+    handler: RESTlerResponseHandler<
+      { cod?: number | string; message?: string }
+    >,
   ) {
     return this._makeRequest<{ cod?: number | string; message?: string }>(
       {
@@ -196,7 +198,7 @@ class PerCallWeatherAPI extends WeatherAPI {
         method: 'GET',
         query: { q: city, units: 'metric' },
       },
-      handler,
+      { responseHandler: handler },
     );
   }
 }
@@ -278,10 +280,13 @@ describe('restler.examples.weatherAPI', () => {
         const api = new PerCallWeatherAPI('test-api-key-12345');
         api.setFetch(vendorErrorFetch);
         let perCallRan = false;
-        // The no-op per-call handler overrides the vendor default — which
-        // would have thrown on cod >= 400 — so the request resolves.
-        const response = await api.getCurrentWeatherWith('Atlantis', () => {
+        // The per-call handler overrides the vendor default — which would
+        // have thrown on cod >= 400 — so the request resolves. It must
+        // explicitly return `response.body` to leave it unchanged; the
+        // return value IS the result now, there is no mutate-in-place path.
+        const response = await api.getCurrentWeatherWith('Atlantis', (r) => {
           perCallRan = true;
+          return r.body as { cod?: number | string; message?: string };
         });
         asserts.assert(perCallRan);
         asserts.assertEquals(response.status, 200);

--- a/packages/restler/tests/fixtures/weather/WeatherAPI.ts
+++ b/packages/restler/tests/fixtures/weather/WeatherAPI.ts
@@ -54,8 +54,10 @@ export class WeatherAPI extends RESTler {
    * OpenWeatherMap reports errors via a `cod` field inside the JSON body
    * (e.g. `{"cod":"404","message":"city not found"}`), so this vendor-wide
    * response handler translates that convention into a thrown
-   * {@link RESTlerRequestError}. It applies to every request unless a
-   * per-call handler is passed to `_makeRequest` (which takes precedence).
+   * {@link RESTlerRequestError}. It applies to every request unless
+   * `options.responseHandler` is passed to `_makeRequest` (which takes
+   * precedence entirely, not composed with this default). Must RETURN the
+   * body on the non-error path — there is no mutate-in-place channel.
    */
   protected override _responseHandler: RESTlerResponseHandler = (response) => {
     const body = response.body as
@@ -70,6 +72,7 @@ export class WeatherAPI extends RESTler {
         },
       );
     }
+    return response.body;
   };
 
   /**

--- a/packages/restler/types/RESTlerContentType.ts
+++ b/packages/restler/types/RESTlerContentType.ts
@@ -9,7 +9,10 @@
  *
  * - `JSON` — `application/json`
  * - `XML` — `application/xml`
- * - `FORM` — multipart form data (`FormData`)
+ * - `FORM` — payload SHAPE decides the wire format: a `FormData` payload
+ *   sends `multipart/form-data` (fetch sets the boundary); a
+ *   `URLSearchParams` or plain object payload sends
+ *   `application/x-www-form-urlencoded` instead.
  * - `TEXT` — `text/plain`
  * - `BLOB` — binary data
  */

--- a/packages/restler/types/RESTlerContentTypePayload.ts
+++ b/packages/restler/types/RESTlerContentTypePayload.ts
@@ -21,12 +21,14 @@ export type RESTlerContentTypePayload<
   /**
    * The payload data, typed according to the content type:
    * - JSON/XML: Record<string, unknown>
-   * - FORM: FormData
+   * - FORM: `FormData` (sends `multipart/form-data`) or a `URLSearchParams`/
+   *   plain object (sends `application/x-www-form-urlencoded`) — see
+   *   {@link RESTlerContentType}
    * - TEXT: string
    * - BLOB: Blob
    */
   payload?: P extends 'JSON' | 'XML' ? Record<string, unknown>
-    : P extends 'FORM' ? FormData
+    : P extends 'FORM' ? FormData | URLSearchParams | Record<string, unknown>
     : P extends 'TEXT' ? string
     : P extends 'BLOB' ? Blob
     : never;

--- a/packages/restler/types/RESTlerEndpoint.ts
+++ b/packages/restler/types/RESTlerEndpoint.ts
@@ -17,6 +17,15 @@ export type RESTlerEndpoint<M extends RESTlerMethod = RESTlerMethod> = {
   /**
    * The path part of the URL (e.g., "/users/{id}").
    * Can include {version} placeholder that will be replaced with the version.
+   *
+   * NORMALIZED via `path.join` against the base URL's pathname: a literal
+   * `//` collapses and `.`/`..` segments resolve, the same as joining
+   * filesystem paths. Fine — desirable, even — for ordinary hierarchical
+   * paths, but a hazard if a segment embeds an opaque, caller-controlled
+   * token (an object-storage key, a filename): a key containing `..` or
+   * `//` silently resolves to a DIFFERENT endpoint instead of erroring.
+   * Percent-encode such a token yourself first (including internal `/`
+   * as `%2F`) if it could plausibly contain those sequences.
    */
   path: string;
 

--- a/packages/restler/types/RESTlerRequestOptions.ts
+++ b/packages/restler/types/RESTlerRequestOptions.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Per-call options for {@link RESTler._makeRequest}.
+ *
+ * @module
+ */
+import type { RESTlerResponseHandler } from './RESTlerResponseHandler.ts';
+import type { RESTlerResponseSchema } from './RESTlerResponseSchema.ts';
+
+/**
+ * Per-call options for `_makeRequest`
+ *
+ * `responseHandler` and `responseSchema` are independently optional and
+ * compose into one pipeline: if `responseHandler` is present, it runs
+ * first and its return value feeds `responseSchema` (if also present); if
+ * only one is given, its result is final; if neither is given, the
+ * response body is used as parsed. See {@link RESTlerResponseHandler} and
+ * {@link RESTlerResponseSchema} for what each is for.
+ *
+ * @typeParam H - Type `responseHandler` resolves to (raw parsed body if
+ *   no handler is given — the input `responseSchema` receives).
+ * @typeParam B - Final type the request resolves to.
+ */
+export type RESTlerRequestOptions<H = unknown, B = H> = {
+  /** Vendor hook that interprets the response; overrides `_responseHandler`. */
+  responseHandler?: RESTlerResponseHandler<H>;
+  /** Runtime validator/parser for the value this request resolves to. */
+  responseSchema?: RESTlerResponseSchema<H, B>;
+  /**
+   * Skip the auth-injection step for this ONE request. For a `CUSTOM`
+   * auth's own token-fetch — calling `_makeRequest` from inside
+   * `_authInjector` would otherwise recurse into `_authInjector` again
+   * before the token exists. Everything else `_makeRequest` normally
+   * provides (timeout/abort, the `call` event, error normalization,
+   * witness/tracing) still applies; only the auth step is skipped.
+   */
+  skipAuth?: boolean;
+};

--- a/packages/restler/types/RESTlerResponseHandler.ts
+++ b/packages/restler/types/RESTlerResponseHandler.ts
@@ -10,19 +10,27 @@ import type { RESTlerResponse } from './RESTlerResponse.ts';
  *
  * Runs after the body has been parsed (so it is independent of the
  * JSON/XML/TEXT content handling) on every response, including error
- * statuses and empty bodies. Use it to translate vendor conventions —
- * e.g. a `200` whose body carries an error envelope:
+ * statuses and empty bodies. Receives the FULL response (status/headers
+ * included, not just the body) — a vendor convention like "errors are a
+ * `2xx` with an error envelope" needs more than the body to detect.
  *
  * - **throw** to signal the error (throw a {@link RESTlerError} subclass to
  *   surface it unwrapped; anything else is wrapped in a
  *   `RESTlerRequestError` with the original as `cause`), or
- * - **mutate** `response.body` to unwrap an envelope
- *   (`{ data, error } -> data`).
+ * - **return** the value that becomes the request's result — unwrap a
+ *   vendor envelope (`{ data, error } -> data`), or simply
+ *   `response.body` unchanged if nothing needs transforming.
+ *
+ * Composes with {@link RESTlerResponseSchema}: if both are given to
+ * `_makeRequest`, this handler's return value is what the schema then
+ * validates. Neither is required — a schema alone (encoding the full
+ * "wrapped or not" shape itself, e.g. via a discriminated union) is a
+ * complete, valid way to use `_makeRequest` with no handler at all.
  *
  * Set a vendor-wide default via the client's `_responseHandler` field, or
- * pass one per call as the second argument of `_makeRequest` (which takes
+ * pass one per call in {@link RESTlerRequestOptions} (which takes
  * precedence).
  */
-export type RESTlerResponseHandler = (
+export type RESTlerResponseHandler<H = unknown> = (
   response: RESTlerResponse<unknown>,
-) => void | Promise<void>;
+) => H | Promise<H>;

--- a/packages/restler/types/RESTlerResponseSchema.ts
+++ b/packages/restler/types/RESTlerResponseSchema.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Runtime-validating hook that types and checks a response.
+ *
+ * @module
+ */
+
+/**
+ * Runtime validator/parser for the value a request ultimately resolves
+ * to — the response-side counterpart of the compile-time-only generic
+ * `_makeRequest<B>` used to carry today. `B` is INFERRED from this
+ * function's return type, so a caller no longer has to separately write
+ * out and manually keep in sync a type argument that nothing actually
+ * checks against the wire.
+ *
+ * PLAIN FUNCTION, deliberately — no coupling to `@tundralibs/guardian` or
+ * any other validation library. A guardian schema's own `.parse` (or
+ * `.parseAsync`) satisfies this signature directly:
+ *
+ * ```typescript ignore
+ * this._makeRequest(endpoint, {
+ *   responseSchema: (data) => WeatherResponseSchema.parse(data),
+ * });
+ * ```
+ *
+ * Runs AFTER {@link RESTlerResponseHandler} if both are given — `data` is
+ * the handler's return value, or the raw parsed body if no handler ran.
+ * Throwing (a `GuardianError`, or anything else) is wrapped as
+ * {@link RESTlerResponseValidationError}, distinguishing "the vendor sent
+ * something that doesn't match" from a transport failure or timeout.
+ *
+ * A response wrapped in a vendor envelope (`{ data, error }`-shaped APIs)
+ * needs no special support here: build the envelope as a schema itself —
+ * a `Guardian.discriminatedUnion`/`oneOf` composing the per-endpoint inner
+ * shape with the shared wrapper — and pass it alone, no handler needed.
+ * A successful parse no longer implies success; it means the response
+ * matched ONE of the declared shapes, and the caller narrows on the
+ * result afterward (e.g. on a discriminant field) instead of being forced
+ * into exception-based control flow for an expected error shape.
+ */
+export type RESTlerResponseSchema<H = unknown, B = H> = (
+  data: H,
+) => B | Promise<B>;

--- a/packages/restler/types/mod.ts
+++ b/packages/restler/types/mod.ts
@@ -21,6 +21,8 @@ export type { RESTlerMethod } from './RESTlerMethod.ts';
 export type { RESTlerMethodPayload } from './RESTlerMethodPayload.ts';
 export type { RESTlerOptions } from './RESTlerOptions.ts';
 export type { RESTlerRequest } from './RESTlerRequest.ts';
+export type { RESTlerRequestOptions } from './RESTlerRequestOptions.ts';
 export type { ResponseBody } from './ResponseBody.ts';
 export type { RESTlerResponse } from './RESTlerResponse.ts';
 export type { RESTlerResponseHandler } from './RESTlerResponseHandler.ts';
+export type { RESTlerResponseSchema } from './RESTlerResponseSchema.ts';


### PR DESCRIPTION
Closes #338, #339, #340, #341, #342, #343, #344 — all found and evidenced while building `tundra-connect`'s SigV4, Shared-Key HMAC, and OAuth2 connects against restler. All seven were independently verified against current source before implementation — see the discussion on each issue.

## #338 — signing-based auth can now sign what actually gets sent
`_authInjector` now sees the FULL outbound header set — defaults, `headerProvider()`'s output, and the caller's own explicit headers, already merged — before it runs, not after. Implemented the simpler of the two options discussed: fold the accumulated headers into `endpoint.headers` before calling `_authInjector`, reusing its existing mutation channel rather than changing its signature. Zero signature break for existing `CUSTOM` auth overrides.

## #339 — RFC 3986 query encoding
The query-string builder now percent-encodes manually (`encodeURIComponent`, space → `%20`) instead of `URLSearchParams.set`'s form-urlencoded serializer (space → `+`), which is real, verified platform behavior that breaks signing-based auth re-deriving a canonical query string server-side (confirmed live: `?key=a+value+with+spaces` vs `%20`).

## #340 — FORM branches on payload shape
`FormData` still sends `multipart/form-data` — unchanged. A `URLSearchParams` or plain object now sends `application/x-www-form-urlencoded`, the format OAuth2 token exchange (and Stripe's whole API) requires. Safe by construction: anything other than a real `FormData` under `'FORM'` was already broken before this change (unconditional `as FormData` cast, zero validation), so this is purely additive.

## #341 — BASIC empty password + `_base64Utf8` protected
An empty password is RFC 7617-legal and Stripe's own documented pattern (`sk_live_...:`) — only `username` is required now. `_base64Utf8` is `protected`, not `private` (renamed per the package's `_`/`__` visibility convention), so a `CUSTOM` auth override can reuse the UTF-8-correct base64 encoder instead of reimplementing it.

## #342 — `skipAuth`
A `CUSTOM` auth's own token-exchange request can now go through the normal `_makeRequest` pipeline — timeout/abort, the `call` event, error normalization, witness/tracing — without recursing into its own `_authInjector` before the token exists. Tested end-to-end: a token-exchange class exercising exactly this pattern runs its exchange exactly once, no infinite recursion.

## #343 — docs only
Documented that `RESTlerEndpoint.path` is normalized via `path.join` (confirmed live: `path.join('/v1/objects', '../../admin/secret')` → `/admin/secret`), so an opaque caller-controlled segment needs percent-encoding first. No behavior change.

## #344 — `responseSchema`, and `responseHandler` returns instead of mutates
`responseHandler`'s contract changes from mutate-in-place/`void` to a real return value — composes with a new `responseSchema` hook that runs after it (or on the raw body, if no handler ran). `responseSchema` is a plain function, `(data: H) => B | Promise<B>` — no coupling to any validation library, matching `RapidBinder`'s `validate` in `packages/rapid`, the same "guardian schema or any function" idiom already used elsewhere in the suite. `B` is now inferred from the schema instead of a manual, unchecked type assertion. A thrown validation error surfaces as the new `RESTlerResponseValidationError`, distinguishable from a timeout or transport failure. Neither hook is required — a schema alone, encoding a vendor's wrapped envelope via a discriminated union, needs no handler at all; a non-throw no longer implies success, the caller narrows on the result.

## Consolidation
`_makeRequest`/`_processEndpoint` are consolidated into one options bag: `{ responseHandler?, responseSchema?, skipAuth? }`. This is a breaking change to a **protected** API, with a small, known surface — restler's own test fixtures and `tundra-connect` — migrated as part of this change, not left as follow-up.

One thing worth flagging explicitly: `WeatherAPI.ts`'s own `_responseHandler` needed the exact same return-value fix — under the old mutate-in-place signature it worked, but under a naive migration to the new return-based one it would have silently returned `undefined` on every successful call, since it had no `return` statement. The compiler never flagged this (`undefined` is a valid `unknown`); only re-reading the migration caught it. Fixed and covered by the existing `WeatherAPI.test.ts` suite, which would have failed had this been missed.

## Verification
- 218 test steps (up from 209), `deno check`/`fmt`/`lint` clean across the whole package including fixtures
- `deno publish --dry-run` clean
- All 15 README code blocks verified with `deno check --doc-only`
- README updated: Content Types table, a new "Signing-based auth" and "OAuth2 token exchange" subsection under Authentication, a substantially rewritten "Vendor Response Handling" section covering both hooks and the wrapped-envelope pattern, the Error Handling table and try/catch example, and the API Reference / Key types lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)