### PR TITLE
feat(guardian): add .strict() coercion opt-out to NumberGuardian/BooleanGuardian

### DIFF
--- a/packages/guardian/README.md
+++ b/packages/guardian/README.md
@@ -118,6 +118,16 @@ QuerySchema.parse({ page: '3', limit: '20', q: 'guardian' });
 
 See [Validators](docs/Guardian-Validators.md#coercion-rules) for the full coercion rules per type.
 
+Validating a vendor _response_ instead of parsing input? `Guardian.number()` / `Guardian.boolean()` expose `.strict()` to opt out of coercion — the input must already be the declared JS type, or it throws:
+
+```typescript
+import { Guardian } from '@tundralibs/guardian';
+
+const StrictAge = Guardian.number().strict();
+StrictAge.parse(42); // 42
+StrictAge.parse('42'); // throws — no coercion in strict mode
+```
+
 ### Discriminated unions
 
 ```typescript

--- a/packages/guardian/docs/Guardian-Validators.md
+++ b/packages/guardian/docs/Guardian-Validators.md
@@ -27,7 +27,21 @@ The five primitive guardians (`string`, `number`, `boolean`, `date`, `bigint`) c
 
 `null` and `undefined` are **never** coerced — chain `.nullable()` / `.optional()` if you want to accept them.
 
-To opt out of coercion, chain a `.test()` with your own typeof check, or write a `Guardian.unknown().process(...)` pipeline by hand.
+Coerce-by-default is right for the input-parsing case above, but wrong when you're validating a _response_ — a vendor API returning `age: "42"` where the contract promises a number is a schema violation you want to catch, not silently accept. `Guardian.number()` and `Guardian.boolean()` expose `.strict()` for that case: it requires the input's runtime `typeof` to already match, rejecting the value instead of coercing it. `.strict()` composes correctly no matter where it's called in the chain:
+
+```typescript
+import { Guardian } from '@tundralibs/guardian';
+
+const StrictAge = Guardian.number().strict().min(0);
+StrictAge.parse(42); // 42
+StrictAge.parse('42'); // throws — no coercion in strict mode
+
+const StrictFlag = Guardian.boolean().strict();
+StrictFlag.parse(true); // true
+StrictFlag.parse('true'); // throws
+```
+
+For the other primitives (`string`, `date`, `bigint`), opt out of coercion by chaining a `.test()` with your own typeof check, or by writing a `Guardian.unknown().process(...)` pipeline by hand.
 
 ## `Guardian.string()`
 
@@ -140,22 +154,23 @@ Age.parse('42'); // 42  ← coerced
 
 ### Type checks
 
-| Method                                                    | Behaviour                                                                                       |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `.integer(msg?)`                                          | `Number.isInteger(input)`                                                                       |
-| `.finite(msg?)`                                           | rejects `Infinity` / `-Infinity`                                                                |
-| `.safeInteger(msg?)`                                      | within `Number.MIN_SAFE_INTEGER`…`MAX_SAFE_INTEGER`                                             |
-| `.odd(msg?)` / `.even(msg?)` / `.prime(msg?)`             | parity / primality                                                                              |
-| `.naturalNumber(msg?)`                                    | positive integer (`> 0`, no fractions)                                                          |
-| `.multipleOf(n, msg?)` / `.evenlyDivisible(n, msg?)`      | `input % n === 0` (alias)                                                                       |
-| `.power(base?, msg?)`                                     | perfect power (of given base or any base)                                                       |
-| `.validPort(msg?)` / `.port(msg?)`                        | 0–65535 integer                                                                                 |
-| `.timestamp(msg?)`                                        | valid Unix timestamp (non-negative integer)                                                     |
-| `.unixSeconds(msg?)` / `.unixMillis(msg?)`                | timestamp validation at second / millisecond resolution                                         |
-| `.fullYear(msg?)`                                         | 4-digit calendar year (1900–9999)                                                               |
-| `.percentage(msg?)` / `.probability(msg?)` / `.bps(msg?)` | `[0,100]` / `[0,1]` / basis-points `[0,10000]` ranges                                           |
-| `.bigDecimal(msg?)`                                       | finite number — alias for `.finite()` framed as "numeric value suitable for decimal accounting" |
-| `.latitude(msg?)` / `.longitude(msg?)`                    | geographic ranges                                                                               |
+| Method                                                    | Behaviour                                                                                         |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `.integer(msg?)`                                          | `Number.isInteger(input)`                                                                         |
+| `.finite(msg?)`                                           | rejects `Infinity` / `-Infinity`                                                                  |
+| `.safeInteger(msg?)`                                      | within `Number.MIN_SAFE_INTEGER`…`MAX_SAFE_INTEGER`                                               |
+| `.odd(msg?)` / `.even(msg?)` / `.prime(msg?)`             | parity / primality                                                                                |
+| `.naturalNumber(msg?)`                                    | positive integer (`> 0`, no fractions)                                                            |
+| `.multipleOf(n, msg?)` / `.evenlyDivisible(n, msg?)`      | `input % n === 0` (alias)                                                                         |
+| `.power(base?, msg?)`                                     | perfect power (of given base or any base)                                                         |
+| `.validPort(msg?)` / `.port(msg?)`                        | 0–65535 integer                                                                                   |
+| `.timestamp(msg?)`                                        | valid Unix timestamp (non-negative integer)                                                       |
+| `.unixSeconds(msg?)` / `.unixMillis(msg?)`                | timestamp validation at second / millisecond resolution                                           |
+| `.fullYear(msg?)`                                         | 4-digit calendar year (1900–9999)                                                                 |
+| `.percentage(msg?)` / `.probability(msg?)` / `.bps(msg?)` | `[0,100]` / `[0,1]` / basis-points `[0,10000]` ranges                                             |
+| `.bigDecimal(msg?)`                                       | finite number — alias for `.finite()` framed as "numeric value suitable for decimal accounting"   |
+| `.latitude(msg?)` / `.longitude(msg?)`                    | geographic ranges                                                                                 |
+| `.strict(msg?)`                                           | reject coercion — input must already be `typeof 'number'` (see [Coercion rules](#coercion-rules)) |
 
 ### Transforms
 
@@ -197,10 +212,11 @@ Accepted.parse(42); // throws — only 0/1 accepted
 
 ### Validators
 
-| Method         | Behaviour        |
-| -------------- | ---------------- |
-| `.true(msg?)`  | requires `true`  |
-| `.false(msg?)` | requires `false` |
+| Method          | Behaviour                                                                                          |
+| --------------- | -------------------------------------------------------------------------------------------------- |
+| `.true(msg?)`   | requires `true`                                                                                    |
+| `.false(msg?)`  | requires `false`                                                                                   |
+| `.strict(msg?)` | reject coercion — input must already be `typeof 'boolean'` (see [Coercion rules](#coercion-rules)) |
 
 ### Transforms
 

--- a/packages/guardian/guards/BooleanGuardian.ts
+++ b/packages/guardian/guards/BooleanGuardian.ts
@@ -51,6 +51,55 @@ export class BooleanGuardian extends BaseGuardian<boolean> {
     super(initialTransform || defaultTransform, metaData);
   }
 
+  //#region Coercion Control
+
+  /**
+   * Rejects coercion — the input must already be `typeof 'boolean'`.
+   * Strings (`'true'`, `'yes'`, …) and numbers (`0`/`1`) that the
+   * default (coercing) behaviour would otherwise convert are rejected
+   * instead.
+   *
+   * Implemented as a wrapper around the chain built so far (not a
+   * rebuild from constructor parts, unlike {@link
+   * ObjectGuardian.strict}), so it composes correctly no matter where
+   * in the chain it's called — `Guardian.boolean().strict().true()` and
+   * `Guardian.boolean().true().strict()` both reject a coerced input
+   * the same way.
+   *
+   * @param errorMessage - Optional custom error message
+   * @returns A new BooleanGuardian with the validation applied (the receiver is never mutated)
+   * @throws {GuardianError} If the input is not already a `boolean`
+   *
+   * @example
+   * ```ts
+   * import { Guardian } from '@tundralibs/guardian';
+   *
+   * const StrictFlag = Guardian.boolean().strict();
+   * StrictFlag.parse(true);   // true
+   * StrictFlag.parse('true'); // throws — no coercion in strict mode
+   * ```
+   */
+  strict(errorMessage?: string): this {
+    const previousTransform = this._composedTransform;
+    return this._cloneWith((input: unknown) => {
+      if (typeof input !== 'boolean') {
+        throw new GuardianError(
+          errorMessage ||
+            `Boolean must not be coerced (strict mode) — expected typeof "boolean", got ${typeof input}`,
+          {
+            expected: 'boolean (no coercion)',
+            got: typeof input,
+            comparison: 'strict',
+            type: 'boolean',
+          },
+        );
+      }
+      return previousTransform(input);
+    }, this._metaData) as this;
+  }
+
+  //#endregion
+
   //#region Validation Methods
 
   /**

--- a/packages/guardian/guards/NumberGuardian.ts
+++ b/packages/guardian/guards/NumberGuardian.ts
@@ -106,6 +106,54 @@ export class NumberGuardian extends BaseGuardian<number> {
     super(finalTransform, metaData);
   }
 
+  //#region Coercion Control
+
+  /**
+   * Rejects coercion — the input must already be `typeof 'number'`.
+   * Strings, bigints, booleans, and `Date`s that the default (coercing)
+   * behaviour would otherwise convert are rejected instead.
+   *
+   * Implemented as a wrapper around the chain built so far (not a
+   * rebuild from constructor parts, unlike {@link
+   * ObjectGuardian.strict}), so it composes correctly no matter where
+   * in the chain it's called — `Guardian.number().strict().min(0)` and
+   * `Guardian.number().min(0).strict()` both reject a coerced input the
+   * same way.
+   *
+   * @param errorMessage - Optional custom error message
+   * @returns A new NumberGuardian with the validation applied (the receiver is never mutated)
+   * @throws {GuardianError} If the input is not already a `number`
+   *
+   * @example
+   * ```ts
+   * import { Guardian } from '@tundralibs/guardian';
+   *
+   * const StrictAge = Guardian.number().strict().min(0);
+   * StrictAge.parse(42);   // 42
+   * StrictAge.parse('42'); // throws — no coercion in strict mode
+   * ```
+   */
+  strict(errorMessage?: string): this {
+    const previousTransform = this._composedTransform;
+    return this._cloneWith((input: unknown) => {
+      if (typeof input !== 'number') {
+        throw new GuardianError(
+          errorMessage ||
+            `Number must not be coerced (strict mode) — expected typeof "number", got ${typeof input}`,
+          {
+            expected: 'number (no coercion)',
+            got: typeof input,
+            comparison: 'strict',
+            type: 'number',
+          },
+        );
+      }
+      return previousTransform(input);
+    }, this._metaData) as this;
+  }
+
+  //#endregion
+
   //#region Range Validation Methods
 
   /**

--- a/packages/guardian/helpers/coerce.ts
+++ b/packages/guardian/helpers/coerce.ts
@@ -21,6 +21,16 @@
  * values upstream of the type validation — so an `.optional()` chain
  * still does what you'd expect.
  *
+ * Coerce-by-default is right for *input parsing* (the API/DB boundary
+ * this module targets) but wrong for *response validation* — a vendor
+ * API returning `age: "42"` where the contract promises a number is a
+ * schema violation you want to catch, not silently accept. There's no
+ * single default that serves both: `NumberGuardian` / `BooleanGuardian`
+ * bias toward the more common input-parsing case and expose `.strict()`
+ * as the opt-out for the response-validation case (see {@link
+ * NumberGuardian.strict} / {@link BooleanGuardian.strict}), rather than
+ * flipping the default and forcing input-parsing callers to opt in.
+ *
  * @module
  */
 

--- a/packages/guardian/tests/guards/BooleanGuardian.test.ts
+++ b/packages/guardian/tests/guards/BooleanGuardian.test.ts
@@ -480,4 +480,55 @@ describe('guardian.BooleanGuardian', () => {
       asserts.assertEquals(schema.nullable, true);
     });
   });
+
+  describe('strict (#337: coercion opt-out)', () => {
+    it('accepts an already-typed boolean, unaffected by strict', () => {
+      const schema = new BooleanGuardian().strict();
+      asserts.assertEquals(schema.parse(true), true);
+      asserts.assertEquals(schema.parse(false), false);
+    });
+
+    it('rejects inputs the default (coercing) transform would accept', () => {
+      const schema = new BooleanGuardian().strict();
+      asserts.assertThrows(() => schema.parse('true'), GuardianError);
+      asserts.assertThrows(() => schema.parse('yes'), GuardianError);
+      asserts.assertThrows(() => schema.parse(1), GuardianError);
+      asserts.assertThrows(() => schema.parse(0), GuardianError);
+    });
+
+    it('does not affect the default (non-strict) guardian — coercion still works', () => {
+      const schema = new BooleanGuardian();
+      asserts.assertEquals(schema.parse('yes'), true);
+    });
+
+    it('composes correctly when called BEFORE other chain steps', () => {
+      const schema = new BooleanGuardian().strict().true();
+      asserts.assertEquals(schema.parse(true), true);
+      asserts.assertThrows(() => schema.parse('true'), GuardianError);
+      asserts.assertThrows(() => schema.parse(false), GuardianError);
+    });
+
+    it('composes correctly when called AFTER other chain steps', () => {
+      const schema = new BooleanGuardian().true().strict();
+      asserts.assertEquals(schema.parse(true), true);
+      asserts.assertThrows(() => schema.parse('true'), GuardianError);
+    });
+
+    it('supports a custom error message', () => {
+      try {
+        new BooleanGuardian().strict('no strings allowed').parse('true');
+        throw new Error('expected parse to throw');
+      } catch (e) {
+        asserts.assert(e instanceof GuardianError);
+        asserts.assertEquals((e as Error).message, 'no strings allowed');
+      }
+    });
+
+    it('the receiver is never mutated by strict()', () => {
+      const loose = new BooleanGuardian();
+      const strict = loose.strict();
+      asserts.assertEquals(loose.parse('yes'), true);
+      asserts.assertThrows(() => strict.parse('yes'), GuardianError);
+    });
+  });
 });

--- a/packages/guardian/tests/guards/NumberGuardian.test.ts
+++ b/packages/guardian/tests/guards/NumberGuardian.test.ts
@@ -1265,4 +1265,64 @@ describe('guardian.NumberGuardian', () => {
       asserts.assertThrows(() => new NumberGuardian().evenlyDivisible([]));
     });
   });
+
+  describe('strict (#337: coercion opt-out)', () => {
+    it('accepts an already-typed number, unaffected by strict', () => {
+      const schema = new NumberGuardian().strict();
+      asserts.assertEquals(schema.parse(42), 42);
+      asserts.assertEquals(schema.parse(-3.14), -3.14);
+      asserts.assertEquals(schema.parse(0), 0);
+    });
+
+    it('rejects inputs the default (coercing) transform would accept', () => {
+      const schema = new NumberGuardian().strict();
+      asserts.assertThrows(() => schema.parse('42'), GuardianError);
+      asserts.assertThrows(() => schema.parse(true), GuardianError);
+      asserts.assertThrows(() => schema.parse(false), GuardianError);
+      asserts.assertThrows(() => schema.parse(42n), GuardianError);
+      asserts.assertThrows(() => schema.parse(new Date()), GuardianError);
+    });
+
+    it('still rejects non-finite values (NaN / Infinity) once typed', () => {
+      const schema = new NumberGuardian().strict();
+      asserts.assertThrows(() => schema.parse(Number.NaN), GuardianError);
+      asserts.assertThrows(() => schema.parse(Infinity), GuardianError);
+    });
+
+    it('does not affect the default (non-strict) guardian — coercion still works', () => {
+      const schema = new NumberGuardian();
+      asserts.assertEquals(schema.parse('42'), 42);
+    });
+
+    it('composes correctly when called BEFORE other chain steps', () => {
+      const schema = new NumberGuardian().strict().min(0).max(100);
+      asserts.assertEquals(schema.parse(50), 50);
+      asserts.assertThrows(() => schema.parse('50'), GuardianError);
+      asserts.assertThrows(() => schema.parse(150), GuardianError);
+    });
+
+    it('composes correctly when called AFTER other chain steps', () => {
+      const schema = new NumberGuardian().min(0).max(100).strict();
+      asserts.assertEquals(schema.parse(50), 50);
+      asserts.assertThrows(() => schema.parse('50'), GuardianError);
+      asserts.assertThrows(() => schema.parse(150), GuardianError);
+    });
+
+    it('supports a custom error message', () => {
+      try {
+        new NumberGuardian().strict('no strings allowed').parse('42');
+        throw new Error('expected parse to throw');
+      } catch (e) {
+        asserts.assert(e instanceof GuardianError);
+        asserts.assertEquals((e as Error).message, 'no strings allowed');
+      }
+    });
+
+    it('the receiver is never mutated by strict()', () => {
+      const loose = new NumberGuardian();
+      const strict = loose.strict();
+      asserts.assertEquals(loose.parse('42'), 42);
+      asserts.assertThrows(() => strict.parse('42'), GuardianError);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #337.

`NumberGuardian` and `BooleanGuardian` coerce by default (`"42"` → `42`, `"yes"` → `true`), which is right for input parsing at API/DB boundaries but wrong for validating a vendor *response* — a field that's supposed to be a `number` but arrives as a string is a schema violation you want to catch, not silently accept.

Adds `.strict(errorMessage?)` to both guardians, mirroring `ObjectGuardian.strict()`'s naming:

```typescript
const StrictAge = Guardian.number().strict().min(0);
StrictAge.parse(42);   // 42
StrictAge.parse('42'); // throws — no coercion in strict mode
```

## Design

Unlike `ObjectGuardian.strict()` (which rebuilds the guardian from its schema and therefore must be called before any other chain step, or it throws), `NumberGuardian`/`BooleanGuardian`'s coercion is baked into the constructor's base transform closure, so there's no "parts" to rebuild from. Instead, `.strict()` wraps the *already-composed* chain with a raw-input `typeof` check that runs first:

```typescript
strict(errorMessage?: string): this {
  const previousTransform = this._composedTransform;
  return this._cloneWith((input: unknown) => {
    if (typeof input !== 'number') throw new GuardianError(/* … */);
    return previousTransform(input);
  }, this._metaData) as this;
}
```

This means `.strict()` composes correctly no matter where it's called in the chain — `.strict().min(0)` and `.min(0).strict()` behave identically — which is a strictly more flexible contract than `ObjectGuardian.strict()`'s "must be first" restriction. Coerce-by-default is unchanged; this is additive only.

## Docs

- `helpers/coerce.ts` fileoverview now documents the input-parsing-vs-response-validation tension and points to `.strict()` as the escape hatch.
- `docs/Guardian-Validators.md`: new `.strict()` row in both the number and boolean method tables, plus an expanded "Coercion rules" section with an example.
- `README.md`: short "Coercion at the boundary" follow-up mentioning `.strict()`.
- All markdown code blocks verified via `deno check --doc-only`.

## Test plan

- [x] `deno test` — 38 files, 2109 steps, all passing
- [x] `deno check .` — clean
- [x] `deno lint .` — clean
- [x] `deno fmt --check .` — clean
- [x] `deno publish --dry-run` — succeeds (no slow-types issues)
- [x] New tests cover: default coercion unaffected, strict rejects coerced inputs, strict still rejects NaN/Infinity, composition before/after other chain steps, custom error message, receiver-not-mutated

🤖 Generated with [Claude Code](https://claude.com/claude-code)